### PR TITLE
 Adds Italic, Color, FontSize to CellBuilder, matching the behavior of ParagraphBuilder methods.

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -773,6 +773,27 @@ func (cb *CellBuilder) FontSize(points int) *CellBuilder {
 	return cb
 }
 
+// Underline sets the underline style of the last run of the last paragraph.
+func (cb *CellBuilder) Underline(style domain.UnderlineStyle) *CellBuilder {
+	if cb.err != nil {
+		return cb
+	}
+
+	lastRun, err := cb.lastRun()
+	if err != nil {
+		cb.err = errors.InvalidState("CellBuilder.Underline", err.Error())
+		cb.parent.parent.parent.errors = append(cb.parent.parent.parent.errors, cb.err)
+		return cb
+	}
+
+	if err := lastRun.SetUnderline(style); err != nil {
+		cb.err = err
+		cb.parent.parent.parent.errors = append(cb.parent.parent.parent.errors, cb.err)
+	}
+
+	return cb
+}
+
 func (cb *CellBuilder) lastRun() (domain.Run, error) {
 	paras := cb.cell.Paragraphs()
 	if len(paras) == 0 {

--- a/builder.go
+++ b/builder.go
@@ -693,26 +693,97 @@ func (cb *CellBuilder) Bold() *CellBuilder {
 		return cb
 	}
 
-	paragraphs := cb.cell.Paragraphs()
-	if len(paragraphs) == 0 {
-		cb.err = errors.InvalidState("CellBuilder.Bold", "no paragraphs in cell")
+	lastRun, err := cb.lastRun()
+	if err != nil {
+		cb.err = errors.InvalidState("CellBuilder.Bold", err.Error())
 		cb.parent.parent.parent.errors = append(cb.parent.parent.parent.errors, cb.err)
 		return cb
 	}
 
-	runs := paragraphs[len(paragraphs)-1].Runs()
-	if len(runs) == 0 {
-		cb.err = errors.InvalidState("CellBuilder.Bold", "no runs in paragraph")
-		cb.parent.parent.parent.errors = append(cb.parent.parent.parent.errors, cb.err)
-		return cb
-	}
-
-	if err := runs[len(runs)-1].SetBold(true); err != nil {
+	if err := lastRun.SetBold(true); err != nil {
 		cb.err = err
 		cb.parent.parent.parent.errors = append(cb.parent.parent.parent.errors, err)
 	}
 
 	return cb
+}
+
+// Italic makes the last run in the last paragraph italic.
+func (cb *CellBuilder) Italic() *CellBuilder {
+	if cb.err != nil {
+		return cb
+	}
+
+	lastRun, err := cb.lastRun()
+	if err != nil {
+		cb.err = errors.InvalidState("CellBuilder.Italic", err.Error())
+		cb.parent.parent.parent.errors = append(cb.parent.parent.parent.errors, cb.err)
+		return cb
+	}
+
+	if err := lastRun.SetItalic(true); err != nil {
+		cb.err = err
+		cb.parent.parent.parent.errors = append(cb.parent.parent.parent.errors, cb.err)
+	}
+
+	return cb
+}
+
+// Color sets the color of the last run of the last paragraph.
+func (cb *CellBuilder) Color(color domain.Color) *CellBuilder {
+	if cb.err != nil {
+		return cb
+	}
+
+	lastRun, err := cb.lastRun()
+	if err != nil {
+		cb.err = errors.InvalidState("CellBuilder.Color", err.Error())
+		cb.parent.parent.parent.errors = append(cb.parent.parent.parent.errors, cb.err)
+		return cb
+	}
+
+	if err := lastRun.SetColor(color); err != nil {
+		cb.err = err
+		cb.parent.parent.parent.errors = append(cb.parent.parent.parent.errors, cb.err)
+	}
+
+	return cb
+}
+
+// FontSize sets the font size of the last run of the last paragraph.
+func (cb *CellBuilder) FontSize(points int) *CellBuilder {
+	if cb.err != nil {
+		return cb
+	}
+
+	lastRun, err := cb.lastRun()
+	if err != nil {
+		cb.err = errors.InvalidState("CellBuilder.FontSize", err.Error())
+		cb.parent.parent.parent.errors = append(cb.parent.parent.parent.errors, cb.err)
+		return cb
+	}
+
+	// Convert points to half-points
+	halfPoints := points * 2
+	if err := lastRun.SetSize(halfPoints); err != nil {
+		cb.err = err
+		cb.parent.parent.parent.errors = append(cb.parent.parent.parent.errors, cb.err)
+	}
+
+	return cb
+}
+
+func (cb *CellBuilder) lastRun() (domain.Run, error) {
+	paras := cb.cell.Paragraphs()
+	if len(paras) == 0 {
+		return nil, fmt.Errorf("no paragraphs in cell")
+	}
+	runs := paras[len(paras)-1].Runs()
+	if len(runs) == 0 {
+		return nil, fmt.Errorf("no runs in paragraph")
+	}
+
+	return runs[len(runs)-1], nil
 }
 
 // Width sets the cell width.

--- a/builder_test.go
+++ b/builder_test.go
@@ -563,6 +563,154 @@ func TestCellBuilder_Formatting(t *testing.T) {
 	})
 }
 
+func TestCellBuilder_RunFormatting(t *testing.T) {
+	t.Run("applies formatting to last run", func(t *testing.T) {
+		textColor := domain.Color{R: 255, G: 0, B: 0}
+		builder := NewDocumentBuilder()
+		builder.AddTable(1, 1).
+			Row(0).
+			Cell(0).
+			Text("Formatted").
+			Italic().
+			Color(textColor).
+			FontSize(14).
+			End().
+			End().
+			End()
+
+		doc, err := builder.Build()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		paragraphs := firstTableCellParagraphs(t, doc)
+		if len(paragraphs) != 1 {
+			t.Fatalf("expected 1 paragraph, got %d", len(paragraphs))
+		}
+
+		runs := paragraphs[len(paragraphs)-1].Runs()
+		if len(runs) != 1 {
+			t.Fatalf("expected 1 run, got %d", len(runs))
+		}
+
+		run := runs[len(runs)-1]
+		if !run.Italic() {
+			t.Error("expected run to be italic")
+		}
+		if run.Color() != textColor {
+			t.Errorf("expected color %+v, got %+v", textColor, run.Color())
+		}
+		if run.Size() != 28 {
+			t.Errorf("expected font size 28 half-points, got %d", run.Size())
+		}
+	})
+
+	t.Run("formats only last paragraph run", func(t *testing.T) {
+		builder := NewDocumentBuilder()
+		builder.AddTable(1, 1).
+			Row(0).
+			Cell(0).
+			Text("Plain").
+			Text("Formatted").
+			Italic().
+			End().
+			End().
+			End()
+
+		doc, err := builder.Build()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		paragraphs := firstTableCellParagraphs(t, doc)
+		if len(paragraphs) != 2 {
+			t.Fatalf("expected 2 paragraphs, got %d", len(paragraphs))
+		}
+
+		firstRuns := paragraphs[0].Runs()
+		if len(firstRuns) != 1 {
+			t.Fatalf("expected first paragraph to have 1 run, got %d", len(firstRuns))
+		}
+		if firstRuns[0].Italic() {
+			t.Error("expected first paragraph run to stay non-italic")
+		}
+
+		lastRuns := paragraphs[len(paragraphs)-1].Runs()
+		if len(lastRuns) != 1 {
+			t.Fatalf("expected last paragraph to have 1 run, got %d", len(lastRuns))
+		}
+		if !lastRuns[len(lastRuns)-1].Italic() {
+			t.Error("expected last paragraph run to be italic")
+		}
+	})
+}
+
+func TestCellBuilder_RunFormattingErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		apply func(*CellBuilder) *CellBuilder
+	}{
+		{"italic before text", func(cb *CellBuilder) *CellBuilder { return cb.Italic() }},
+		{"color before text", func(cb *CellBuilder) *CellBuilder { return cb.Color(domain.Color{R: 255, G: 0, B: 0}) }},
+		{"font size before text", func(cb *CellBuilder) *CellBuilder { return cb.FontSize(14) }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewDocumentBuilder()
+			tt.apply(builder.AddTable(1, 1).
+				Row(0).
+				Cell(0)).
+				End().
+				End().
+				End()
+
+			_, err := builder.Build()
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+
+	t.Run("returns error for invalid font size", func(t *testing.T) {
+		builder := NewDocumentBuilder()
+		builder.AddTable(1, 1).
+			Row(0).
+			Cell(0).
+			Text("Text").
+			FontSize(0).
+			End().
+			End().
+			End()
+
+		_, err := builder.Build()
+		if err == nil {
+			t.Fatal("expected error for invalid font size, got nil")
+		}
+	})
+}
+
+func firstTableCellParagraphs(t *testing.T, doc domain.Document) []domain.Paragraph {
+	t.Helper()
+
+	tables := doc.Tables()
+	if len(tables) != 1 {
+		t.Fatalf("expected 1 table, got %d", len(tables))
+	}
+
+	row, err := tables[0].Row(0)
+	if err != nil {
+		t.Fatalf("expected row 0, got %v", err)
+	}
+
+	cell, err := row.Cell(0)
+	if err != nil {
+		t.Fatalf("expected cell 0, got %v", err)
+	}
+
+	return cell.Paragraphs()
+}
+
 func TestTableBuilder_ComplexTable(t *testing.T) {
 	t.Run("creates table with mixed formatting", func(t *testing.T) {
 		builder := NewDocumentBuilder()

--- a/builder_test.go
+++ b/builder_test.go
@@ -574,6 +574,7 @@ func TestCellBuilder_RunFormatting(t *testing.T) {
 			Italic().
 			Color(textColor).
 			FontSize(14).
+			Underline(domain.UnderlineSingle).
 			End().
 			End().
 			End()
@@ -602,6 +603,9 @@ func TestCellBuilder_RunFormatting(t *testing.T) {
 		}
 		if run.Size() != 28 {
 			t.Errorf("expected font size 28 half-points, got %d", run.Size())
+		}
+		if run.Underline() != domain.UnderlineSingle {
+			t.Errorf("expected underline %v, got %v", domain.UnderlineSingle, run.Underline())
 		}
 	})
 
@@ -653,6 +657,7 @@ func TestCellBuilder_RunFormattingErrors(t *testing.T) {
 		{"italic before text", func(cb *CellBuilder) *CellBuilder { return cb.Italic() }},
 		{"color before text", func(cb *CellBuilder) *CellBuilder { return cb.Color(domain.Color{R: 255, G: 0, B: 0}) }},
 		{"font size before text", func(cb *CellBuilder) *CellBuilder { return cb.FontSize(14) }},
+		{"underline before text", func(cb *CellBuilder) *CellBuilder { return cb.Underline(domain.UnderlineSingle) }},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
CellBuilder already supports `Text()` and `Bold()`, but users cannot set the font size, color or italic through the fluent table API. The underlying run model already supports `SetSize`, `Italic` and `Color`, so this adds a small ergonomic helper.