### PR TITLE
feat: add AddImageFromBytes API for in-memory image insertion

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -529,6 +529,49 @@ func (pb *ParagraphBuilder) AddImageWithPosition(path string, size domain.ImageS
 	return pb
 }
 
+// AddImageFromBytes adds an image from raw byte data to the paragraph.
+// The format parameter specifies the image type (e.g., domain.ImageFormatPNG).
+func (pb *ParagraphBuilder) AddImageFromBytes(data []byte, format domain.ImageFormat) *ParagraphBuilder {
+	if pb.err != nil {
+		return pb
+	}
+
+	if _, err := pb.para.AddImageFromBytes(data, format); err != nil {
+		pb.err = err
+		pb.parent.errors = append(pb.parent.errors, err)
+	}
+
+	return pb
+}
+
+// AddImageFromBytesWithSize adds an image from byte data with custom dimensions.
+func (pb *ParagraphBuilder) AddImageFromBytesWithSize(data []byte, format domain.ImageFormat, size domain.ImageSize) *ParagraphBuilder {
+	if pb.err != nil {
+		return pb
+	}
+
+	if _, err := pb.para.AddImageFromBytesWithSize(data, format, size); err != nil {
+		pb.err = err
+		pb.parent.errors = append(pb.parent.errors, err)
+	}
+
+	return pb
+}
+
+// AddImageFromBytesWithPosition adds a floating image from byte data with custom positioning.
+func (pb *ParagraphBuilder) AddImageFromBytesWithPosition(data []byte, format domain.ImageFormat, size domain.ImageSize, pos domain.ImagePosition) *ParagraphBuilder {
+	if pb.err != nil {
+		return pb
+	}
+
+	if _, err := pb.para.AddImageFromBytesWithPosition(data, format, size, pos); err != nil {
+		pb.err = err
+		pb.parent.errors = append(pb.parent.errors, err)
+	}
+
+	return pb
+}
+
 // End returns to the DocumentBuilder for further operations.
 func (pb *ParagraphBuilder) End() *DocumentBuilder {
 	return pb.parent

--- a/builder_test.go
+++ b/builder_test.go
@@ -1033,4 +1033,46 @@ func TestParagraphBuilder_AddImage(t *testing.T) {
 			t.Fatal("expected error for empty image path, got nil")
 		}
 	})
+
+	t.Run("AddImageFromBytes fails with empty data", func(t *testing.T) {
+		builder := NewDocumentBuilder()
+		builder.AddParagraph().
+			Text("Before image").
+			AddImageFromBytes(nil, domain.ImageFormatPNG).
+			End()
+
+		_, err := builder.Build()
+		if err == nil {
+			t.Fatal("expected error for nil image data, got nil")
+		}
+	})
+
+	t.Run("AddImageFromBytesWithSize fails with empty data", func(t *testing.T) {
+		builder := NewDocumentBuilder()
+		size := domain.NewImageSize(100, 100)
+		builder.AddParagraph().
+			Text("Before image").
+			AddImageFromBytesWithSize(nil, domain.ImageFormatPNG, size).
+			End()
+
+		_, err := builder.Build()
+		if err == nil {
+			t.Fatal("expected error for nil image data, got nil")
+		}
+	})
+
+	t.Run("AddImageFromBytesWithPosition fails with empty data", func(t *testing.T) {
+		builder := NewDocumentBuilder()
+		size := domain.NewImageSize(100, 100)
+		pos := domain.DefaultImagePosition()
+		builder.AddParagraph().
+			Text("Before image").
+			AddImageFromBytesWithPosition(nil, domain.ImageFormatPNG, size, pos).
+			End()
+
+		_, err := builder.Build()
+		if err == nil {
+			t.Fatal("expected error for nil image data, got nil")
+		}
+	})
 }

--- a/cmd/docxgo/handlers.go
+++ b/cmd/docxgo/handlers.go
@@ -835,31 +835,26 @@ func applyField(para domain.Paragraph, f *fieldDef) error {
 
 // applyImage adds an image to a paragraph.
 func applyImage(para domain.Paragraph, img *imageDef) error {
-	path := img.Path
-
+	// If base64 data is provided, use AddImageFromBytes directly (no temp file needed).
 	if img.Base64 != "" {
 		data, err := base64.StdEncoding.DecodeString(img.Base64)
 		if err != nil {
 			return fmt.Errorf("invalid image base64: %w", err)
 		}
-		ext := img.Format
-		if ext == "" {
-			ext = "png"
+		format := domain.ImageFormat(img.Format)
+		if format == "" {
+			format = domain.ImageFormatPNG
 		}
-		tmp, err := os.CreateTemp("", "docxgo-img-*."+ext)
-		if err != nil {
-			return fmt.Errorf("failed to create temp image: %w", err)
+		if img.WidthPx > 0 || img.HeightPx > 0 {
+			size := domain.NewImageSize(img.WidthPx, img.HeightPx)
+			_, err = para.AddImageFromBytesWithSize(data, format, size)
+			return err
 		}
-		if _, err := tmp.Write(data); err != nil {
-			_ = tmp.Close()
-			_ = os.Remove(tmp.Name())
-			return fmt.Errorf("failed to write temp image: %w", err)
-		}
-		_ = tmp.Close()
-		path = tmp.Name()
-		defer os.Remove(path)
+		_, err = para.AddImageFromBytes(data, format)
+		return err
 	}
 
+	path := img.Path
 	if path == "" {
 		return fmt.Errorf("image requires path or base64")
 	}

--- a/domain/paragraph.go
+++ b/domain/paragraph.go
@@ -48,6 +48,16 @@ type Paragraph interface {
 	// AddImageWithPosition adds an image with custom positioning.
 	AddImageWithPosition(path string, size ImageSize, pos ImagePosition) (Image, error)
 
+	// AddImageFromBytes adds an image from raw byte data.
+	// The format parameter specifies the image type (e.g., ImageFormatPNG).
+	AddImageFromBytes(data []byte, format ImageFormat) (Image, error)
+
+	// AddImageFromBytesWithSize adds an image from byte data with custom dimensions.
+	AddImageFromBytesWithSize(data []byte, format ImageFormat, size ImageSize) (Image, error)
+
+	// AddImageFromBytesWithPosition adds an image from byte data with custom positioning.
+	AddImageFromBytesWithPosition(data []byte, format ImageFormat, size ImageSize, pos ImagePosition) (Image, error)
+
 	// Images returns all images in this paragraph.
 	Images() []Image
 

--- a/examples/08_images/main.go
+++ b/examples/08_images/main.go
@@ -15,6 +15,7 @@ This example demonstrates:
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"image"
 	"image/color"
@@ -245,6 +246,49 @@ func main() {
 		Text(" <- Three inline images").
 		End()
 
+	builder.AddParagraph().Text("").End()
+
+	// Example 8: Image from bytes (no file system required)
+	builder.AddParagraph().
+		Text("8. Image from Byte Data (AddImageFromBytes)").
+		Bold().
+		FontSize(16).
+		End()
+
+	builder.AddParagraph().
+		Text("This image was created entirely in memory, without writing to disk:").
+		End()
+
+	// Create an image in memory
+	memImg := image.NewRGBA(image.Rect(0, 0, 300, 200))
+	for y := 0; y < 200; y++ {
+		for x := 0; x < 300; x++ {
+			memImg.Set(x, y, color.RGBA{
+				R: uint8(x * 255 / 300),
+				G: uint8(y * 255 / 200),
+				B: 180,
+				A: 255,
+			})
+		}
+	}
+	var imgBuf bytes.Buffer
+	if err := png.Encode(&imgBuf, memImg); err != nil {
+		log.Fatalf("Failed to encode in-memory image: %v", err)
+	}
+	imgBytes := imgBuf.Bytes()
+
+	builder.AddParagraph().
+		AddImageFromBytes(imgBytes, domain.ImageFormatPNG).
+		End()
+
+	builder.AddParagraph().
+		Text("You can also use AddImageFromBytesWithSize to control dimensions:").
+		End()
+
+	builder.AddParagraph().
+		AddImageFromBytesWithSize(imgBytes, domain.ImageFormatPNG, domain.NewImageSize(150, 100)).
+		End()
+
 	// Save document
 	doc, err := builder.Build()
 	if err != nil {
@@ -264,4 +308,5 @@ func main() {
 	fmt.Println("  - Floating images (center, left, right)")
 	fmt.Println("  - Text wrapping (square, tight)")
 	fmt.Println("  - Multiple images in one paragraph")
+	fmt.Println("  - Images from byte data (no file system)")
 }

--- a/internal/core/image.go
+++ b/internal/core/image.go
@@ -344,6 +344,9 @@ func NewImageFromBytes(id string, data []byte, format domain.ImageFormat) (domai
 		return nil, errors.Wrap(err, "NewImageFromBytes")
 	}
 
+	copyData := make([]byte, len(data))
+	copy(copyData, data)
+
 	target := fmt.Sprintf("media/image%s.%s", id, normalized)
 
 	return &docxImage{
@@ -351,7 +354,7 @@ func NewImageFromBytes(id string, data []byte, format domain.ImageFormat) (domai
 		format:       normalized,
 		size:         size,
 		originalSize: size,
-		data:         data,
+		data:         copyData,
 		target:       target,
 		description:  "",
 		position:     domain.DefaultImagePosition(),

--- a/internal/core/image.go
+++ b/internal/core/image.go
@@ -25,6 +25,7 @@ SOFTWARE.
 package core
 
 import (
+	"bytes"
 	"fmt"
 	"image"
 	_ "image/gif"  // Register GIF format decoder
@@ -270,7 +271,15 @@ func detectImageFormat(path string) domain.ImageFormat {
 	ext := strings.ToLower(filepath.Ext(path))
 	ext = strings.TrimPrefix(ext, ".")
 
-	switch ext {
+	return normalizeImageFormat(domain.ImageFormat(ext))
+}
+
+// normalizeImageFormat validates and normalizes an ImageFormat value.
+// Returns empty string for unsupported formats.
+func normalizeImageFormat(format domain.ImageFormat) domain.ImageFormat {
+	normalized := strings.ToLower(strings.TrimPrefix(string(format), "."))
+
+	switch normalized {
 	case "png":
 		return domain.ImageFormatPNG
 	case "jpg", "jpeg":
@@ -309,15 +318,9 @@ func formatFromContentType(contentType string) domain.ImageFormat {
 
 // getImageDimensions reads image dimensions from image data.
 func getImageDimensions(data []byte) (domain.ImageSize, error) {
-	// Decode image to get dimensions
-	img, format, err := image.DecodeConfig(strings.NewReader(string(data)))
+	img, format, err := image.DecodeConfig(bytes.NewReader(data))
 	if err != nil {
-		// If decode fails, try reading as binary
-		reader := strings.NewReader(string(data))
-		img, format, err = image.DecodeConfig(reader)
-		if err != nil {
-			return domain.ImageSize{}, errors.Wrap(err, "getImageDimensions")
-		}
+		return domain.ImageSize{}, errors.Wrap(err, "getImageDimensions")
 	}
 
 	_ = format // format string is for logging if needed
@@ -328,10 +331,12 @@ func getImageDimensions(data []byte) (domain.ImageSize, error) {
 // NewImageFromBytes creates a new image from raw byte data.
 func NewImageFromBytes(id string, data []byte, format domain.ImageFormat) (domain.Image, error) {
 	if len(data) == 0 {
-		return nil, errors.InvalidArgument("NewImageFromBytes", "data", nil, "image data cannot be empty")
+		return nil, errors.InvalidArgument("NewImageFromBytes", "data", data, "image data cannot be empty")
 	}
-	if format == "" {
-		return nil, errors.InvalidArgument("NewImageFromBytes", "format", format, "image format is required")
+
+	normalized := normalizeImageFormat(format)
+	if normalized == "" {
+		return nil, errors.InvalidArgument("NewImageFromBytes", "format", format, "unsupported image format")
 	}
 
 	size, err := getImageDimensions(data)
@@ -339,17 +344,14 @@ func NewImageFromBytes(id string, data []byte, format domain.ImageFormat) (domai
 		return nil, errors.Wrap(err, "NewImageFromBytes")
 	}
 
-	copyData := make([]byte, len(data))
-	copy(copyData, data)
-
-	target := fmt.Sprintf("media/image%s.%s", id, format)
+	target := fmt.Sprintf("media/image%s.%s", id, normalized)
 
 	return &docxImage{
 		id:           id,
-		format:       format,
+		format:       normalized,
 		size:         size,
 		originalSize: size,
-		data:         copyData,
+		data:         data,
 		target:       target,
 		description:  "",
 		position:     domain.DefaultImagePosition(),

--- a/internal/core/image.go
+++ b/internal/core/image.go
@@ -325,6 +325,64 @@ func getImageDimensions(data []byte) (domain.ImageSize, error) {
 	return domain.NewImageSize(img.Width, img.Height), nil
 }
 
+// NewImageFromBytes creates a new image from raw byte data.
+func NewImageFromBytes(id string, data []byte, format domain.ImageFormat) (domain.Image, error) {
+	if len(data) == 0 {
+		return nil, errors.InvalidArgument("NewImageFromBytes", "data", nil, "image data cannot be empty")
+	}
+	if format == "" {
+		return nil, errors.InvalidArgument("NewImageFromBytes", "format", format, "image format is required")
+	}
+
+	size, err := getImageDimensions(data)
+	if err != nil {
+		return nil, errors.Wrap(err, "NewImageFromBytes")
+	}
+
+	copyData := make([]byte, len(data))
+	copy(copyData, data)
+
+	target := fmt.Sprintf("media/image%s.%s", id, format)
+
+	return &docxImage{
+		id:           id,
+		format:       format,
+		size:         size,
+		originalSize: size,
+		data:         copyData,
+		target:       target,
+		description:  "",
+		position:     domain.DefaultImagePosition(),
+	}, nil
+}
+
+// NewImageFromBytesWithSize creates a new image from byte data with custom dimensions.
+func NewImageFromBytesWithSize(id string, data []byte, format domain.ImageFormat, size domain.ImageSize) (domain.Image, error) {
+	img, err := NewImageFromBytes(id, data, format)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := img.SetSize(size); err != nil {
+		return nil, err
+	}
+
+	return img, nil
+}
+
+// NewImageFromBytesWithPosition creates a new image from byte data with custom positioning.
+func NewImageFromBytesWithPosition(id string, data []byte, format domain.ImageFormat, size domain.ImageSize, pos domain.ImagePosition) (domain.Image, error) {
+	img, err := NewImageFromBytesWithSize(id, data, format, size)
+	if err != nil {
+		return nil, err
+	}
+
+	docxImg := img.(*docxImage)
+	docxImg.position = pos
+
+	return img, nil
+}
+
 // ReadImageFromReader creates an image from an io.Reader.
 func ReadImageFromReader(id string, reader io.Reader, format domain.ImageFormat) (domain.Image, error) {
 	// Read all data

--- a/internal/core/image_test.go
+++ b/internal/core/image_test.go
@@ -415,3 +415,94 @@ func TestDefaultImagePosition(t *testing.T) {
 		t.Errorf("WrapText = %v, want %v", pos.WrapText, domain.WrapNone)
 	}
 }
+
+func createTestImageBytes(t *testing.T, width, height int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{R: 255, G: 0, B: 0, A: 255})
+		}
+	}
+	buf := new(bytes.Buffer)
+	if err := png.Encode(buf, img); err != nil {
+		t.Fatalf("Failed to encode PNG: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestNewImageFromBytes(t *testing.T) {
+	t.Run("valid PNG bytes", func(t *testing.T) {
+		data := createTestImageBytes(t, 200, 150)
+		img, err := NewImageFromBytes("img10", data, domain.ImageFormatPNG)
+		if err != nil {
+			t.Fatalf("NewImageFromBytes() error = %v", err)
+		}
+		if img.ID() != "img10" {
+			t.Errorf("ID() = %v, want img10", img.ID())
+		}
+		if img.Format() != domain.ImageFormatPNG {
+			t.Errorf("Format() = %v, want png", img.Format())
+		}
+		size := img.Size()
+		if size.WidthPx != 200 || size.HeightPx != 150 {
+			t.Errorf("Size() = %dx%d, want 200x150", size.WidthPx, size.HeightPx)
+		}
+		if len(img.Data()) == 0 {
+			t.Error("Data() returned empty slice")
+		}
+		if !strings.Contains(img.Target(), "media/image") {
+			t.Errorf("Target() = %v, expected to contain media/image", img.Target())
+		}
+	})
+
+	t.Run("empty data returns error", func(t *testing.T) {
+		_, err := NewImageFromBytes("img11", nil, domain.ImageFormatPNG)
+		if err == nil {
+			t.Fatal("Expected error for empty data, got nil")
+		}
+	})
+
+	t.Run("empty format returns error", func(t *testing.T) {
+		data := createTestImageBytes(t, 100, 100)
+		_, err := NewImageFromBytes("img12", data, "")
+		if err == nil {
+			t.Fatal("Expected error for empty format, got nil")
+		}
+	})
+}
+
+func TestNewImageFromBytesWithSize(t *testing.T) {
+	data := createTestImageBytes(t, 200, 150)
+	size := domain.NewImageSize(100, 75)
+	img, err := NewImageFromBytesWithSize("img13", data, domain.ImageFormatPNG, size)
+	if err != nil {
+		t.Fatalf("NewImageFromBytesWithSize() error = %v", err)
+	}
+	result := img.Size()
+	if result.WidthPx != 100 || result.HeightPx != 75 {
+		t.Errorf("Size() = %dx%d, want 100x75", result.WidthPx, result.HeightPx)
+	}
+}
+
+func TestNewImageFromBytesWithPosition(t *testing.T) {
+	data := createTestImageBytes(t, 200, 150)
+	size := domain.NewImageSize(100, 75)
+	pos := domain.ImagePosition{
+		Type:     domain.ImagePositionFloating,
+		HAlign:   domain.HAlignCenter,
+		VAlign:   domain.VAlignTop,
+		WrapText: domain.WrapSquare,
+	}
+	img, err := NewImageFromBytesWithPosition("img14", data, domain.ImageFormatPNG, size, pos)
+	if err != nil {
+		t.Fatalf("NewImageFromBytesWithPosition() error = %v", err)
+	}
+	imgPos := img.Position()
+	if imgPos.Type != domain.ImagePositionFloating {
+		t.Errorf("Position().Type = %v, want floating", imgPos.Type)
+	}
+	if imgPos.HAlign != domain.HAlignCenter {
+		t.Errorf("Position().HAlign = %v, want center", imgPos.HAlign)
+	}
+}

--- a/internal/core/image_test.go
+++ b/internal/core/image_test.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 	"image"
 	"image/color"
+	"image/jpeg"
 	"image/png"
 	"os"
 	"path/filepath"
@@ -491,9 +492,19 @@ func TestNewImageFromBytes(t *testing.T) {
 	})
 
 	t.Run("normalizes jpg to jpeg", func(t *testing.T) {
-		// Use PNG data but verify format normalization logic
-		data := createTestImageBytes(t, 50, 50)
-		img, err := NewImageFromBytes("img12d", data, "JPG")
+		// Generate actual JPEG bytes
+		rawImg := image.NewRGBA(image.Rect(0, 0, 50, 50))
+		for y := 0; y < 50; y++ {
+			for x := 0; x < 50; x++ {
+				rawImg.Set(x, y, color.RGBA{R: 0, G: 128, B: 255, A: 255})
+			}
+		}
+		var jpegBuf bytes.Buffer
+		if err := jpeg.Encode(&jpegBuf, rawImg, nil); err != nil {
+			t.Fatalf("Failed to encode JPEG: %v", err)
+		}
+
+		img, err := NewImageFromBytes("img12d", jpegBuf.Bytes(), "JPG")
 		if err != nil {
 			t.Fatalf("NewImageFromBytes() error = %v", err)
 		}

--- a/internal/core/image_test.go
+++ b/internal/core/image_test.go
@@ -470,6 +470,37 @@ func TestNewImageFromBytes(t *testing.T) {
 			t.Fatal("Expected error for empty format, got nil")
 		}
 	})
+
+	t.Run("invalid format returns error", func(t *testing.T) {
+		data := createTestImageBytes(t, 100, 100)
+		_, err := NewImageFromBytes("img12b", data, "xyz")
+		if err == nil {
+			t.Fatal("Expected error for unsupported format, got nil")
+		}
+	})
+
+	t.Run("normalizes uppercase format", func(t *testing.T) {
+		data := createTestImageBytes(t, 100, 100)
+		img, err := NewImageFromBytes("img12c", data, "PNG")
+		if err != nil {
+			t.Fatalf("NewImageFromBytes() error = %v", err)
+		}
+		if img.Format() != domain.ImageFormatPNG {
+			t.Errorf("Format() = %v, want png", img.Format())
+		}
+	})
+
+	t.Run("normalizes jpg to jpeg", func(t *testing.T) {
+		// Use PNG data but verify format normalization logic
+		data := createTestImageBytes(t, 50, 50)
+		img, err := NewImageFromBytes("img12d", data, "JPG")
+		if err != nil {
+			t.Fatalf("NewImageFromBytes() error = %v", err)
+		}
+		if img.Format() != domain.ImageFormatJPEG {
+			t.Errorf("Format() = %v, want jpeg", img.Format())
+		}
+	})
 }
 
 func TestNewImageFromBytesWithSize(t *testing.T) {

--- a/internal/core/paragraph.go
+++ b/internal/core/paragraph.go
@@ -215,7 +215,7 @@ func (p *paragraph) AddImageFromBytesWithPosition(data []byte, format domain.Ima
 		return nil, errors.Wrap(err, "Paragraph.AddImageFromBytesWithPosition")
 	}
 
-	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, format)); err != nil {
+	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, img.Format())); err != nil {
 		return nil, err
 	}
 

--- a/internal/core/paragraph.go
+++ b/internal/core/paragraph.go
@@ -26,6 +26,7 @@ SOFTWARE.
 package core
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -170,6 +171,51 @@ func (p *paragraph) AddImageWithPosition(path string, size domain.ImageSize, pos
 	}
 
 	if err := p.attachImage(img, filepath.Base(path)); err != nil {
+		return nil, err
+	}
+
+	return img, nil
+}
+
+// AddImageFromBytes adds an image from raw byte data.
+func (p *paragraph) AddImageFromBytes(data []byte, format domain.ImageFormat) (domain.Image, error) {
+	id := p.idGen.NextImageID()
+	img, err := NewImageFromBytes(id, data, format)
+	if err != nil {
+		return nil, errors.Wrap(err, "Paragraph.AddImageFromBytes")
+	}
+
+	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, format)); err != nil {
+		return nil, err
+	}
+
+	return img, nil
+}
+
+// AddImageFromBytesWithSize adds an image from byte data with custom dimensions.
+func (p *paragraph) AddImageFromBytesWithSize(data []byte, format domain.ImageFormat, size domain.ImageSize) (domain.Image, error) {
+	id := p.idGen.NextImageID()
+	img, err := NewImageFromBytesWithSize(id, data, format, size)
+	if err != nil {
+		return nil, errors.Wrap(err, "Paragraph.AddImageFromBytesWithSize")
+	}
+
+	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, format)); err != nil {
+		return nil, err
+	}
+
+	return img, nil
+}
+
+// AddImageFromBytesWithPosition adds an image from byte data with custom positioning.
+func (p *paragraph) AddImageFromBytesWithPosition(data []byte, format domain.ImageFormat, size domain.ImageSize, pos domain.ImagePosition) (domain.Image, error) {
+	id := p.idGen.NextImageID()
+	img, err := NewImageFromBytesWithPosition(id, data, format, size, pos)
+	if err != nil {
+		return nil, errors.Wrap(err, "Paragraph.AddImageFromBytesWithPosition")
+	}
+
+	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, format)); err != nil {
 		return nil, err
 	}
 

--- a/internal/core/paragraph.go
+++ b/internal/core/paragraph.go
@@ -185,7 +185,7 @@ func (p *paragraph) AddImageFromBytes(data []byte, format domain.ImageFormat) (d
 		return nil, errors.Wrap(err, "Paragraph.AddImageFromBytes")
 	}
 
-	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, format)); err != nil {
+	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, img.Format())); err != nil {
 		return nil, err
 	}
 
@@ -200,7 +200,7 @@ func (p *paragraph) AddImageFromBytesWithSize(data []byte, format domain.ImageFo
 		return nil, errors.Wrap(err, "Paragraph.AddImageFromBytesWithSize")
 	}
 
-	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, format)); err != nil {
+	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, img.Format())); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

Add support for adding images from raw byte data without requiring file system access, addressing the use case described in #29.

## Changes

### New public API (`ParagraphBuilder`)
- `AddImageFromBytes(data []byte, format ImageFormat)` — inline image from bytes
- `AddImageFromBytesWithSize(data, format, size)` — with custom dimensions
- `AddImageFromBytesWithPosition(data, format, size, pos)` — floating with positioning

### New domain interface methods (`Paragraph`)
- `AddImageFromBytes`, `AddImageFromBytesWithSize`, `AddImageFromBytesWithPosition`

### Internal constructors (`core`)
- `NewImageFromBytes`, `NewImageFromBytesWithSize`, `NewImageFromBytesWithPosition`

### CLI handler optimization
- `applyImage()` now uses `AddImageFromBytes` directly for base64 images instead of writing to a temp file and calling `AddImage(path)`. Eliminates unnecessary disk I/O.

### Tests & examples
- Unit tests for all 3 core constructors (valid data, empty data, empty format)
- Builder tests for all 3 new methods (error path validation)
- Updated `examples/08_images` with a new section demonstrating in-memory image creation

## Usage

```go
// Image from bytes — no file system needed
builder.AddParagraph().
    AddImageFromBytes(pngBytes, domain.ImageFormatPNG).
    End()

// With custom size
builder.AddParagraph().
    AddImageFromBytesWithSize(pngBytes, domain.ImageFormatPNG, domain.NewImageSize(200, 150)).
    End()
```

Closes #29