### PR TITLE
release: v2.4.0 — in-memory image API + merged-cell round-trip fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+## v2.4.0 — 2026-04-30
+
+### Added
+
+- **In-memory image API** (`pkg/builder` + `domain.Paragraph`) — insert images from byte slices without touching the file system (PR #30, closes #29)
+  - `ParagraphBuilder.AddImageFromBytes(data, format)` — inline image from bytes
+  - `ParagraphBuilder.AddImageFromBytesWithSize(data, format, size)` — with custom dimensions
+  - `ParagraphBuilder.AddImageFromBytesWithPosition(data, format, size, pos)` — floating with positioning
+  - Matching methods on `domain.Paragraph` (`AddImageFromBytes`, `AddImageFromBytesWithSize`, `AddImageFromBytesWithPosition`)
+  - New `internal/core` constructors: `NewImageFromBytes`, `NewImageFromBytesWithSize`, `NewImageFromBytesWithPosition`
+  - Format normalization (`JPG` → `jpeg`, leading `.` trimmed) and validation against the supported set
+  - Defensive copy of the input byte slice so callers can safely reuse buffers
+- `examples/08_images` updated to demonstrate the new in-memory image flow
+
+### Fixed
+
+- **Round-trip preservation of `w:gridSpan` and `w:vMerge`** for merged table cells (PR #26, closes #25)
+  - `hydrateTableCell` now parses `<w:tcPr>` and applies horizontal merges through `cell.Merge(span, 1)` so spanned-over cells are correctly marked as `IsHorizontallyMergedContinuation()`
+  - Restores `w:vMerge` (`restart` / `continue`) onto reconstructed `domain.TableCell`s
+  - `hydrateTable` tracks `colOffset` and recomputes `maxCols` from gridSpan sums so XML cells map to the correct grid columns
+  - Numeric parse errors wrapped with `errors.WrapWithContext` (attribute + raw value) for clearer diagnostics
+
+### Changed
+
+- CLI handler (`cmd/docxgo/handlers.go`) `applyImage()` now uses `AddImageFromBytes*` directly for base64 images, eliminating the temp-file write/read round-trip
+
+### Tests
+
+- `TestGridSpanPreservedAfterRoundTrip` — verifies horizontal merge survives save + reopen and that continuation cells are flagged correctly
+- `TestVMergePreservedAfterRoundTrip` — verifies vertical merge `restart` / `continue` survives save + reopen
+- Unit tests for all three `NewImageFromBytes*` constructors (valid data, empty data, empty/invalid format)
+- Builder tests for all three `AddImageFromBytes*` methods (error path validation)
+
+---
+
 ## v2.3.0 — 2026-02-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,20 +19,21 @@ Production-grade Microsoft Word .docx (OOXML) file manipulation in Go.
 - ✅ **Production Ready** - EXCELLENT error handling, comprehensive validation
 - ✅ **Well Documented** - Complete godoc, examples, and architecture docs
 - ✅ **Template / Mail Merge** - Placeholder detection, data merging, batch document generation
+- ✅ **In-Memory Images** - Insert images from byte slices without touching the file system
 - ✅ **Open Source** - MIT License, use in commercial and private projects
 
 ---
 
 ## Status
 
-**Current Version**: v2.3.0 (Stable)
+**Current Version**: v2.4.0 (Stable)
 **Stability**: Production Ready
-**Released**: February 2026
+**Released**: April 2026
 **Test Coverage**: 50.7%
 
-**Latest Features**: Template / Mail Merge Engine (v2.3.0), Theme System (v2.1.0+), Round-trip Style Preservation (v2.2.1)
+**Latest Features**: In-memory Image API (v2.4.0), Template / Mail Merge Engine (v2.3.0), Theme System (v2.1.0+), Round-trip Style Preservation (v2.2.1)
 
-> **Note**: This library underwent a complete architectural rewrite in 2024-2025, implementing clean architecture principles, comprehensive testing, and modern Go practices. Version 2.0.0 released October 2025, with theme system added in v2.1.0, continued improvements through v2.2.x, and template/mail merge engine in v2.3.0.
+> **Note**: This library underwent a complete architectural rewrite in 2024-2025, implementing clean architecture principles, comprehensive testing, and modern Go practices. Version 2.0.0 released October 2025, with theme system added in v2.1.0, continued improvements through v2.2.x, template/mail merge engine in v2.3.0, and in-memory image insertion plus merged-cell round-trip fixes in v2.4.0.
 
 ---
 
@@ -524,7 +525,18 @@ For complete project genealogy, see [CREDITS.md](CREDITS.md).
 
 ### Release History
 
-- **v2.2.2** (February 2026 - Current Stable)
+- **v2.4.0** (April 2026 - Current Stable)
+  - In-memory image API: `AddImageFromBytes`, `AddImageFromBytesWithSize`, `AddImageFromBytesWithPosition`
+  - Round-trip preservation of `w:gridSpan` and `w:vMerge` for merged table cells
+  - CLI handler now embeds base64 images without temp files
+
+- **v2.3.0** (February 2026)
+  - Template / Mail Merge engine (`pkg/template/`)
+  - MERGEFIELD support with real Word templates and `«»` delimiters
+  - Paragraph mutation APIs (`ClearRuns`, `RemoveRun`, `InsertRunAt`)
+  - Examples 14 and 15 (mail merge + external Word templates)
+
+- **v2.2.2** (February 2026)
   - Table style borders fix (TableGrid, PlainTable1 now render with visible borders)
   - Grid column width calculation from cell widths
   - Comprehensive documentation overhaul
@@ -558,20 +570,14 @@ For complete project genealogy, see [CREDITS.md](CREDITS.md).
 - **v2.0.0-beta** (October 2025)
   - Initial beta release
 
-### Upcoming (dev branch)
-
-- Table style borders (TableGrid, PlainTable1) - fix for [#15](https://github.com/mmonterroca/docxgo/issues/15)
-- Updated examples with table styles
-- Restored example 13 (themes)
-
 ### Planned Features
 
-- Mail merge and templates
 - Comments and change tracking
 - Content controls / form fields
 - Custom XML parts
 - Advanced drawing shapes
 - Document comparison
+- Header/footer reading round-trip
 
 See [docs/IMPLEMENTATION_STATUS.md](docs/IMPLEMENTATION_STATUS.md) for detailed status.
 

--- a/RELEASE_NOTES_v2.4.0.md
+++ b/RELEASE_NOTES_v2.4.0.md
@@ -1,0 +1,82 @@
+# Release Notes - v2.4.0
+
+**Release Date:** April 2026
+
+## Summary
+
+v2.4.0 ships a new in-memory image API and a critical round-trip fix for merged table cells. The release adds `AddImageFromBytes*` methods on `ParagraphBuilder` (and the underlying `domain.Paragraph` interface) so callers can embed images directly from byte slices without touching the file system, and restores `w:gridSpan` / `w:vMerge` properties when reopening documents — fixing data loss for tables with horizontal or vertical cell merges.
+
+## New Features
+
+### In-Memory Image Insertion (PR #30, closes #29)
+
+Three new methods on `ParagraphBuilder` and `domain.Paragraph` let you insert images straight from a `[]byte` payload:
+
+- `AddImageFromBytes(data []byte, format ImageFormat)` — inline image from raw bytes
+- `AddImageFromBytesWithSize(data, format, size)` — with custom dimensions
+- `AddImageFromBytesWithPosition(data, format, size, pos)` — floating with positioning
+
+Highlights:
+
+- Format strings are normalized (`JPG` → `jpeg`, leading `.` trimmed) and validated against the supported set; unknown formats fail fast with a clear `InvalidArgument` error.
+- The byte slice is defensively copied so callers can safely reuse or mutate their buffer after insertion.
+- The CLI handler (`cmd/docxgo`) now routes base64 images through this path, eliminating the temp-file write/read round-trip used previously.
+
+```go
+// Inline image from bytes — no file system needed
+builder.AddParagraph().
+    AddImageFromBytes(pngBytes, domain.ImageFormatPNG).
+    End()
+
+// With custom size
+builder.AddParagraph().
+    AddImageFromBytesWithSize(pngBytes, domain.ImageFormatPNG, domain.NewImageSize(200, 150)).
+    End()
+```
+
+The `examples/08_images` example now demonstrates the in-memory flow alongside file-based image insertion.
+
+## Bug Fixes
+
+### Preserve `gridSpan` and `vMerge` on document reopen (PR #26, closes #25)
+
+`hydrateTableCell` in `internal/reader/reconstruct.go` previously skipped `<w:tcPr>`, so horizontal (`w:gridSpan`) and vertical (`w:vMerge`) merge metadata was dropped when reading a document. Re-saving the file then emitted extra `<w:tc>` elements and broke the original table layout.
+
+The reader now:
+
+- Parses `<w:tcPr>` and applies horizontal merges through `cell.Merge(span, 1)` so spanned-over cells are correctly marked as `IsHorizontallyMergedContinuation()`.
+- Restores `w:vMerge` (`restart` / `continue`) onto the rebuilt `domain.TableCell`.
+- Tracks `colOffset` in `hydrateTable` and recomputes `maxCols` from gridSpan sums so XML cells map to the correct grid columns.
+- Wraps numeric parse errors with `errors.WrapWithContext` (attribute + raw value) for clearer diagnostics on malformed documents.
+
+Two regression tests cover the round-trip:
+
+- `TestGridSpanPreservedAfterRoundTrip` — 2×3 table with row 0 spanning all 3 columns; asserts `GridSpan() == 3` and that cells 1 and 2 report `IsHorizontallyMergedContinuation()`.
+- `TestVMergePreservedAfterRoundTrip` — 3×2 table with a 3-row vertical merge; asserts `VMergeRestart` on row 0 and `VMergeContinue` on rows 1 and 2.
+
+## Internal Changes
+
+- `internal/core` adds `NewImageFromBytes`, `NewImageFromBytesWithSize`, and `NewImageFromBytesWithPosition` constructors with full unit-test coverage (valid data, empty data, empty/invalid format).
+- `cmd/docxgo/handlers.go` `applyImage()` now uses the new in-memory APIs directly for base64 payloads instead of writing to a temp file and calling `AddImage(path)`.
+
+## Installation
+
+```bash
+go get github.com/mmonterroca/docxgo/v2@v2.4.0
+```
+
+## Compatibility
+
+- Backward compatible with v2.3.x — all additions are new methods on existing interfaces. Custom `domain.Paragraph` implementations outside this module will need to add the three `AddImageFromBytes*` methods.
+- Documents written with earlier versions are unchanged; only round-trip behavior for merged tables improves.
+
+## Acknowledgements
+
+- PR #26 (`fix/issue-25-gridspan-lost-on-reopen`) — table merge round-trip fix
+- PR #30 (`feature/add-image-from-bytes`) — in-memory image API
+- Code review feedback from Copilot, Codex, and Gemini Code Assist on both PRs
+
+## Related Issues
+
+- Closes [#25](https://github.com/mmonterroca/docxgo/issues/25) — OpenDocument drops horizontal cell merges
+- Closes [#29](https://github.com/mmonterroca/docxgo/issues/29) — AddImageFromBytes

--- a/RELEASE_NOTES_v2.4.0.md
+++ b/RELEASE_NOTES_v2.4.0.md
@@ -67,8 +67,10 @@ go get github.com/mmonterroca/docxgo/v2@v2.4.0
 
 ## Compatibility
 
-- Backward compatible with v2.3.x — all additions are new methods on existing interfaces. Custom `domain.Paragraph` implementations outside this module will need to add the three `AddImageFromBytes*` methods.
-- Documents written with earlier versions are unchanged; only round-trip behavior for merged tables improves.
+- **Source-compatible for typical callers** using the built-in implementations from this module — the new image APIs are purely additive.
+- **Breaking for custom `domain.Paragraph` implementations** outside this module: the interface gains three new methods (`AddImageFromBytes`, `AddImageFromBytesWithSize`, `AddImageFromBytesWithPosition`) which custom implementers must add.
+- **Supported in-memory image formats**: PNG, JPEG, and GIF. These are the formats with registered Go decoders for dimension detection and mapped MIME types in the media manager. Use the file-based `AddImage(path)` API for BMP/TIFF/SVG/WEBP.
+- **Documents written with earlier versions are unchanged**; only round-trip behavior for merged tables improves.
 
 ## Acknowledgements
 

--- a/builder.go
+++ b/builder.go
@@ -529,6 +529,49 @@ func (pb *ParagraphBuilder) AddImageWithPosition(path string, size domain.ImageS
 	return pb
 }
 
+// AddImageFromBytes adds an image from raw byte data to the paragraph.
+// The format parameter specifies the image type (e.g., domain.ImageFormatPNG).
+func (pb *ParagraphBuilder) AddImageFromBytes(data []byte, format domain.ImageFormat) *ParagraphBuilder {
+	if pb.err != nil {
+		return pb
+	}
+
+	if _, err := pb.para.AddImageFromBytes(data, format); err != nil {
+		pb.err = err
+		pb.parent.errors = append(pb.parent.errors, err)
+	}
+
+	return pb
+}
+
+// AddImageFromBytesWithSize adds an image from byte data with custom dimensions.
+func (pb *ParagraphBuilder) AddImageFromBytesWithSize(data []byte, format domain.ImageFormat, size domain.ImageSize) *ParagraphBuilder {
+	if pb.err != nil {
+		return pb
+	}
+
+	if _, err := pb.para.AddImageFromBytesWithSize(data, format, size); err != nil {
+		pb.err = err
+		pb.parent.errors = append(pb.parent.errors, err)
+	}
+
+	return pb
+}
+
+// AddImageFromBytesWithPosition adds a floating image from byte data with custom positioning.
+func (pb *ParagraphBuilder) AddImageFromBytesWithPosition(data []byte, format domain.ImageFormat, size domain.ImageSize, pos domain.ImagePosition) *ParagraphBuilder {
+	if pb.err != nil {
+		return pb
+	}
+
+	if _, err := pb.para.AddImageFromBytesWithPosition(data, format, size, pos); err != nil {
+		pb.err = err
+		pb.parent.errors = append(pb.parent.errors, err)
+	}
+
+	return pb
+}
+
 // End returns to the DocumentBuilder for further operations.
 func (pb *ParagraphBuilder) End() *DocumentBuilder {
 	return pb.parent

--- a/builder_test.go
+++ b/builder_test.go
@@ -1033,4 +1033,46 @@ func TestParagraphBuilder_AddImage(t *testing.T) {
 			t.Fatal("expected error for empty image path, got nil")
 		}
 	})
+
+	t.Run("AddImageFromBytes fails with empty data", func(t *testing.T) {
+		builder := NewDocumentBuilder()
+		builder.AddParagraph().
+			Text("Before image").
+			AddImageFromBytes(nil, domain.ImageFormatPNG).
+			End()
+
+		_, err := builder.Build()
+		if err == nil {
+			t.Fatal("expected error for nil image data, got nil")
+		}
+	})
+
+	t.Run("AddImageFromBytesWithSize fails with empty data", func(t *testing.T) {
+		builder := NewDocumentBuilder()
+		size := domain.NewImageSize(100, 100)
+		builder.AddParagraph().
+			Text("Before image").
+			AddImageFromBytesWithSize(nil, domain.ImageFormatPNG, size).
+			End()
+
+		_, err := builder.Build()
+		if err == nil {
+			t.Fatal("expected error for nil image data, got nil")
+		}
+	})
+
+	t.Run("AddImageFromBytesWithPosition fails with empty data", func(t *testing.T) {
+		builder := NewDocumentBuilder()
+		size := domain.NewImageSize(100, 100)
+		pos := domain.DefaultImagePosition()
+		builder.AddParagraph().
+			Text("Before image").
+			AddImageFromBytesWithPosition(nil, domain.ImageFormatPNG, size, pos).
+			End()
+
+		_, err := builder.Build()
+		if err == nil {
+			t.Fatal("expected error for nil image data, got nil")
+		}
+	})
 }

--- a/cmd/docxgo/handlers.go
+++ b/cmd/docxgo/handlers.go
@@ -835,31 +835,26 @@ func applyField(para domain.Paragraph, f *fieldDef) error {
 
 // applyImage adds an image to a paragraph.
 func applyImage(para domain.Paragraph, img *imageDef) error {
-	path := img.Path
-
+	// If base64 data is provided, use AddImageFromBytes directly (no temp file needed).
 	if img.Base64 != "" {
 		data, err := base64.StdEncoding.DecodeString(img.Base64)
 		if err != nil {
 			return fmt.Errorf("invalid image base64: %w", err)
 		}
-		ext := img.Format
-		if ext == "" {
-			ext = "png"
+		format := domain.ImageFormat(img.Format)
+		if format == "" {
+			format = domain.ImageFormatPNG
 		}
-		tmp, err := os.CreateTemp("", "docxgo-img-*."+ext)
-		if err != nil {
-			return fmt.Errorf("failed to create temp image: %w", err)
+		if img.WidthPx > 0 || img.HeightPx > 0 {
+			size := domain.NewImageSize(img.WidthPx, img.HeightPx)
+			_, err = para.AddImageFromBytesWithSize(data, format, size)
+			return err
 		}
-		if _, err := tmp.Write(data); err != nil {
-			_ = tmp.Close()
-			_ = os.Remove(tmp.Name())
-			return fmt.Errorf("failed to write temp image: %w", err)
-		}
-		_ = tmp.Close()
-		path = tmp.Name()
-		defer os.Remove(path)
+		_, err = para.AddImageFromBytes(data, format)
+		return err
 	}
 
+	path := img.Path
 	if path == "" {
 		return fmt.Errorf("image requires path or base64")
 	}

--- a/doc.go
+++ b/doc.go
@@ -308,7 +308,7 @@ This library generates Office Open XML (OOXML) documents compatible with:
 
 # Version
 
-Current version: 2.3.0
+Current version: 2.4.0
 
 This is a major rewrite of the original go-docx library with breaking changes.
 See the migration guide in docs/V2_DESIGN.md for details.

--- a/docs/V2_API_GUIDE.md
+++ b/docs/V2_API_GUIDE.md
@@ -1,6 +1,6 @@
 # go-docx v2 API Guide
 
-**Version**: 2.3.0
+**Version**: 2.4.0
 **Last Updated**: February 2026
 
 ---
@@ -973,4 +973,4 @@ See [`examples/14_mail_merge/`](../examples/14_mail_merge/) for a complete worki
 ---
 
 **Last Updated**: February 2026
-**Version**: 2.3.0
+**Version**: 2.4.0

--- a/docs/V2_API_GUIDE.md
+++ b/docs/V2_API_GUIDE.md
@@ -1,7 +1,7 @@
 # go-docx v2 API Guide
 
 **Version**: 2.4.0
-**Last Updated**: February 2026
+**Last Updated**: April 2026
 
 ---
 

--- a/docs/V2_DESIGN.md
+++ b/docs/V2_DESIGN.md
@@ -1339,7 +1339,7 @@ See [CREDITS.md](../CREDITS.md) for complete project history.
 
 ---
 
-**Last Updated**: February 2026
+**Last Updated**: April 2026
 **Status**: ✅ v2.4.0 Stable
 **Progress**: Production Ready (all core features complete)
 

--- a/docs/V2_DESIGN.md
+++ b/docs/V2_DESIGN.md
@@ -1,8 +1,8 @@
 # go-docx v2.0 - Clean Architecture Design
 
-**Status**: ✅ v2.3.0 Stable
+**Status**: ✅ v2.4.0 Stable
 **Progress**: Production Ready (all core features complete)
-**Latest Release**: v2.3.0 (February 2026)
+**Latest Release**: v2.4.0 (April 2026)
 **Breaking Changes**: Yes (major version bump from original fork)
 
 > **Project Note**: This project originated as a fork of `fumiama/go-docx` but has been completely rewritten with a clean architecture design. The current version represents a ground-up rebuild focused on maintainability, type safety, and modern Go practices.
@@ -1340,7 +1340,7 @@ See [CREDITS.md](../CREDITS.md) for complete project history.
 ---
 
 **Last Updated**: February 2026
-**Status**: ✅ v2.3.0 Stable
+**Status**: ✅ v2.4.0 Stable
 **Progress**: Production Ready (all core features complete)
 
 **Current State:**

--- a/docx_read_test.go
+++ b/docx_read_test.go
@@ -127,4 +127,99 @@ func TestGridSpanPreservedAfterRoundTrip(t *testing.T) {
 	if got := cell.GridSpan(); got != 3 {
 		t.Errorf("after reopen: GridSpan = %d, want 3", got)
 	}
+
+	// Verify continuation cells are marked so the serializer skips them.
+	cell1, err := row0.Cell(1)
+	if err != nil {
+		t.Fatalf("Cell(1) after reopen: %v", err)
+	}
+	if !cell1.IsHorizontallyMergedContinuation() {
+		t.Errorf("Cell(1) should be a horizontal merge continuation")
+	}
+	cell2, err := row0.Cell(2)
+	if err != nil {
+		t.Fatalf("Cell(2) after reopen: %v", err)
+	}
+	if !cell2.IsHorizontallyMergedContinuation() {
+		t.Errorf("Cell(2) should be a horizontal merge continuation")
+	}
+}
+
+// TestVMergePreservedAfterRoundTrip verifies vertical cell merges survive save+reopen.
+func TestVMergePreservedAfterRoundTrip(t *testing.T) {
+	doc := NewDocument()
+	table, err := doc.AddTable(3, 2)
+	if err != nil {
+		t.Fatalf("AddTable: %v", err)
+	}
+	table.SetStyle(domain.TableStyleGrid)
+
+	// Merge rows 0-2 in column 0 vertically (3 rows, 1 col).
+	row0, err := table.Row(0)
+	if err != nil {
+		t.Fatalf("Row(0): %v", err)
+	}
+	cell, err := row0.Cell(0)
+	if err != nil {
+		t.Fatalf("Cell(0): %v", err)
+	}
+	if err := cell.Merge(1, 3); err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	p, err := cell.AddParagraph()
+	if err != nil {
+		t.Fatalf("AddParagraph: %v", err)
+	}
+	r, err := p.AddRun()
+	if err != nil {
+		t.Fatalf("AddRun: %v", err)
+	}
+	if err := r.AddText("Vertical span"); err != nil {
+		t.Fatalf("AddText: %v", err)
+	}
+
+	if got := cell.VMerge(); got != domain.VMergeRestart {
+		t.Fatalf("before save: VMerge = %v, want VMergeRestart", got)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	doc2, err := OpenDocumentFromBytes(buf.Bytes())
+	if err != nil {
+		t.Fatalf("OpenDocumentFromBytes: %v", err)
+	}
+
+	tables := doc2.Tables()
+	if len(tables) == 0 {
+		t.Fatal("expected at least one table after reopen")
+	}
+
+	// Row 0, Cell 0: should be VMergeRestart
+	r0, err := tables[0].Row(0)
+	if err != nil {
+		t.Fatalf("Row(0) after reopen: %v", err)
+	}
+	c0, err := r0.Cell(0)
+	if err != nil {
+		t.Fatalf("Row(0).Cell(0) after reopen: %v", err)
+	}
+	if got := c0.VMerge(); got != domain.VMergeRestart {
+		t.Errorf("Row(0).Cell(0) VMerge = %v, want VMergeRestart", got)
+	}
+
+	// Row 1, Cell 0: should be VMergeContinue
+	r1, err := tables[0].Row(1)
+	if err != nil {
+		t.Fatalf("Row(1) after reopen: %v", err)
+	}
+	c1, err := r1.Cell(0)
+	if err != nil {
+		t.Fatalf("Row(1).Cell(0) after reopen: %v", err)
+	}
+	if got := c1.VMerge(); got != domain.VMergeContinue {
+		t.Errorf("Row(1).Cell(0) VMerge = %v, want VMergeContinue", got)
+	}
 }

--- a/docx_read_test.go
+++ b/docx_read_test.go
@@ -62,3 +62,69 @@ func assertParagraphText(t *testing.T, doc domain.Document, expected string) {
 		t.Fatalf("unexpected paragraph text: %q", got)
 	}
 }
+
+// TestGridSpanPreservedAfterRoundTrip reproduces issue #25:
+// horizontal cell merges (w:gridSpan) are lost after save+reopen.
+func TestGridSpanPreservedAfterRoundTrip(t *testing.T) {
+	doc := NewDocument()
+	table, err := doc.AddTable(2, 3)
+	if err != nil {
+		t.Fatalf("AddTable: %v", err)
+	}
+	table.SetStyle(domain.TableStyleGrid)
+
+	row0, err := table.Row(0)
+	if err != nil {
+		t.Fatalf("Row(0): %v", err)
+	}
+	cell, err := row0.Cell(0)
+	if err != nil {
+		t.Fatalf("Cell(0): %v", err)
+	}
+	if err := cell.Merge(3, 1); err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	p, err := cell.AddParagraph()
+	if err != nil {
+		t.Fatalf("AddParagraph: %v", err)
+	}
+	r, err := p.AddRun()
+	if err != nil {
+		t.Fatalf("AddRun: %v", err)
+	}
+	if err := r.AddText("Spans 3 columns"); err != nil {
+		t.Fatalf("AddText: %v", err)
+	}
+
+	if got := cell.GridSpan(); got != 3 {
+		t.Fatalf("before save: GridSpan = %d, want 3", got)
+	}
+
+	// Round-trip through bytes
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	doc2, err := OpenDocumentFromBytes(buf.Bytes())
+	if err != nil {
+		t.Fatalf("OpenDocumentFromBytes: %v", err)
+	}
+
+	tables := doc2.Tables()
+	if len(tables) == 0 {
+		t.Fatal("expected at least one table after reopen")
+	}
+	row0, err = tables[0].Row(0)
+	if err != nil {
+		t.Fatalf("Row(0) after reopen: %v", err)
+	}
+	cell, err = row0.Cell(0)
+	if err != nil {
+		t.Fatalf("Cell(0) after reopen: %v", err)
+	}
+
+	if got := cell.GridSpan(); got != 3 {
+		t.Errorf("after reopen: GridSpan = %d, want 3", got)
+	}
+}

--- a/domain/paragraph.go
+++ b/domain/paragraph.go
@@ -48,6 +48,16 @@ type Paragraph interface {
 	// AddImageWithPosition adds an image with custom positioning.
 	AddImageWithPosition(path string, size ImageSize, pos ImagePosition) (Image, error)
 
+	// AddImageFromBytes adds an image from raw byte data.
+	// The format parameter specifies the image type (e.g., ImageFormatPNG).
+	AddImageFromBytes(data []byte, format ImageFormat) (Image, error)
+
+	// AddImageFromBytesWithSize adds an image from byte data with custom dimensions.
+	AddImageFromBytesWithSize(data []byte, format ImageFormat, size ImageSize) (Image, error)
+
+	// AddImageFromBytesWithPosition adds an image from byte data with custom positioning.
+	AddImageFromBytesWithPosition(data []byte, format ImageFormat, size ImageSize, pos ImagePosition) (Image, error)
+
 	// Images returns all images in this paragraph.
 	Images() []Image
 

--- a/examples/08_images/main.go
+++ b/examples/08_images/main.go
@@ -15,6 +15,7 @@ This example demonstrates:
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"image"
 	"image/color"
@@ -245,6 +246,49 @@ func main() {
 		Text(" <- Three inline images").
 		End()
 
+	builder.AddParagraph().Text("").End()
+
+	// Example 8: Image from bytes (no file system required)
+	builder.AddParagraph().
+		Text("8. Image from Byte Data (AddImageFromBytes)").
+		Bold().
+		FontSize(16).
+		End()
+
+	builder.AddParagraph().
+		Text("This image was created entirely in memory, without writing to disk:").
+		End()
+
+	// Create an image in memory
+	memImg := image.NewRGBA(image.Rect(0, 0, 300, 200))
+	for y := 0; y < 200; y++ {
+		for x := 0; x < 300; x++ {
+			memImg.Set(x, y, color.RGBA{
+				R: uint8(x * 255 / 300),
+				G: uint8(y * 255 / 200),
+				B: 180,
+				A: 255,
+			})
+		}
+	}
+	var imgBuf bytes.Buffer
+	if err := png.Encode(&imgBuf, memImg); err != nil {
+		log.Fatalf("Failed to encode in-memory image: %v", err)
+	}
+	imgBytes := imgBuf.Bytes()
+
+	builder.AddParagraph().
+		AddImageFromBytes(imgBytes, domain.ImageFormatPNG).
+		End()
+
+	builder.AddParagraph().
+		Text("You can also use AddImageFromBytesWithSize to control dimensions:").
+		End()
+
+	builder.AddParagraph().
+		AddImageFromBytesWithSize(imgBytes, domain.ImageFormatPNG, domain.NewImageSize(150, 100)).
+		End()
+
 	// Save document
 	doc, err := builder.Build()
 	if err != nil {
@@ -264,4 +308,5 @@ func main() {
 	fmt.Println("  - Floating images (center, left, right)")
 	fmt.Println("  - Text wrapping (square, tight)")
 	fmt.Println("  - Multiple images in one paragraph")
+	fmt.Println("  - Images from byte data (no file system)")
 }

--- a/internal/core/image.go
+++ b/internal/core/image.go
@@ -344,6 +344,9 @@ func NewImageFromBytes(id string, data []byte, format domain.ImageFormat) (domai
 		return nil, errors.Wrap(err, "NewImageFromBytes")
 	}
 
+	copyData := make([]byte, len(data))
+	copy(copyData, data)
+
 	target := fmt.Sprintf("media/image%s.%s", id, normalized)
 
 	return &docxImage{
@@ -351,7 +354,7 @@ func NewImageFromBytes(id string, data []byte, format domain.ImageFormat) (domai
 		format:       normalized,
 		size:         size,
 		originalSize: size,
-		data:         data,
+		data:         copyData,
 		target:       target,
 		description:  "",
 		position:     domain.DefaultImagePosition(),

--- a/internal/core/image.go
+++ b/internal/core/image.go
@@ -25,6 +25,7 @@ SOFTWARE.
 package core
 
 import (
+	"bytes"
 	"fmt"
 	"image"
 	_ "image/gif"  // Register GIF format decoder
@@ -270,7 +271,15 @@ func detectImageFormat(path string) domain.ImageFormat {
 	ext := strings.ToLower(filepath.Ext(path))
 	ext = strings.TrimPrefix(ext, ".")
 
-	switch ext {
+	return normalizeImageFormat(domain.ImageFormat(ext))
+}
+
+// normalizeImageFormat validates and normalizes an ImageFormat value.
+// Returns empty string for unsupported formats.
+func normalizeImageFormat(format domain.ImageFormat) domain.ImageFormat {
+	normalized := strings.ToLower(strings.TrimPrefix(string(format), "."))
+
+	switch normalized {
 	case "png":
 		return domain.ImageFormatPNG
 	case "jpg", "jpeg":
@@ -309,15 +318,9 @@ func formatFromContentType(contentType string) domain.ImageFormat {
 
 // getImageDimensions reads image dimensions from image data.
 func getImageDimensions(data []byte) (domain.ImageSize, error) {
-	// Decode image to get dimensions
-	img, format, err := image.DecodeConfig(strings.NewReader(string(data)))
+	img, format, err := image.DecodeConfig(bytes.NewReader(data))
 	if err != nil {
-		// If decode fails, try reading as binary
-		reader := strings.NewReader(string(data))
-		img, format, err = image.DecodeConfig(reader)
-		if err != nil {
-			return domain.ImageSize{}, errors.Wrap(err, "getImageDimensions")
-		}
+		return domain.ImageSize{}, errors.Wrap(err, "getImageDimensions")
 	}
 
 	_ = format // format string is for logging if needed
@@ -328,10 +331,12 @@ func getImageDimensions(data []byte) (domain.ImageSize, error) {
 // NewImageFromBytes creates a new image from raw byte data.
 func NewImageFromBytes(id string, data []byte, format domain.ImageFormat) (domain.Image, error) {
 	if len(data) == 0 {
-		return nil, errors.InvalidArgument("NewImageFromBytes", "data", nil, "image data cannot be empty")
+		return nil, errors.InvalidArgument("NewImageFromBytes", "data", data, "image data cannot be empty")
 	}
-	if format == "" {
-		return nil, errors.InvalidArgument("NewImageFromBytes", "format", format, "image format is required")
+
+	normalized := normalizeImageFormat(format)
+	if normalized == "" {
+		return nil, errors.InvalidArgument("NewImageFromBytes", "format", format, "unsupported image format")
 	}
 
 	size, err := getImageDimensions(data)
@@ -339,17 +344,14 @@ func NewImageFromBytes(id string, data []byte, format domain.ImageFormat) (domai
 		return nil, errors.Wrap(err, "NewImageFromBytes")
 	}
 
-	copyData := make([]byte, len(data))
-	copy(copyData, data)
-
-	target := fmt.Sprintf("media/image%s.%s", id, format)
+	target := fmt.Sprintf("media/image%s.%s", id, normalized)
 
 	return &docxImage{
 		id:           id,
-		format:       format,
+		format:       normalized,
 		size:         size,
 		originalSize: size,
-		data:         copyData,
+		data:         data,
 		target:       target,
 		description:  "",
 		position:     domain.DefaultImagePosition(),

--- a/internal/core/image.go
+++ b/internal/core/image.go
@@ -328,6 +328,20 @@ func getImageDimensions(data []byte) (domain.ImageSize, error) {
 	return domain.NewImageSize(img.Width, img.Height), nil
 }
 
+// isDecodableInMemoryFormat reports whether a format can be decoded by
+// image.DecodeConfig with the registered Go standard-library decoders
+// AND has a mapped MIME type in MediaManager.detectContentType. Used by
+// NewImageFromBytes* to fail fast for formats that would otherwise produce
+// a decode error or an application/octet-stream content type.
+func isDecodableInMemoryFormat(f domain.ImageFormat) bool {
+	switch f {
+	case domain.ImageFormatPNG, domain.ImageFormatJPEG, domain.ImageFormatGIF:
+		return true
+	default:
+		return false
+	}
+}
+
 // NewImageFromBytes creates a new image from raw byte data.
 func NewImageFromBytes(id string, data []byte, format domain.ImageFormat) (domain.Image, error) {
 	if len(data) == 0 {
@@ -337,6 +351,10 @@ func NewImageFromBytes(id string, data []byte, format domain.ImageFormat) (domai
 	normalized := normalizeImageFormat(format)
 	if normalized == "" {
 		return nil, errors.InvalidArgument("NewImageFromBytes", "format", format, "unsupported image format")
+	}
+	if !isDecodableInMemoryFormat(normalized) {
+		return nil, errors.InvalidArgument("NewImageFromBytes", "format", format,
+			"in-memory image insertion only supports PNG, JPEG, and GIF; use AddImage(path) for other formats")
 	}
 
 	size, err := getImageDimensions(data)

--- a/internal/core/image.go
+++ b/internal/core/image.go
@@ -325,6 +325,64 @@ func getImageDimensions(data []byte) (domain.ImageSize, error) {
 	return domain.NewImageSize(img.Width, img.Height), nil
 }
 
+// NewImageFromBytes creates a new image from raw byte data.
+func NewImageFromBytes(id string, data []byte, format domain.ImageFormat) (domain.Image, error) {
+	if len(data) == 0 {
+		return nil, errors.InvalidArgument("NewImageFromBytes", "data", nil, "image data cannot be empty")
+	}
+	if format == "" {
+		return nil, errors.InvalidArgument("NewImageFromBytes", "format", format, "image format is required")
+	}
+
+	size, err := getImageDimensions(data)
+	if err != nil {
+		return nil, errors.Wrap(err, "NewImageFromBytes")
+	}
+
+	copyData := make([]byte, len(data))
+	copy(copyData, data)
+
+	target := fmt.Sprintf("media/image%s.%s", id, format)
+
+	return &docxImage{
+		id:           id,
+		format:       format,
+		size:         size,
+		originalSize: size,
+		data:         copyData,
+		target:       target,
+		description:  "",
+		position:     domain.DefaultImagePosition(),
+	}, nil
+}
+
+// NewImageFromBytesWithSize creates a new image from byte data with custom dimensions.
+func NewImageFromBytesWithSize(id string, data []byte, format domain.ImageFormat, size domain.ImageSize) (domain.Image, error) {
+	img, err := NewImageFromBytes(id, data, format)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := img.SetSize(size); err != nil {
+		return nil, err
+	}
+
+	return img, nil
+}
+
+// NewImageFromBytesWithPosition creates a new image from byte data with custom positioning.
+func NewImageFromBytesWithPosition(id string, data []byte, format domain.ImageFormat, size domain.ImageSize, pos domain.ImagePosition) (domain.Image, error) {
+	img, err := NewImageFromBytesWithSize(id, data, format, size)
+	if err != nil {
+		return nil, err
+	}
+
+	docxImg := img.(*docxImage)
+	docxImg.position = pos
+
+	return img, nil
+}
+
 // ReadImageFromReader creates an image from an io.Reader.
 func ReadImageFromReader(id string, reader io.Reader, format domain.ImageFormat) (domain.Image, error) {
 	// Read all data

--- a/internal/core/image_test.go
+++ b/internal/core/image_test.go
@@ -415,3 +415,94 @@ func TestDefaultImagePosition(t *testing.T) {
 		t.Errorf("WrapText = %v, want %v", pos.WrapText, domain.WrapNone)
 	}
 }
+
+func createTestImageBytes(t *testing.T, width, height int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.Set(x, y, color.RGBA{R: 255, G: 0, B: 0, A: 255})
+		}
+	}
+	buf := new(bytes.Buffer)
+	if err := png.Encode(buf, img); err != nil {
+		t.Fatalf("Failed to encode PNG: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestNewImageFromBytes(t *testing.T) {
+	t.Run("valid PNG bytes", func(t *testing.T) {
+		data := createTestImageBytes(t, 200, 150)
+		img, err := NewImageFromBytes("img10", data, domain.ImageFormatPNG)
+		if err != nil {
+			t.Fatalf("NewImageFromBytes() error = %v", err)
+		}
+		if img.ID() != "img10" {
+			t.Errorf("ID() = %v, want img10", img.ID())
+		}
+		if img.Format() != domain.ImageFormatPNG {
+			t.Errorf("Format() = %v, want png", img.Format())
+		}
+		size := img.Size()
+		if size.WidthPx != 200 || size.HeightPx != 150 {
+			t.Errorf("Size() = %dx%d, want 200x150", size.WidthPx, size.HeightPx)
+		}
+		if len(img.Data()) == 0 {
+			t.Error("Data() returned empty slice")
+		}
+		if !strings.Contains(img.Target(), "media/image") {
+			t.Errorf("Target() = %v, expected to contain media/image", img.Target())
+		}
+	})
+
+	t.Run("empty data returns error", func(t *testing.T) {
+		_, err := NewImageFromBytes("img11", nil, domain.ImageFormatPNG)
+		if err == nil {
+			t.Fatal("Expected error for empty data, got nil")
+		}
+	})
+
+	t.Run("empty format returns error", func(t *testing.T) {
+		data := createTestImageBytes(t, 100, 100)
+		_, err := NewImageFromBytes("img12", data, "")
+		if err == nil {
+			t.Fatal("Expected error for empty format, got nil")
+		}
+	})
+}
+
+func TestNewImageFromBytesWithSize(t *testing.T) {
+	data := createTestImageBytes(t, 200, 150)
+	size := domain.NewImageSize(100, 75)
+	img, err := NewImageFromBytesWithSize("img13", data, domain.ImageFormatPNG, size)
+	if err != nil {
+		t.Fatalf("NewImageFromBytesWithSize() error = %v", err)
+	}
+	result := img.Size()
+	if result.WidthPx != 100 || result.HeightPx != 75 {
+		t.Errorf("Size() = %dx%d, want 100x75", result.WidthPx, result.HeightPx)
+	}
+}
+
+func TestNewImageFromBytesWithPosition(t *testing.T) {
+	data := createTestImageBytes(t, 200, 150)
+	size := domain.NewImageSize(100, 75)
+	pos := domain.ImagePosition{
+		Type:     domain.ImagePositionFloating,
+		HAlign:   domain.HAlignCenter,
+		VAlign:   domain.VAlignTop,
+		WrapText: domain.WrapSquare,
+	}
+	img, err := NewImageFromBytesWithPosition("img14", data, domain.ImageFormatPNG, size, pos)
+	if err != nil {
+		t.Fatalf("NewImageFromBytesWithPosition() error = %v", err)
+	}
+	imgPos := img.Position()
+	if imgPos.Type != domain.ImagePositionFloating {
+		t.Errorf("Position().Type = %v, want floating", imgPos.Type)
+	}
+	if imgPos.HAlign != domain.HAlignCenter {
+		t.Errorf("Position().HAlign = %v, want center", imgPos.HAlign)
+	}
+}

--- a/internal/core/image_test.go
+++ b/internal/core/image_test.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 	"image"
 	"image/color"
+	"image/jpeg"
 	"image/png"
 	"os"
 	"path/filepath"
@@ -491,9 +492,19 @@ func TestNewImageFromBytes(t *testing.T) {
 	})
 
 	t.Run("normalizes jpg to jpeg", func(t *testing.T) {
-		// Use PNG data but verify format normalization logic
-		data := createTestImageBytes(t, 50, 50)
-		img, err := NewImageFromBytes("img12d", data, "JPG")
+		// Generate actual JPEG bytes
+		rawImg := image.NewRGBA(image.Rect(0, 0, 50, 50))
+		for y := 0; y < 50; y++ {
+			for x := 0; x < 50; x++ {
+				rawImg.Set(x, y, color.RGBA{R: 0, G: 128, B: 255, A: 255})
+			}
+		}
+		var jpegBuf bytes.Buffer
+		if err := jpeg.Encode(&jpegBuf, rawImg, nil); err != nil {
+			t.Fatalf("Failed to encode JPEG: %v", err)
+		}
+
+		img, err := NewImageFromBytes("img12d", jpegBuf.Bytes(), "JPG")
 		if err != nil {
 			t.Fatalf("NewImageFromBytes() error = %v", err)
 		}

--- a/internal/core/image_test.go
+++ b/internal/core/image_test.go
@@ -470,6 +470,37 @@ func TestNewImageFromBytes(t *testing.T) {
 			t.Fatal("Expected error for empty format, got nil")
 		}
 	})
+
+	t.Run("invalid format returns error", func(t *testing.T) {
+		data := createTestImageBytes(t, 100, 100)
+		_, err := NewImageFromBytes("img12b", data, "xyz")
+		if err == nil {
+			t.Fatal("Expected error for unsupported format, got nil")
+		}
+	})
+
+	t.Run("normalizes uppercase format", func(t *testing.T) {
+		data := createTestImageBytes(t, 100, 100)
+		img, err := NewImageFromBytes("img12c", data, "PNG")
+		if err != nil {
+			t.Fatalf("NewImageFromBytes() error = %v", err)
+		}
+		if img.Format() != domain.ImageFormatPNG {
+			t.Errorf("Format() = %v, want png", img.Format())
+		}
+	})
+
+	t.Run("normalizes jpg to jpeg", func(t *testing.T) {
+		// Use PNG data but verify format normalization logic
+		data := createTestImageBytes(t, 50, 50)
+		img, err := NewImageFromBytes("img12d", data, "JPG")
+		if err != nil {
+			t.Fatalf("NewImageFromBytes() error = %v", err)
+		}
+		if img.Format() != domain.ImageFormatJPEG {
+			t.Errorf("Format() = %v, want jpeg", img.Format())
+		}
+	})
 }
 
 func TestNewImageFromBytesWithSize(t *testing.T) {

--- a/internal/core/paragraph.go
+++ b/internal/core/paragraph.go
@@ -215,7 +215,7 @@ func (p *paragraph) AddImageFromBytesWithPosition(data []byte, format domain.Ima
 		return nil, errors.Wrap(err, "Paragraph.AddImageFromBytesWithPosition")
 	}
 
-	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, format)); err != nil {
+	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, img.Format())); err != nil {
 		return nil, err
 	}
 

--- a/internal/core/paragraph.go
+++ b/internal/core/paragraph.go
@@ -26,6 +26,7 @@ SOFTWARE.
 package core
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -170,6 +171,51 @@ func (p *paragraph) AddImageWithPosition(path string, size domain.ImageSize, pos
 	}
 
 	if err := p.attachImage(img, filepath.Base(path)); err != nil {
+		return nil, err
+	}
+
+	return img, nil
+}
+
+// AddImageFromBytes adds an image from raw byte data.
+func (p *paragraph) AddImageFromBytes(data []byte, format domain.ImageFormat) (domain.Image, error) {
+	id := p.idGen.NextImageID()
+	img, err := NewImageFromBytes(id, data, format)
+	if err != nil {
+		return nil, errors.Wrap(err, "Paragraph.AddImageFromBytes")
+	}
+
+	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, format)); err != nil {
+		return nil, err
+	}
+
+	return img, nil
+}
+
+// AddImageFromBytesWithSize adds an image from byte data with custom dimensions.
+func (p *paragraph) AddImageFromBytesWithSize(data []byte, format domain.ImageFormat, size domain.ImageSize) (domain.Image, error) {
+	id := p.idGen.NextImageID()
+	img, err := NewImageFromBytesWithSize(id, data, format, size)
+	if err != nil {
+		return nil, errors.Wrap(err, "Paragraph.AddImageFromBytesWithSize")
+	}
+
+	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, format)); err != nil {
+		return nil, err
+	}
+
+	return img, nil
+}
+
+// AddImageFromBytesWithPosition adds an image from byte data with custom positioning.
+func (p *paragraph) AddImageFromBytesWithPosition(data []byte, format domain.ImageFormat, size domain.ImageSize, pos domain.ImagePosition) (domain.Image, error) {
+	id := p.idGen.NextImageID()
+	img, err := NewImageFromBytesWithPosition(id, data, format, size, pos)
+	if err != nil {
+		return nil, errors.Wrap(err, "Paragraph.AddImageFromBytesWithPosition")
+	}
+
+	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, format)); err != nil {
 		return nil, err
 	}
 

--- a/internal/core/paragraph.go
+++ b/internal/core/paragraph.go
@@ -185,7 +185,7 @@ func (p *paragraph) AddImageFromBytes(data []byte, format domain.ImageFormat) (d
 		return nil, errors.Wrap(err, "Paragraph.AddImageFromBytes")
 	}
 
-	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, format)); err != nil {
+	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, img.Format())); err != nil {
 		return nil, err
 	}
 
@@ -200,7 +200,7 @@ func (p *paragraph) AddImageFromBytesWithSize(data []byte, format domain.ImageFo
 		return nil, errors.Wrap(err, "Paragraph.AddImageFromBytesWithSize")
 	}
 
-	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, format)); err != nil {
+	if err := p.attachImage(img, fmt.Sprintf("image%s.%s", id, img.Format())); err != nil {
 		return nil, err
 	}
 

--- a/internal/reader/reconstruct.go
+++ b/internal/reader/reconstruct.go
@@ -1949,8 +1949,13 @@ func hydrateTable(doc domain.Document, elem *Element, ctx *reconstructContext) e
 			}
 			cells = append(cells, child)
 		}
-		if len(cells) > maxCols {
-			maxCols = len(cells)
+		// Sum gridSpan values to get the actual grid column count.
+		gridCols := 0
+		for _, c := range cells {
+			gridCols += cellGridSpan(c)
+		}
+		if gridCols > maxCols {
+			maxCols = gridCols
 		}
 		rowCells[idx] = cells
 	}
@@ -1970,12 +1975,13 @@ func hydrateTable(doc domain.Document, elem *Element, ctx *reconstructContext) e
 			return errors.Wrap(err, opHydrateTable)
 		}
 
-		for j, cellElem := range cells {
-			if j >= table.ColumnCount() {
-				continue
+		colOffset := 0
+		for _, cellElem := range cells {
+			if colOffset >= table.ColumnCount() {
+				break
 			}
 
-			cell, err := row.Cell(j)
+			cell, err := row.Cell(colOffset)
 			if err != nil {
 				return errors.Wrap(err, opHydrateTable)
 			}
@@ -1983,6 +1989,8 @@ func hydrateTable(doc domain.Document, elem *Element, ctx *reconstructContext) e
 			if err := hydrateTableCell(cell, cellElem, ctx); err != nil {
 				return err
 			}
+
+			colOffset += cellGridSpan(cellElem)
 		}
 	}
 
@@ -2000,10 +2008,12 @@ func hydrateTableCell(cell domain.TableCell, elem *Element, ctx *reconstructCont
 			if val, ok := getAttr(gs, "val"); ok && val != "" {
 				span, err := strconv.Atoi(val)
 				if err != nil {
-					return errors.Wrap(err, opHydrateTableCell)
+					return errors.WrapWithContext(err, opHydrateTableCell, map[string]interface{}{"attr": "gridSpan", "value": val})
 				}
-				if err := cell.SetGridSpan(span); err != nil {
-					return errors.Wrap(err, opHydrateTableCell)
+				if span > 1 {
+					if err := cell.Merge(span, 1); err != nil {
+						return errors.Wrap(err, opHydrateTableCell)
+					}
 				}
 			}
 		}
@@ -2039,6 +2049,20 @@ func hydrateTableCell(cell domain.TableCell, elem *Element, ctx *reconstructCont
 	}
 
 	return nil
+}
+
+// cellGridSpan returns the grid column span for a <w:tc> element (defaults to 1).
+func cellGridSpan(tcElem *Element) int {
+	if tcPr := findChild(tcElem, "tcPr"); tcPr != nil {
+		if gs := findChild(tcPr, "gridSpan"); gs != nil {
+			if val, ok := getAttr(gs, "val"); ok {
+				if n, err := strconv.Atoi(val); err == nil && n > 1 {
+					return n
+				}
+			}
+		}
+	}
+	return 1
 }
 
 // preserveOriginalParts stores all original document parts for round-trip operations.

--- a/internal/reader/reconstruct.go
+++ b/internal/reader/reconstruct.go
@@ -1994,6 +1994,35 @@ func hydrateTableCell(cell domain.TableCell, elem *Element, ctx *reconstructCont
 		return nil
 	}
 
+	// Parse cell properties (w:tcPr) for merge info.
+	if tcPr := findChild(elem, "tcPr"); tcPr != nil {
+		if gs := findChild(tcPr, "gridSpan"); gs != nil {
+			if val, ok := getAttr(gs, "val"); ok && val != "" {
+				span, err := strconv.Atoi(val)
+				if err != nil {
+					return errors.Wrap(err, opHydrateTableCell)
+				}
+				if err := cell.SetGridSpan(span); err != nil {
+					return errors.Wrap(err, opHydrateTableCell)
+				}
+			}
+		}
+		if vm := findChild(tcPr, "vMerge"); vm != nil {
+			val, _ := getAttr(vm, "val")
+			switch val {
+			case "restart":
+				if err := cell.SetVMerge(domain.VMergeRestart); err != nil {
+					return errors.Wrap(err, opHydrateTableCell)
+				}
+			default:
+				// Empty or absent val means "continue"
+				if err := cell.SetVMerge(domain.VMergeContinue); err != nil {
+					return errors.Wrap(err, opHydrateTableCell)
+				}
+			}
+		}
+	}
+
 	for _, child := range elem.Children {
 		if child == nil || child.Name.Local != "p" {
 			continue


### PR DESCRIPTION
## Summary

Release **v2.4.0** consolidating two merged feature/fix branches:

- **PR #30** — `feat: AddImageFromBytes API for in-memory image insertion` (closes #29)
- **PR #26** — `fix: preserve gridSpan and vMerge when reopening documents` (closes #25)

## What's included

### New Features
- In-memory image API on `ParagraphBuilder` and `domain.Paragraph`:
  - `AddImageFromBytes(data, format)`
  - `AddImageFromBytesWithSize(data, format, size)`
  - `AddImageFromBytesWithPosition(data, format, size, pos)`
- Format normalization (\`JPG\` → \`jpeg\`, leading \`.\` trimmed) + validation against supported set
- Defensive copy of input bytes for safe buffer reuse
- CLI handler now embeds base64 images without temp files

### Bug Fixes
- \`hydrateTableCell\` now parses \`<w:tcPr>\` and restores \`w:gridSpan\` (via \`cell.Merge(span, 1)\`) and \`w:vMerge\` on document reopen
- \`hydrateTable\` tracks \`colOffset\` and recomputes \`maxCols\` from gridSpan sums
- Numeric parse errors wrapped with \`errors.WrapWithContext\` for clearer diagnostics

### Tests
- \`TestGridSpanPreservedAfterRoundTrip\` (asserts \`IsHorizontallyMergedContinuation()\` on spanned cells)
- \`TestVMergePreservedAfterRoundTrip\` (asserts \`VMergeRestart\` / \`VMergeContinue\` round-trip)
- Unit + builder tests for all 3 \`AddImageFromBytes*\` paths

### Documentation
- \`CHANGELOG.md\` — new v2.4.0 section
- \`RELEASE_NOTES_v2.4.0.md\` — full release notes
- \`README.md\` — version, features list, refreshed Roadmap (release history + planned)
- \`doc.go\`, \`docs/V2_DESIGN.md\`, \`docs/V2_API_GUIDE.md\` — version bumped to 2.4.0

## Verification

- ✅ \`go build ./...\`
- ✅ \`go test ./...\` (all packages green)

## Post-merge

After merging, tag and create the GitHub Release:

\`\`\`bash
git checkout master && git pull
git tag -a v2.4.0 -m \"v2.4.0 — in-memory image API + merged-cell round-trip fix\"
git push origin v2.4.0
\`\`\`

Closes #25
Closes #29