### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, dev ]


### PR DESCRIPTION
Potential fix for [https://github.com/mmonterroca/docxgo/security/code-scanning/1](https://github.com/mmonterroca/docxgo/security/code-scanning/1)

In general, the fix is to explicitly define a `permissions` block so that the `GITHUB_TOKEN` used by this workflow has only the scopes it needs. Since this workflow only checks out code and runs local Go commands, it only needs read access to repository contents.

The best minimal fix is to add a workflow-level `permissions` section near the top of `.github/workflows/ci.yml`, alongside `name` and `on`, specifying `contents: read`. This applies to all jobs that do not override it, including `lint-and-test`, and does not change any of the existing job steps or behavior. No additional imports or dependencies are required; this is purely a YAML configuration change.

Concretely: in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `name: CI` line (line 1) and before the `on:` block (line 3). No other lines need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
