### PR TITLE
fix: resolve header/footer relationship IDs per-part (#37)

### DIFF
--- a/docx_read_test.go
+++ b/docx_read_test.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"image/color"
 	"image/png"
+	"io"
 	"path/filepath"
 	"testing"
 
@@ -438,6 +439,87 @@ func buildCollidingRelationshipDocx(t *testing.T, pngBytes []byte) []byte {
 		}
 	}
 
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip.Close: %v", err)
+	}
+
+	return buf.Bytes()
+}
+
+// TestOpenDocument_MalformedHeaderRelsIsTolerated guards against a regression:
+// a header/footer part's own .rels was previously never parsed, so a document
+// with an unparseable "word/_rels/header1.xml.rels" still opened. Parsing those
+// .rels for per-part relationship scoping (issue #37) must not make an
+// otherwise-valid document unreadable just because one part's .rels is corrupt;
+// the corrupt part's rels is skipped and parsing proceeds.
+//
+// The header is rewritten to text-only so the test isolates parse-time
+// tolerance: a header that references media through its own (now unreadable)
+// .rels is a separate, harder concern than "don't abort the whole open".
+func TestOpenDocument_MalformedHeaderRelsIsTolerated(t *testing.T) {
+	const textOnlyHeaderXML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<w:p><w:r><w:t>Header text</w:t></w:r></w:p>
+</w:hdr>`
+
+	docxBytes := buildCollidingRelationshipDocx(t, encodeTestPNG(t))
+	docxBytes = rewriteZipEntry(t, docxBytes, "word/header1.xml", []byte(textOnlyHeaderXML))
+	docxBytes = rewriteZipEntry(t, docxBytes, "word/_rels/header1.xml.rels",
+		[]byte(`<?xml version="1.0"?><Relationships><unclosed`))
+
+	doc, err := OpenDocumentFromBytes(docxBytes)
+	if err != nil {
+		t.Fatalf("OpenDocumentFromBytes with malformed header .rels: %v", err)
+	}
+	if err := doc.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+}
+
+// rewriteZipEntry returns a copy of the zip archive in docxBytes with the entry
+// named target replaced by newData, leaving every other entry byte-for-byte.
+func rewriteZipEntry(t *testing.T, docxBytes []byte, target string, newData []byte) []byte {
+	t.Helper()
+
+	zr, err := zip.NewReader(bytes.NewReader(docxBytes), int64(len(docxBytes)))
+	if err != nil {
+		t.Fatalf("zip.NewReader: %v", err)
+	}
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	var replaced bool
+	for _, f := range zr.File {
+		w, err := zw.Create(f.Name)
+		if err != nil {
+			t.Fatalf("zip.Create(%s): %v", f.Name, err)
+		}
+
+		data := newData
+		if f.Name != target {
+			rc, err := f.Open()
+			if err != nil {
+				t.Fatalf("open %s: %v", f.Name, err)
+			}
+			original, err := io.ReadAll(rc)
+			rc.Close()
+			if err != nil {
+				t.Fatalf("read %s: %v", f.Name, err)
+			}
+			data = original
+		} else {
+			replaced = true
+		}
+
+		if _, err := w.Write(data); err != nil {
+			t.Fatalf("write %s: %v", f.Name, err)
+		}
+	}
+
+	if !replaced {
+		t.Fatalf("rewriteZipEntry: entry %q not found in archive", target)
+	}
 	if err := zw.Close(); err != nil {
 		t.Fatalf("zip.Close: %v", err)
 	}

--- a/docx_read_test.go
+++ b/docx_read_test.go
@@ -1,7 +1,11 @@
 package docx
 
 import (
+	"archive/zip"
 	"bytes"
+	"image"
+	"image/color"
+	"image/png"
 	"path/filepath"
 	"testing"
 
@@ -222,4 +226,221 @@ func TestVMergePreservedAfterRoundTrip(t *testing.T) {
 	if got := c1.VMerge(); got != domain.VMergeContinue {
 		t.Errorf("Row(1).Cell(0) VMerge = %v, want VMergeContinue", got)
 	}
+}
+
+// TestOpenDocument_CollidingRelationshipIDsAcrossParts reproduces issue #37:
+// relationship IDs are scoped per-part in OOXML, so a header's own
+// "word/_rels/header1.xml.rels" may reuse an ID (e.g. rId1) that also exists
+// in "word/_rels/document.xml.rels" for something unrelated (e.g. a customXml
+// part). Opening such a document must resolve each drawing's r:embed against
+// its own part's relationships, not the document's.
+//
+// No fixture .docx exists in this repo, and the library's own writer cannot
+// produce a cross-part ID collision (relationship IDs are allocated from one
+// shared counter, and header/footer .rels are not even emitted on write), so
+// the minimal colliding package is hand-built here with archive/zip.
+func TestOpenDocument_CollidingRelationshipIDsAcrossParts(t *testing.T) {
+	pngBytes := encodeTestPNG(t)
+	docxBytes := buildCollidingRelationshipDocx(t, pngBytes)
+
+	doc, err := OpenDocumentFromBytes(docxBytes)
+	if err != nil {
+		t.Fatalf("OpenDocumentFromBytes: %v", err)
+	}
+
+	if err := doc.Validate(); err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	sections := doc.Sections()
+	if len(sections) == 0 {
+		t.Fatal("expected at least one section")
+	}
+
+	header, err := sections[0].Header(domain.HeaderDefault)
+	if err != nil {
+		t.Fatalf("Header: %v", err)
+	}
+
+	var headerImage domain.Image
+	for _, p := range header.Paragraphs() {
+		if images := p.Images(); len(images) > 0 {
+			headerImage = images[0]
+			break
+		}
+	}
+
+	if headerImage == nil {
+		t.Fatal("expected header to contain a hydrated image")
+	}
+
+	if !bytes.Equal(headerImage.Data(), pngBytes) {
+		t.Fatal("header image data does not match the header's own media part; " +
+			"rId1 likely resolved against document.xml.rels instead of header1.xml.rels")
+	}
+
+	// Round-trip guard: the header's own .rels is preserved verbatim as an
+	// opaque part, so saving and reopening must keep working too.
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "colliding-rel-ids.docx")
+	if err := doc.SaveAs(path); err != nil {
+		t.Fatalf("SaveAs: %v", err)
+	}
+
+	reopened, err := OpenDocument(path)
+	if err != nil {
+		t.Fatalf("OpenDocument after round-trip: %v", err)
+	}
+	if err := reopened.Validate(); err != nil {
+		t.Fatalf("Validate after round-trip: %v", err)
+	}
+}
+
+// encodeTestPNG returns the bytes of a tiny valid PNG, used as the header's
+// media part in TestOpenDocument_CollidingRelationshipIDsAcrossParts.
+func encodeTestPNG(t *testing.T) []byte {
+	t.Helper()
+
+	img := image.NewRGBA(image.Rect(0, 0, 2, 2))
+	for y := 0; y < 2; y++ {
+		for x := 0; x < 2; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(100 * x), G: uint8(100 * y), B: 50, A: 255})
+		}
+	}
+
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("png.Encode: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// buildCollidingRelationshipDocx hand-assembles a minimal but valid .docx
+// package where "rId1" is defined independently in both
+// word/_rels/document.xml.rels (pointing at a customXml part) and
+// word/_rels/header1.xml.rels (pointing at the header's image), mirroring
+// the file attached to GitHub issue #37.
+func buildCollidingRelationshipDocx(t *testing.T, pngBytes []byte) []byte {
+	t.Helper()
+
+	const contentTypesXML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+<Default Extension="xml" ContentType="application/xml"/>
+<Default Extension="png" ContentType="image/png"/>
+<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+<Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+</Types>`
+
+	const rootRelsXML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`
+
+	const documentXML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+<w:body>
+<w:p><w:r><w:t>Body paragraph</w:t></w:r></w:p>
+<w:sectPr>
+<w:headerReference w:type="default" r:id="rId7"/>
+<w:pgSz w:w="11906" w:h="16838"/>
+</w:sectPr>
+</w:body>
+</w:document>`
+
+	// The collision: rId1 here targets a customXml part, while rId1 in
+	// header1.xml.rels (below) targets the header's image. Per OOXML both
+	// are valid since relationship IDs are scoped to their owning part.
+	const documentRelsXML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/customXml" Target="../customXml/item1.xml"/>
+<Relationship Id="rId7" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>
+</Relationships>`
+
+	const headerXML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+       xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+       xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+       xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">
+<w:p>
+<w:r>
+<w:drawing>
+<wp:inline distT="0" distB="0" distL="0" distR="0">
+<wp:extent cx="655320" cy="655320"/>
+<wp:docPr id="1" name="Picture 1"/>
+<a:graphic>
+<a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">
+<pic:pic>
+<pic:nvPicPr>
+<pic:cNvPr id="1" name="Picture 1"/>
+<pic:cNvPicPr>
+<a:picLocks noChangeAspect="1" noChangeArrowheads="1"/>
+</pic:cNvPicPr>
+</pic:nvPicPr>
+<pic:blipFill>
+<a:blip r:embed="rId1"/>
+<a:stretch>
+<a:fillRect/>
+</a:stretch>
+</pic:blipFill>
+<pic:spPr bwMode="auto">
+<a:xfrm>
+<a:off x="0" y="0"/>
+<a:ext cx="655320" cy="655320"/>
+</a:xfrm>
+<a:prstGeom prst="rect">
+<a:avLst/>
+</a:prstGeom>
+</pic:spPr>
+</pic:pic>
+</a:graphicData>
+</a:graphic>
+</wp:inline>
+</w:drawing>
+</w:r>
+</w:p>
+</w:hdr>`
+
+	// header1.xml.rels has its OWN rId1, distinct from document.xml.rels's rId1.
+	const headerRelsXML = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+</Relationships>`
+
+	const customXMLItem = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?><root/>`
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	files := []struct {
+		name string
+		data []byte
+	}{
+		{"[Content_Types].xml", []byte(contentTypesXML)},
+		{"_rels/.rels", []byte(rootRelsXML)},
+		{"word/document.xml", []byte(documentXML)},
+		{"word/_rels/document.xml.rels", []byte(documentRelsXML)},
+		{"word/header1.xml", []byte(headerXML)},
+		{"word/_rels/header1.xml.rels", []byte(headerRelsXML)},
+		{"word/media/image1.png", pngBytes},
+		{"customXml/item1.xml", []byte(customXMLItem)},
+	}
+
+	for _, f := range files {
+		w, err := zw.Create(f.name)
+		if err != nil {
+			t.Fatalf("zip.Create(%s): %v", f.name, err)
+		}
+		if _, err := w.Write(f.data); err != nil {
+			t.Fatalf("write %s: %v", f.name, err)
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip.Close: %v", err)
+	}
+
+	return buf.Bytes()
 }

--- a/internal/reader/parser.go
+++ b/internal/reader/parser.go
@@ -26,6 +26,7 @@ package reader
 
 import (
 	"encoding/xml"
+	stdpath "path"
 
 	xmlstructs "github.com/mmonterroca/docxgo/v2/internal/xml"
 	"github.com/mmonterroca/docxgo/v2/pkg/constants"
@@ -47,6 +48,13 @@ type ParsedPackage struct {
 
 	RootRelationships     *xmlstructs.Relationships
 	DocumentRelationships *xmlstructs.Relationships
+
+	// HeaderRelationships and FooterRelationships hold each header/footer
+	// part's own relationships, keyed the same way as HeaderTrees/FooterTrees
+	// (e.g. "word/header1.xml"). Relationship IDs are scoped per-part in
+	// OOXML, so these must not be merged into DocumentRelationships.
+	HeaderRelationships map[string]*xmlstructs.Relationships
+	FooterRelationships map[string]*xmlstructs.Relationships
 
 	CorePropertiesTree *Element
 	AppPropertiesTree  *Element
@@ -149,6 +157,15 @@ func ParsePackage(pkg *Package) (*ParsedPackage, error) {
 		parsed.FooterTrees[name] = tree
 	}
 
+	parsed.HeaderRelationships, err = partRelationships(pkg, pkg.Headers)
+	if err != nil {
+		return nil, err
+	}
+	parsed.FooterRelationships, err = partRelationships(pkg, pkg.Footers)
+	if err != nil {
+		return nil, err
+	}
+
 	for name, data := range pkg.ThemeParts {
 		if len(data) == 0 {
 			continue
@@ -169,6 +186,35 @@ func decodeXML(data []byte, dest interface{}, part string) error {
 	}
 
 	return nil
+}
+
+// relsPathFor returns the archive path of a part's relationships file,
+// e.g. "word/header1.xml" -> "word/_rels/header1.xml.rels".
+func relsPathFor(partPath string) string {
+	return stdpath.Join(stdpath.Dir(partPath), "_rels", stdpath.Base(partPath)+".rels")
+}
+
+// partRelationships parses the per-part .rels file for each entry in parts
+// (header or footer bodies keyed by archive path) and returns them keyed the
+// same way. Parts without a .rels file are simply omitted.
+func partRelationships(pkg *Package, parts map[string][]byte) (map[string]*xmlstructs.Relationships, error) {
+	out := make(map[string]*xmlstructs.Relationships, len(parts))
+	for name := range parts {
+		relsName, ok := pkg.lookupPart(relsPathFor(name))
+		if !ok {
+			continue
+		}
+		data := pkg.RawParts[relsName]
+		if len(data) == 0 {
+			continue
+		}
+		var rels xmlstructs.Relationships
+		if err := decodeXML(data, &rels, relsName); err != nil {
+			return nil, err
+		}
+		out[name] = &rels
+	}
+	return out, nil
 }
 
 func xmlPartError(part string, err error) error {

--- a/internal/reader/parser.go
+++ b/internal/reader/parser.go
@@ -49,12 +49,11 @@ type ParsedPackage struct {
 	RootRelationships     *xmlstructs.Relationships
 	DocumentRelationships *xmlstructs.Relationships
 
-	// HeaderRelationships and FooterRelationships hold each header/footer
-	// part's own relationships, keyed the same way as HeaderTrees/FooterTrees
-	// (e.g. "word/header1.xml"). Relationship IDs are scoped per-part in
-	// OOXML, so these must not be merged into DocumentRelationships.
-	HeaderRelationships map[string]*xmlstructs.Relationships
-	FooterRelationships map[string]*xmlstructs.Relationships
+	// PartRelationships holds each header/footer part's own relationships,
+	// keyed the same way as HeaderTrees/FooterTrees (e.g. "word/header1.xml").
+	// Relationship IDs are scoped per-part in OOXML, so these must not be
+	// merged into DocumentRelationships.
+	PartRelationships map[string]*xmlstructs.Relationships
 
 	CorePropertiesTree *Element
 	AppPropertiesTree  *Element
@@ -157,14 +156,7 @@ func ParsePackage(pkg *Package) (*ParsedPackage, error) {
 		parsed.FooterTrees[name] = tree
 	}
 
-	parsed.HeaderRelationships, err = partRelationships(pkg, pkg.Headers)
-	if err != nil {
-		return nil, err
-	}
-	parsed.FooterRelationships, err = partRelationships(pkg, pkg.Footers)
-	if err != nil {
-		return nil, err
-	}
+	parsed.PartRelationships = partRelationships(pkg, pkg.Headers, pkg.Footers)
 
 	for name, data := range pkg.ThemeParts {
 		if len(data) == 0 {
@@ -194,27 +186,32 @@ func relsPathFor(partPath string) string {
 	return stdpath.Join(stdpath.Dir(partPath), "_rels", stdpath.Base(partPath)+".rels")
 }
 
-// partRelationships parses the per-part .rels file for each entry in parts
-// (header or footer bodies keyed by archive path) and returns them keyed the
-// same way. Parts without a .rels file are simply omitted.
-func partRelationships(pkg *Package, parts map[string][]byte) (map[string]*xmlstructs.Relationships, error) {
-	out := make(map[string]*xmlstructs.Relationships, len(parts))
-	for name := range parts {
-		relsName, ok := pkg.lookupPart(relsPathFor(name))
-		if !ok {
-			continue
+// partRelationships parses the per-part .rels file for each entry in the given
+// part sets (header and/or footer bodies keyed by archive path) and returns
+// them keyed the same way. Parts without a .rels file — or with one that fails
+// to parse — are simply omitted, so hydration falls back to document-wide
+// resolution rather than failing the whole document open over a part that was
+// previously ignored entirely.
+func partRelationships(pkg *Package, partSets ...map[string][]byte) map[string]*xmlstructs.Relationships {
+	out := make(map[string]*xmlstructs.Relationships)
+	for _, parts := range partSets {
+		for name := range parts {
+			relsName, ok := pkg.lookupPart(relsPathFor(name))
+			if !ok {
+				continue
+			}
+			data := pkg.RawParts[relsName]
+			if len(data) == 0 {
+				continue
+			}
+			var rels xmlstructs.Relationships
+			if err := decodeXML(data, &rels, relsName); err != nil {
+				continue
+			}
+			out[name] = &rels
 		}
-		data := pkg.RawParts[relsName]
-		if len(data) == 0 {
-			continue
-		}
-		var rels xmlstructs.Relationships
-		if err := decodeXML(data, &rels, relsName); err != nil {
-			return nil, err
-		}
-		out[name] = &rels
 	}
-	return out, nil
+	return out
 }
 
 func xmlPartError(part string, err error) error {

--- a/internal/reader/reconstruct.go
+++ b/internal/reader/reconstruct.go
@@ -58,6 +58,7 @@ const (
 
 type reconstructContext struct {
 	relationships            map[string]*xmlstructs.Relationship
+	activeRelationships      map[string]*xmlstructs.Relationship
 	media                    map[string]*MediaPart
 	doc                      domain.Document
 	parsed                   *ParsedPackage
@@ -1173,12 +1174,62 @@ func (ctx *reconstructContext) resolveRelationshipTarget(id string) (string, boo
 		return "", false
 	}
 
+	if ctx.activeRelationships != nil {
+		if rel, ok := ctx.activeRelationships[id]; ok && rel != nil {
+			return rel.Target, true
+		}
+	}
+
 	rel, ok := ctx.relationships[id]
 	if !ok || rel == nil {
 		return "", false
 	}
 
 	return rel.Target, true
+}
+
+// partRelationshipMap builds an ID-keyed relationship map for the part whose
+// archive path matches target, looked up in sets (HeaderRelationships or
+// FooterRelationships). Relationship IDs are scoped per-part in OOXML, so
+// this must be used instead of the document-wide ctx.relationships when
+// hydrating header/footer content.
+func (ctx *reconstructContext) partRelationshipMap(target string, sets map[string]*xmlstructs.Relationships) map[string]*xmlstructs.Relationship {
+	if sets == nil {
+		return nil
+	}
+
+	want := normalizePartName(normalizeMediaPath(target))
+	for name, set := range sets {
+		if set == nil || normalizePartName(name) != want {
+			continue
+		}
+		out := make(map[string]*xmlstructs.Relationship, len(set.Relationships))
+		for _, rel := range set.Relationships {
+			if rel == nil || rel.ID == "" {
+				continue
+			}
+			out[rel.ID] = rel
+		}
+		return out
+	}
+
+	return nil
+}
+
+// withPartRelationships temporarily scopes relationship-ID resolution to
+// rels while fn runs, restoring the previous scope afterward.
+func (ctx *reconstructContext) withPartRelationships(rels map[string]*xmlstructs.Relationship, fn func() error) error {
+	if fn == nil {
+		return nil
+	}
+	if ctx == nil {
+		return fn()
+	}
+
+	prev := ctx.activeRelationships
+	ctx.activeRelationships = rels
+	defer func() { ctx.activeRelationships = prev }()
+	return fn()
 }
 
 func (ctx *reconstructContext) mediaPartFor(target string) (*MediaPart, string, bool) {
@@ -1574,20 +1625,23 @@ func (ctx *reconstructContext) hydrateHeader(section domain.Section, headerType 
 		return nil
 	}
 
+	partRels := ctx.partRelationshipMap(target, ctx.parsed.HeaderRelationships)
 	return ctx.withSectionHydrationDisabled(func() error {
-		for _, child := range tree.Children {
-			if child == nil || child.Name.Local != "p" {
-				continue
+		return ctx.withPartRelationships(partRels, func() error {
+			for _, child := range tree.Children {
+				if child == nil || child.Name.Local != "p" {
+					continue
+				}
+				para, err := header.AddParagraph()
+				if err != nil {
+					return errors.Wrap(err, opHydrateSectionHeader)
+				}
+				if err := populateParagraph(para, child, ctx); err != nil {
+					return err
+				}
 			}
-			para, err := header.AddParagraph()
-			if err != nil {
-				return errors.Wrap(err, opHydrateSectionHeader)
-			}
-			if err := populateParagraph(para, child, ctx); err != nil {
-				return err
-			}
-		}
-		return nil
+			return nil
+		})
 	})
 }
 
@@ -1614,20 +1668,23 @@ func (ctx *reconstructContext) hydrateFooter(section domain.Section, footerType 
 		return nil
 	}
 
+	partRels := ctx.partRelationshipMap(target, ctx.parsed.FooterRelationships)
 	return ctx.withSectionHydrationDisabled(func() error {
-		for _, child := range tree.Children {
-			if child == nil || child.Name.Local != "p" {
-				continue
+		return ctx.withPartRelationships(partRels, func() error {
+			for _, child := range tree.Children {
+				if child == nil || child.Name.Local != "p" {
+					continue
+				}
+				para, err := footer.AddParagraph()
+				if err != nil {
+					return errors.Wrap(err, opHydrateSectionFooter)
+				}
+				if err := populateParagraph(para, child, ctx); err != nil {
+					return err
+				}
 			}
-			para, err := footer.AddParagraph()
-			if err != nil {
-				return errors.Wrap(err, opHydrateSectionFooter)
-			}
-			if err := populateParagraph(para, child, ctx); err != nil {
-				return err
-			}
-		}
-		return nil
+			return nil
+		})
 	})
 }
 

--- a/internal/reader/reconstruct.go
+++ b/internal/reader/reconstruct.go
@@ -1188,18 +1188,17 @@ func (ctx *reconstructContext) resolveRelationshipTarget(id string) (string, boo
 	return rel.Target, true
 }
 
-// partRelationshipMap builds an ID-keyed relationship map for the part whose
-// archive path matches target, looked up in sets (HeaderRelationships or
-// FooterRelationships). Relationship IDs are scoped per-part in OOXML, so
-// this must be used instead of the document-wide ctx.relationships when
-// hydrating header/footer content.
-func (ctx *reconstructContext) partRelationshipMap(target string, sets map[string]*xmlstructs.Relationships) map[string]*xmlstructs.Relationship {
-	if sets == nil {
+// partRelationshipMap builds an ID-keyed relationship map for the header/footer
+// part whose archive path matches target, looked up in ctx.parsed.PartRelationships.
+// Relationship IDs are scoped per-part in OOXML, so this must be used instead of
+// the document-wide ctx.relationships when hydrating header/footer content.
+func (ctx *reconstructContext) partRelationshipMap(target string) map[string]*xmlstructs.Relationship {
+	if ctx == nil || ctx.parsed == nil || ctx.parsed.PartRelationships == nil {
 		return nil
 	}
 
 	want := normalizePartName(normalizeMediaPath(target))
-	for name, set := range sets {
+	for name, set := range ctx.parsed.PartRelationships {
 		if set == nil || normalizePartName(name) != want {
 			continue
 		}
@@ -1625,16 +1624,29 @@ func (ctx *reconstructContext) hydrateHeader(section domain.Section, headerType 
 		return nil
 	}
 
-	partRels := ctx.partRelationshipMap(target, ctx.parsed.HeaderRelationships)
+	return ctx.hydratePartParagraphs(header, tree, target, opHydrateSectionHeader)
+}
+
+// partParagraphContainer is satisfied by both domain.Header and domain.Footer,
+// letting hydratePartParagraphs drive either from the same code path.
+type partParagraphContainer interface {
+	AddParagraph() (domain.Paragraph, error)
+}
+
+// hydratePartParagraphs copies the paragraph children of a header/footer part
+// tree into container, resolving relationship IDs against that part's own
+// relationships (per-part scoping) with section hydration suppressed.
+func (ctx *reconstructContext) hydratePartParagraphs(container partParagraphContainer, tree *Element, target, op string) error {
+	partRels := ctx.partRelationshipMap(target)
 	return ctx.withSectionHydrationDisabled(func() error {
 		return ctx.withPartRelationships(partRels, func() error {
 			for _, child := range tree.Children {
 				if child == nil || child.Name.Local != "p" {
 					continue
 				}
-				para, err := header.AddParagraph()
+				para, err := container.AddParagraph()
 				if err != nil {
-					return errors.Wrap(err, opHydrateSectionHeader)
+					return errors.Wrap(err, op)
 				}
 				if err := populateParagraph(para, child, ctx); err != nil {
 					return err
@@ -1668,24 +1680,7 @@ func (ctx *reconstructContext) hydrateFooter(section domain.Section, footerType 
 		return nil
 	}
 
-	partRels := ctx.partRelationshipMap(target, ctx.parsed.FooterRelationships)
-	return ctx.withSectionHydrationDisabled(func() error {
-		return ctx.withPartRelationships(partRels, func() error {
-			for _, child := range tree.Children {
-				if child == nil || child.Name.Local != "p" {
-					continue
-				}
-				para, err := footer.AddParagraph()
-				if err != nil {
-					return errors.Wrap(err, opHydrateSectionFooter)
-				}
-				if err := populateParagraph(para, child, ctx); err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-	})
+	return ctx.hydratePartParagraphs(footer, tree, target, opHydrateSectionFooter)
 }
 
 func (ctx *reconstructContext) withSectionHydrationDisabled(fn func() error) error {


### PR DESCRIPTION
## Summary

Fixes #37. Relationship IDs in OOXML are scoped per-part, so a header's own `word/_rels/header1.xml.rels` may reuse an ID (e.g. `rId1`) that also exists in `word/_rels/document.xml.rels` for something unrelated (e.g. a customXml part). Previously, drawings inside headers/footers resolved their `r:embed` against the document-wide relationships, hydrating the wrong media — or none at all.

## Changes

- **`internal/reader/parser.go`**: parse each header/footer part's own `.rels` file into a `PartRelationships` map on `ParsedPackage`, keyed by part path. An unparseable per-part `.rels` is skipped rather than aborting the whole document open.
- **`internal/reader/reconstruct.go`**: add an `activeRelationships` scope to `reconstructContext`. While hydrating a header/footer, resolve relationship IDs against that part's own `.rels`, falling back to the document-wide map. Header/footer hydration shares a single `hydratePartParagraphs` helper.
- **`docx_read_test.go`**: `TestOpenDocument_CollidingRelationshipIDsAcrossParts` hand-builds a minimal `.docx` where `rId1` is defined independently in both `document.xml.rels` and `header1.xml.rels`, and asserts the header image resolves to the header's own media part (plus a save/reopen round-trip guard). `TestOpenDocument_MalformedHeaderRelsIsTolerated` guards that a corrupt per-part `.rels` no longer fails the open.

## Testing

- `go test ./...` — all passing.