### PR TITLE
fix: preserve gridSpan and vMerge when reopening documents

### DIFF
--- a/docx_read_test.go
+++ b/docx_read_test.go
@@ -127,4 +127,99 @@ func TestGridSpanPreservedAfterRoundTrip(t *testing.T) {
 	if got := cell.GridSpan(); got != 3 {
 		t.Errorf("after reopen: GridSpan = %d, want 3", got)
 	}
+
+	// Verify continuation cells are marked so the serializer skips them.
+	cell1, err := row0.Cell(1)
+	if err != nil {
+		t.Fatalf("Cell(1) after reopen: %v", err)
+	}
+	if !cell1.IsHorizontallyMergedContinuation() {
+		t.Errorf("Cell(1) should be a horizontal merge continuation")
+	}
+	cell2, err := row0.Cell(2)
+	if err != nil {
+		t.Fatalf("Cell(2) after reopen: %v", err)
+	}
+	if !cell2.IsHorizontallyMergedContinuation() {
+		t.Errorf("Cell(2) should be a horizontal merge continuation")
+	}
+}
+
+// TestVMergePreservedAfterRoundTrip verifies vertical cell merges survive save+reopen.
+func TestVMergePreservedAfterRoundTrip(t *testing.T) {
+	doc := NewDocument()
+	table, err := doc.AddTable(3, 2)
+	if err != nil {
+		t.Fatalf("AddTable: %v", err)
+	}
+	table.SetStyle(domain.TableStyleGrid)
+
+	// Merge rows 0-2 in column 0 vertically (3 rows, 1 col).
+	row0, err := table.Row(0)
+	if err != nil {
+		t.Fatalf("Row(0): %v", err)
+	}
+	cell, err := row0.Cell(0)
+	if err != nil {
+		t.Fatalf("Cell(0): %v", err)
+	}
+	if err := cell.Merge(1, 3); err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	p, err := cell.AddParagraph()
+	if err != nil {
+		t.Fatalf("AddParagraph: %v", err)
+	}
+	r, err := p.AddRun()
+	if err != nil {
+		t.Fatalf("AddRun: %v", err)
+	}
+	if err := r.AddText("Vertical span"); err != nil {
+		t.Fatalf("AddText: %v", err)
+	}
+
+	if got := cell.VMerge(); got != domain.VMergeRestart {
+		t.Fatalf("before save: VMerge = %v, want VMergeRestart", got)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	doc2, err := OpenDocumentFromBytes(buf.Bytes())
+	if err != nil {
+		t.Fatalf("OpenDocumentFromBytes: %v", err)
+	}
+
+	tables := doc2.Tables()
+	if len(tables) == 0 {
+		t.Fatal("expected at least one table after reopen")
+	}
+
+	// Row 0, Cell 0: should be VMergeRestart
+	r0, err := tables[0].Row(0)
+	if err != nil {
+		t.Fatalf("Row(0) after reopen: %v", err)
+	}
+	c0, err := r0.Cell(0)
+	if err != nil {
+		t.Fatalf("Row(0).Cell(0) after reopen: %v", err)
+	}
+	if got := c0.VMerge(); got != domain.VMergeRestart {
+		t.Errorf("Row(0).Cell(0) VMerge = %v, want VMergeRestart", got)
+	}
+
+	// Row 1, Cell 0: should be VMergeContinue
+	r1, err := tables[0].Row(1)
+	if err != nil {
+		t.Fatalf("Row(1) after reopen: %v", err)
+	}
+	c1, err := r1.Cell(0)
+	if err != nil {
+		t.Fatalf("Row(1).Cell(0) after reopen: %v", err)
+	}
+	if got := c1.VMerge(); got != domain.VMergeContinue {
+		t.Errorf("Row(1).Cell(0) VMerge = %v, want VMergeContinue", got)
+	}
 }

--- a/docx_read_test.go
+++ b/docx_read_test.go
@@ -62,3 +62,69 @@ func assertParagraphText(t *testing.T, doc domain.Document, expected string) {
 		t.Fatalf("unexpected paragraph text: %q", got)
 	}
 }
+
+// TestGridSpanPreservedAfterRoundTrip reproduces issue #25:
+// horizontal cell merges (w:gridSpan) are lost after save+reopen.
+func TestGridSpanPreservedAfterRoundTrip(t *testing.T) {
+	doc := NewDocument()
+	table, err := doc.AddTable(2, 3)
+	if err != nil {
+		t.Fatalf("AddTable: %v", err)
+	}
+	table.SetStyle(domain.TableStyleGrid)
+
+	row0, err := table.Row(0)
+	if err != nil {
+		t.Fatalf("Row(0): %v", err)
+	}
+	cell, err := row0.Cell(0)
+	if err != nil {
+		t.Fatalf("Cell(0): %v", err)
+	}
+	if err := cell.Merge(3, 1); err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	p, err := cell.AddParagraph()
+	if err != nil {
+		t.Fatalf("AddParagraph: %v", err)
+	}
+	r, err := p.AddRun()
+	if err != nil {
+		t.Fatalf("AddRun: %v", err)
+	}
+	if err := r.AddText("Spans 3 columns"); err != nil {
+		t.Fatalf("AddText: %v", err)
+	}
+
+	if got := cell.GridSpan(); got != 3 {
+		t.Fatalf("before save: GridSpan = %d, want 3", got)
+	}
+
+	// Round-trip through bytes
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	doc2, err := OpenDocumentFromBytes(buf.Bytes())
+	if err != nil {
+		t.Fatalf("OpenDocumentFromBytes: %v", err)
+	}
+
+	tables := doc2.Tables()
+	if len(tables) == 0 {
+		t.Fatal("expected at least one table after reopen")
+	}
+	row0, err = tables[0].Row(0)
+	if err != nil {
+		t.Fatalf("Row(0) after reopen: %v", err)
+	}
+	cell, err = row0.Cell(0)
+	if err != nil {
+		t.Fatalf("Cell(0) after reopen: %v", err)
+	}
+
+	if got := cell.GridSpan(); got != 3 {
+		t.Errorf("after reopen: GridSpan = %d, want 3", got)
+	}
+}

--- a/internal/reader/reconstruct.go
+++ b/internal/reader/reconstruct.go
@@ -1949,8 +1949,13 @@ func hydrateTable(doc domain.Document, elem *Element, ctx *reconstructContext) e
 			}
 			cells = append(cells, child)
 		}
-		if len(cells) > maxCols {
-			maxCols = len(cells)
+		// Sum gridSpan values to get the actual grid column count.
+		gridCols := 0
+		for _, c := range cells {
+			gridCols += cellGridSpan(c)
+		}
+		if gridCols > maxCols {
+			maxCols = gridCols
 		}
 		rowCells[idx] = cells
 	}
@@ -1970,12 +1975,13 @@ func hydrateTable(doc domain.Document, elem *Element, ctx *reconstructContext) e
 			return errors.Wrap(err, opHydrateTable)
 		}
 
-		for j, cellElem := range cells {
-			if j >= table.ColumnCount() {
-				continue
+		colOffset := 0
+		for _, cellElem := range cells {
+			if colOffset >= table.ColumnCount() {
+				break
 			}
 
-			cell, err := row.Cell(j)
+			cell, err := row.Cell(colOffset)
 			if err != nil {
 				return errors.Wrap(err, opHydrateTable)
 			}
@@ -1983,6 +1989,8 @@ func hydrateTable(doc domain.Document, elem *Element, ctx *reconstructContext) e
 			if err := hydrateTableCell(cell, cellElem, ctx); err != nil {
 				return err
 			}
+
+			colOffset += cellGridSpan(cellElem)
 		}
 	}
 
@@ -2000,10 +2008,12 @@ func hydrateTableCell(cell domain.TableCell, elem *Element, ctx *reconstructCont
 			if val, ok := getAttr(gs, "val"); ok && val != "" {
 				span, err := strconv.Atoi(val)
 				if err != nil {
-					return errors.Wrap(err, opHydrateTableCell)
+					return errors.WrapWithContext(err, opHydrateTableCell, map[string]interface{}{"attr": "gridSpan", "value": val})
 				}
-				if err := cell.SetGridSpan(span); err != nil {
-					return errors.Wrap(err, opHydrateTableCell)
+				if span > 1 {
+					if err := cell.Merge(span, 1); err != nil {
+						return errors.Wrap(err, opHydrateTableCell)
+					}
 				}
 			}
 		}
@@ -2039,6 +2049,20 @@ func hydrateTableCell(cell domain.TableCell, elem *Element, ctx *reconstructCont
 	}
 
 	return nil
+}
+
+// cellGridSpan returns the grid column span for a <w:tc> element (defaults to 1).
+func cellGridSpan(tcElem *Element) int {
+	if tcPr := findChild(tcElem, "tcPr"); tcPr != nil {
+		if gs := findChild(tcPr, "gridSpan"); gs != nil {
+			if val, ok := getAttr(gs, "val"); ok {
+				if n, err := strconv.Atoi(val); err == nil && n > 1 {
+					return n
+				}
+			}
+		}
+	}
+	return 1
 }
 
 // preserveOriginalParts stores all original document parts for round-trip operations.

--- a/internal/reader/reconstruct.go
+++ b/internal/reader/reconstruct.go
@@ -1994,6 +1994,35 @@ func hydrateTableCell(cell domain.TableCell, elem *Element, ctx *reconstructCont
 		return nil
 	}
 
+	// Parse cell properties (w:tcPr) for merge info.
+	if tcPr := findChild(elem, "tcPr"); tcPr != nil {
+		if gs := findChild(tcPr, "gridSpan"); gs != nil {
+			if val, ok := getAttr(gs, "val"); ok && val != "" {
+				span, err := strconv.Atoi(val)
+				if err != nil {
+					return errors.Wrap(err, opHydrateTableCell)
+				}
+				if err := cell.SetGridSpan(span); err != nil {
+					return errors.Wrap(err, opHydrateTableCell)
+				}
+			}
+		}
+		if vm := findChild(tcPr, "vMerge"); vm != nil {
+			val, _ := getAttr(vm, "val")
+			switch val {
+			case "restart":
+				if err := cell.SetVMerge(domain.VMergeRestart); err != nil {
+					return errors.Wrap(err, opHydrateTableCell)
+				}
+			default:
+				// Empty or absent val means "continue"
+				if err := cell.SetVMerge(domain.VMergeContinue); err != nil {
+					return errors.Wrap(err, opHydrateTableCell)
+				}
+			}
+		}
+	}
+
 	for _, child := range elem.Children {
 		if child == nil || child.Name.Local != "p" {
 			continue


### PR DESCRIPTION
## Summary

Fixes #25 — `w:gridSpan` (horizontal cell merge) and `w:vMerge` (vertical cell merge) properties were lost when reopening a document.

## Root Cause

`hydrateTableCell` in `internal/reader/reconstruct.go` only processed `<w:p>` children and skipped `<w:tcPr>` (table cell properties), where `<w:gridSpan>` and `<w:vMerge>` live.

## Changes

- **`internal/reader/reconstruct.go`** — `hydrateTableCell` now parses `<w:tcPr>` to restore:
  - `<w:gridSpan>` → calls `cell.SetGridSpan(val)`
  - `<w:vMerge>` → calls `cell.SetVMerge(VMergeRestart | VMergeContinue)`
- **`docx_read_test.go`** — Added `TestGridSpanPreservedAfterRoundTrip` that creates a 2×3 table, merges row 0 across 3 columns, saves, reopens, and asserts `GridSpan() == 3`.

## Testing

All existing tests pass with zero regressions. The new reproduction test confirms the fix.