### PR TITLE
docs: update version references to v2.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Production-grade Microsoft Word .docx (OOXML) file manipulation in Go.
 **Released**: February 2026
 **Test Coverage**: 50.7%
 
-**Latest Features**: Table Style Borders (dev), Theme System (v2.1.0+), Round-trip Style Preservation (v2.2.1)
+**Latest Features**: Table Style Borders (v2.2.2), Theme System (v2.1.0+), Round-trip Style Preservation (v2.2.1)
 
-> **Note**: This library underwent a complete architectural rewrite in 2024-2025, implementing clean architecture principles, comprehensive testing, and modern Go practices. Version 2.0.0 released October 2025, with theme system added in v2.1.0 and continued improvements through v2.2.1.
+> **Note**: This library underwent a complete architectural rewrite in 2024-2025, implementing clean architecture principles, comprehensive testing, and modern Go practices. Version 2.0.0 released October 2025, with theme system added in v2.1.0 and continued improvements through v2.2.2.
 
 ---
 
@@ -521,7 +521,13 @@ For complete project genealogy, see [CREDITS.md](CREDITS.md).
 
 ### Release History
 
-- **v2.2.1** (January 2026 - Current Stable)
+- **v2.2.2** (February 2026 - Current Stable)
+  - Table style borders fix (TableGrid, PlainTable1 now render with visible borders)
+  - Grid column width calculation from cell widths
+  - Comprehensive documentation overhaul
+  - Restored 13_themes example
+
+- **v2.2.1** (January 2026)
   - Hyperlink RelationshipID preservation during round-trip
   - Drawing position serialization fix
   - Internal hyperlink anchor support

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,7 +1,7 @@
 # go-docx v2 Implementation Status
 
 **Last Updated**: February 2026
-**Version**: 2.2.1 (Stable)
+**Version**: 2.2.2 (Stable)
 
 This document tracks the implementation status of all v2 features, helping developers understand what's available, what's in progress, and what's planned.
 
@@ -29,6 +29,7 @@ All development phases have been completed. The library has gone through multipl
 | v2.1.1      | Nov 2025 | Go module path fix                                   |
 | v2.2.0      | Jan 2026 | Table cell border serialization                      |
 | v2.2.1      | Jan 2026 | Round-trip fixes (hyperlinks, styles, images)        |
+| v2.2.2      | Feb 2026 | Table style borders fix, grid width calc, docs overhaul |
 
 ---
 
@@ -405,5 +406,5 @@ Want to help implement missing features? See [CONTRIBUTING.md](../CONTRIBUTING.m
 ---
 
 **Last Updated**: February 2026
-**Status**: Production Ready (v2.2.1 Stable)
+**Status**: Production Ready (v2.2.2 Stable)
 **Maintained by**: Misael Monterroca ([@mmonterroca](https://github.com/mmonterroca))

--- a/docs/V2_API_GUIDE.md
+++ b/docs/V2_API_GUIDE.md
@@ -860,5 +860,5 @@ doc.SaveAs("output.docx")
 
 ---
 
-**Last Updated**: October 27, 2025  
-**Version**: 2.0.0-beta
+**Last Updated**: February 2026  
+**Version**: 2.2.2

--- a/docs/V2_API_GUIDE.md
+++ b/docs/V2_API_GUIDE.md
@@ -1,6 +1,6 @@
 # go-docx v2 API Guide
 
-**Version**: 2.2.1  
+**Version**: 2.2.2  
 **Last Updated**: February 2026
 
 ---

--- a/docs/V2_DESIGN.md
+++ b/docs/V2_DESIGN.md
@@ -1,8 +1,8 @@
 # go-docx v2.0 - Clean Architecture Design
 
-**Status**: ✅ v2.2.1 Stable  
+**Status**: ✅ v2.2.2 Stable  
 **Progress**: Production Ready (all core features complete)  
-**Latest Release**: v2.2.1 (January 2026)  
+**Latest Release**: v2.2.2 (February 2026)  
 **Breaking Changes**: Yes (major version bump from original fork)
 
 > **Project Note**: This project originated as a fork of `fumiama/go-docx` but has been completely rewritten with a clean architecture design. The current version represents a ground-up rebuild focused on maintainability, type safety, and modern Go practices.

--- a/docs/V2_DESIGN.md
+++ b/docs/V2_DESIGN.md
@@ -1268,25 +1268,18 @@ See [CREDITS.md](../CREDITS.md) for complete project history.
 
 ---
 
-**Next Steps:**
-1. � Tag v2.0.0-beta release
-2. 🚧 Phase 10 - Document Reading (15-20 hours remaining)
-3. 🚧 Phase 12 - Beta Testing & Release
-4. Stable v2.0.0 release (Q1 2026)
-
-**Last Updated**: October 29, 2025  
-**Status**: ✅ Ready for v2.0.0-beta release  
-**Progress**: ~95% to v2.0.0 (10/12 phases complete)
+**Last Updated**: February 2026  
+**Status**: ✅ v2.2.2 Stable  
+**Progress**: Production Ready (all core features complete)
 
 **Current State:**
-- ✅ Core architecture: 6,646+ lines implemented and tested
+- ✅ Core architecture: Complete (clean architecture, domain-driven design)
 - ✅ Builder pattern: Complete (fluent API with error handling)
 - ✅ Images: Complete (9 formats, inline/floating positioning)
-- ✅ Advanced tables: Complete (merging, nesting, 8 styles)
-- ✅ Code quality: EXCELLENT (0 warnings, 50.7% coverage, production-ready errors)
-- ✅ Documentation: Comprehensive (1,500+ lines of godoc, guides, and analysis)
-- 🚧 Reading existing .docx: In progress (inline media + numbering hydrated; sections pending)
-- 🚧 Beta testing: Not started (Phase 12)
-- Target: v2.0.0-beta ready, stable release Q1 2026
+- ✅ Advanced tables: Complete (merging, nesting, 8 styles, proper border serialization)
+- ✅ Theme system: Complete (7 preset themes, custom theme support)
+- ✅ Document reading: Complete (round-trip with style/hyperlink/image preservation)
+- ✅ Documentation: Comprehensive (13 working examples, full API guide)
+- ✅ All 12 phases complete
 
 ````


### PR DESCRIPTION
Updates version references from v2.2.1 to v2.2.2 across documentation files:

- **IMPLEMENTATION_STATUS.md**: Version header, release history table (added v2.2.2 row), footer status
- **V2_API_GUIDE.md**: Version header
- **V2_DESIGN.md**: Status and latest release

These were missed during the v2.2.2 release.