### PR TITLE
feat: add WithLanguage/WithLanguageEx to set the document's proofing language

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ permissions:
 
 on:
   push:
-    branches: [ main, dev ]
+    branches: [ master, dev ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [ master, dev ]
 
 jobs:
   lint-and-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,16 @@
 
 - **`WithLanguage` / `WithLanguageEx`** — set the document's default proofing language, used by Word for spell-checking, grammar-checking, and hyphenation (closes #44)
   - `WithLanguage(lang string)` sets the primary language (BCP 47 tag, e.g. `"es-MX"`)
-  - `WithLanguageEx(docx.Language{Val, EastAsia, Bidi})` additionally sets East Asian (CJK) and right-to-left (bidi) script languages
+  - `WithLanguageEx(docx.Language{Val, EastAsia, Bidi})` additionally sets East Asian (CJK) and right-to-left (bidi) script languages; at least one of the three must be non-empty
   - Written as `w:lang` in `word/styles.xml`'s `docDefaults/rPrDefault/rPr` and as `w:themeFontLang` in `word/settings.xml`
-  - Only applies when building a new document; reading and re-saving an existing `.docx` preserves its original `styles.xml`/`settings.xml` verbatim
-  - `domain.Document` gained `SetLanguage`/`Language()`; `domain.Language` is the new public type (aliased as `docx.Language`)
+  - `NewDocumentBuilder` always starts from a new document, so `WithLanguage`/`WithLanguageEx` always take effect
+  - Opening an existing `.docx` via `OpenDocument`/`OpenDocumentFromBytes`/`OpenDocumentFromReader` now hydrates `Language()` from its `styles.xml`, if it declares one
+  - `domain.Document` gained `SetLanguage(*Language) error` and `Language() *Language`; `domain.Language` is the new public type (aliased as `docx.Language`). `Language()` returns a defensive copy — mutating it has no effect on the document
+  - `SetLanguage` returns an error (rather than silently no-op) on a document opened via `OpenDocument` whose `styles.xml`/`settings.xml` were preserved verbatim for round-trip fidelity, since a language set there could never actually reach the saved file. Use `WithLanguage`/`WithLanguageEx` when building a new document instead
+
+### Changed
+
+- **`domain.Document` interface gained two methods** (`SetLanguage`, `Language`, above). If you implement `domain.Document` directly with your own type — most commonly a hand-written test double — you'll need to add both methods; embedding `domain.Document` in your type is unaffected, since the new methods are promoted automatically. No exported docxgo API accepts a `domain.Document` from a caller (only returns one), so this is consistent with `SetBackgroundColor`/`BackgroundColor`, which were added to this same interface in the `v2.0.1` patch release.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## v2.6.0 — 2026-07-17
 
 ### Added
 
@@ -18,6 +18,7 @@
 ### Fixed
 
 - **`word/styles.xml` element order** — `internal/xml.Styles` now marshals `w:docDefaults` before `w:latentStyles`, matching the `CT_Styles` schema. This was previously backwards but unobservable, since `DocDefaults` was never populated before this change.
+- **CI never ran against `master`** — `.github/workflows/ci.yml` triggered on `branches: [ main, dev ]`, but this repo's default/release branch is `master`, not `main`. The Lint/Build/Test job had silently never fired for any push or PR targeting `master` since the workflow was added. Fixed to trigger on `master` and `dev`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [Unreleased]
+
+### Added
+
+- **`WithLanguage` / `WithLanguageEx`** — set the document's default proofing language, used by Word for spell-checking, grammar-checking, and hyphenation (closes #44)
+  - `WithLanguage(lang string)` sets the primary language (BCP 47 tag, e.g. `"es-MX"`)
+  - `WithLanguageEx(docx.Language{Val, EastAsia, Bidi})` additionally sets East Asian (CJK) and right-to-left (bidi) script languages
+  - Written as `w:lang` in `word/styles.xml`'s `docDefaults/rPrDefault/rPr` and as `w:themeFontLang` in `word/settings.xml`
+  - Only applies when building a new document; reading and re-saving an existing `.docx` preserves its original `styles.xml`/`settings.xml` verbatim
+  - `domain.Document` gained `SetLanguage`/`Language()`; `domain.Language` is the new public type (aliased as `docx.Language`)
+
+### Fixed
+
+- **`word/styles.xml` element order** — `internal/xml.Styles` now marshals `w:docDefaults` before `w:latentStyles`, matching the `CT_Styles` schema. This was previously backwards but unobservable, since `DocDefaults` was never populated before this change.
+
+---
+
 ## v2.5.0 — 2026-07-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ func main() {
         docx.WithDefaultFontSize(22), // 11pt in half-points
         docx.WithPageSize(docx.A4),
         docx.WithMargins(docx.NormalMargins),
+        docx.WithLanguage("en-US"), // spell-check, grammar, hyphenation
     )
 
     // Add content using fluent API
@@ -247,6 +248,7 @@ github.com/mmonterroca/docxgo/v2/
 **Core Document Structure**
 
 - Document creation with metadata (title, author, subject, keywords)
+- Default proofing language (spell-check, grammar, hyphenation) via `WithLanguage` / `WithLanguageEx`
 - Paragraphs with comprehensive formatting
 - Text runs with character-level styling
 - Tables with rows, cells, and styling

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ Production-grade Microsoft Word .docx (OOXML) file manipulation in Go.
 
 ## Status
 
-**Current Version**: v2.5.0 (Stable)
+**Current Version**: v2.6.0 (Stable)
 **Stability**: Production Ready
 **Released**: July 2026
 **Test Coverage**: ~51% overall (`domain` & `pkg/errors` at 100%)
 
-**Latest Features**: Full run-level formatting on table cells (v2.5.0), In-memory Image API (v2.4.0), Template / Mail Merge Engine (v2.3.0), Theme System (v2.1.0+), Round-trip Style Preservation (v2.2.1)
+**Latest Features**: Default proofing language via `WithLanguage`/`WithLanguageEx` (v2.6.0), Full run-level formatting on table cells (v2.5.0), In-memory Image API (v2.4.0), Template / Mail Merge Engine (v2.3.0), Theme System (v2.1.0+), Round-trip Style Preservation (v2.2.1)
 
-> **Note**: This library underwent a complete architectural rewrite in 2024-2025, implementing clean architecture principles, comprehensive testing, and modern Go practices. Version 2.0.0 released October 2025, with theme system added in v2.1.0, continued improvements through v2.2.x, template/mail merge engine in v2.3.0, in-memory image insertion plus merged-cell round-trip fixes in v2.4.0, and full run-level cell formatting plus a per-part header/footer relationship fix in v2.5.0.
+> **Note**: This library underwent a complete architectural rewrite in 2024-2025, implementing clean architecture principles, comprehensive testing, and modern Go practices. Version 2.0.0 released October 2025, with theme system added in v2.1.0, continued improvements through v2.2.x, template/mail merge engine in v2.3.0, in-memory image insertion plus merged-cell round-trip fixes in v2.4.0, full run-level cell formatting plus a per-part header/footer relationship fix in v2.5.0, and a default proofing language option in v2.6.0.
 
 ---
 

--- a/builder.go
+++ b/builder.go
@@ -211,6 +211,12 @@ func NewDocumentBuilder(opts ...Option) *DocumentBuilder {
 		}
 	}
 
+	if config.Language != nil {
+		if err := doc.SetLanguage(config.Language); err != nil {
+			builder.errors = append(builder.errors, err)
+		}
+	}
+
 	// Apply theme if provided
 	if config.Theme != nil {
 		// Use type assertion to get Theme interface

--- a/builder_test.go
+++ b/builder_test.go
@@ -25,11 +25,51 @@ SOFTWARE.
 package docx
 
 import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/mmonterroca/docxgo/v2/domain"
 	"github.com/mmonterroca/docxgo/v2/pkg/errors"
 )
+
+// readZipPart builds doc, writes it to a buffer, and returns the content of
+// the named part (e.g. "word/styles.xml") from the resulting .docx ZIP.
+func readZipPart(t *testing.T, doc domain.Document, part string) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo failed: %v", err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Fatalf("failed to read ZIP: %v", err)
+	}
+
+	for _, f := range zr.File {
+		if f.Name != part {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("failed to open %s: %v", part, err)
+		}
+		defer rc.Close()
+
+		content, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", part, err)
+		}
+		return string(content)
+	}
+
+	t.Fatalf("part %s not found in ZIP", part)
+	return ""
+}
 
 func TestDocumentBuilder_Build(t *testing.T) {
 	t.Run("builds document with paragraph", func(t *testing.T) {
@@ -871,6 +911,24 @@ func TestOptions_Validation(t *testing.T) {
 			t.Fatal("expected nil document, got non-nil")
 		}
 	})
+
+	t.Run("WithLanguage validates language tag", func(t *testing.T) {
+		// A paragraph must be added: Build() also fails on an empty document,
+		// and without content that unrelated error would mask whether the
+		// empty language tag was actually rejected.
+		builder := NewDocumentBuilder(
+			WithLanguage(""),
+		)
+		builder.AddParagraph().Text("Test").End()
+
+		doc, err := builder.Build()
+		if err == nil {
+			t.Fatal("expected error for empty language tag, got nil")
+		}
+		if doc != nil {
+			t.Fatal("expected nil document, got non-nil")
+		}
+	})
 }
 
 func TestDocumentBuilder_Options(t *testing.T) {
@@ -1252,4 +1310,89 @@ func TestParagraphBuilder_AddImage(t *testing.T) {
 			t.Fatal("expected error for nil image data, got nil")
 		}
 	})
+}
+
+func TestWithLanguage_WritesLanguageDefaults(t *testing.T) {
+	builder := NewDocumentBuilder(
+		WithLanguage("es-MX"),
+	)
+	builder.AddParagraph().Text("Hola").End()
+
+	doc, err := builder.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	styles := readZipPart(t, doc, "word/styles.xml")
+	if !strings.Contains(styles, `<w:docDefaults>`) {
+		t.Error("expected word/styles.xml to contain w:docDefaults")
+	}
+	if !strings.Contains(styles, `<w:lang w:val="es-MX"`) {
+		t.Errorf("expected word/styles.xml to contain w:lang w:val=\"es-MX\", got: %s", styles)
+	}
+	// CT_Styles requires docDefaults before latentStyles; Word rejects the
+	// reverse order. This guards the internal/xml.Styles field order.
+	docDefaultsIdx := strings.Index(styles, "w:docDefaults")
+	latentStylesIdx := strings.Index(styles, "w:latentStyles")
+	if docDefaultsIdx == -1 || latentStylesIdx == -1 || docDefaultsIdx > latentStylesIdx {
+		t.Error("expected w:docDefaults to precede w:latentStyles in word/styles.xml")
+	}
+
+	settings := readZipPart(t, doc, "word/settings.xml")
+	if !strings.Contains(settings, `<w:themeFontLang w:val="es-MX"`) {
+		t.Errorf("expected word/settings.xml to contain w:themeFontLang w:val=\"es-MX\", got: %s", settings)
+	}
+}
+
+func TestWithLanguageEx_WritesEastAsiaAndBidi(t *testing.T) {
+	builder := NewDocumentBuilder(
+		WithLanguageEx(Language{
+			Val:      "en-US",
+			EastAsia: "ja-JP",
+			Bidi:     "ar-SA",
+		}),
+	)
+	builder.AddParagraph().Text("Test").End()
+
+	doc, err := builder.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	styles := readZipPart(t, doc, "word/styles.xml")
+	for _, want := range []string{`w:val="en-US"`, `w:eastAsia="ja-JP"`, `w:bidi="ar-SA"`} {
+		if !strings.Contains(styles, want) {
+			t.Errorf("expected word/styles.xml to contain %s, got: %s", want, styles)
+		}
+	}
+
+	settings := readZipPart(t, doc, "word/settings.xml")
+	for _, want := range []string{`w:val="en-US"`, `w:eastAsia="ja-JP"`, `w:bidi="ar-SA"`} {
+		if !strings.Contains(settings, want) {
+			t.Errorf("expected word/settings.xml to contain %s, got: %s", want, settings)
+		}
+	}
+}
+
+// TestWithoutLanguage_NoRegression guards against the failure mode this
+// feature was built to avoid: language state silently going nowhere. Without
+// WithLanguage, output must stay exactly as before this change existed.
+func TestWithoutLanguage_NoRegression(t *testing.T) {
+	builder := NewDocumentBuilder()
+	builder.AddParagraph().Text("Test").End()
+
+	doc, err := builder.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	styles := readZipPart(t, doc, "word/styles.xml")
+	if strings.Contains(styles, "w:docDefaults") || strings.Contains(styles, "w:lang") {
+		t.Errorf("expected no w:docDefaults/w:lang without WithLanguage, got: %s", styles)
+	}
+
+	settings := readZipPart(t, doc, "word/settings.xml")
+	if strings.Contains(settings, "themeFontLang") {
+		t.Errorf("expected no w:themeFontLang without WithLanguage, got: %s", settings)
+	}
 }

--- a/builder_test.go
+++ b/builder_test.go
@@ -1396,3 +1396,212 @@ func TestWithoutLanguage_NoRegression(t *testing.T) {
 		t.Errorf("expected no w:themeFontLang without WithLanguage, got: %s", settings)
 	}
 }
+
+// TestWithLanguageEx_SingleScriptTag guards against a real bug found in
+// code review: SetLanguage used to reject any Language whose Val was empty,
+// even when EastAsia or Bidi was set — but <w:lang w:eastAsia="ja-JP"/> with
+// no w:val is valid OOXML, and WithLanguageEx is documented for exactly this
+// mixed-script case.
+func TestWithLanguageEx_SingleScriptTag(t *testing.T) {
+	builder := NewDocumentBuilder(
+		WithLanguageEx(Language{EastAsia: "ja-JP"}),
+	)
+	builder.AddParagraph().Text("Test").End()
+
+	doc, err := builder.Build()
+	if err != nil {
+		t.Fatalf("expected no error for EastAsia-only language, got %v", err)
+	}
+
+	styles := readZipPart(t, doc, "word/styles.xml")
+	if !strings.Contains(styles, `w:eastAsia="ja-JP"`) {
+		t.Errorf("expected word/styles.xml to contain w:eastAsia=\"ja-JP\", got: %s", styles)
+	}
+
+	// themeFontLangXML used to gate on Val alone; an EastAsia/Bidi-only
+	// language silently dropped w:themeFontLang from settings.xml entirely.
+	settings := readZipPart(t, doc, "word/settings.xml")
+	if !strings.Contains(settings, `w:eastAsia="ja-JP"`) {
+		t.Errorf("expected word/settings.xml to contain w:eastAsia=\"ja-JP\", got: %s", settings)
+	}
+}
+
+// TestWithLanguageEx_OptionReuseDoesNotAlias guards against a closure bug:
+// WithLanguageEx's returned Option used to capture &lang from its own
+// parameter, so invoking the same Option value against two Configs left both
+// pointing at one shared Language.
+func TestWithLanguageEx_OptionReuseDoesNotAlias(t *testing.T) {
+	opt := WithLanguageEx(Language{Val: "en-US"})
+
+	c1 := &Config{}
+	c2 := &Config{}
+	opt(c1)
+	opt(c2)
+
+	if c1.Language == c2.Language {
+		t.Fatal("expected independent *Language per Config from reusing one Option, got the same pointer")
+	}
+}
+
+// TestLanguage_ReturnsDefensiveCopy guards against Document.Language()
+// handing out its internal pointer: mutating the result must not affect the
+// document's actual state, matching the sibling BackgroundColor() convention.
+func TestLanguage_ReturnsDefensiveCopy(t *testing.T) {
+	builder := NewDocumentBuilder(WithLanguage("es-MX"))
+	builder.AddParagraph().Text("Test").End()
+	doc, err := builder.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	got := doc.Language()
+	if got == nil {
+		t.Fatal("expected non-nil language")
+	}
+	got.Val = "MUTATED"
+
+	again := doc.Language()
+	if again.Val != "es-MX" {
+		t.Errorf("expected mutation of returned value not to affect document state, got Val=%q", again.Val)
+	}
+}
+
+// TestOpenDocument_HydratesLanguage guards against the reader silently
+// dropping a language that was actually saved: Document.Language() must
+// reflect what styles.xml's docDefaults declares after a round-trip.
+func TestOpenDocument_HydratesLanguage(t *testing.T) {
+	builder := NewDocumentBuilder(
+		WithLanguageEx(Language{Val: "en-US", EastAsia: "ja-JP"}),
+	)
+	builder.AddParagraph().Text("Test").End()
+	doc, err := builder.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo failed: %v", err)
+	}
+
+	reopened, err := OpenDocumentFromBytes(buf.Bytes())
+	if err != nil {
+		t.Fatalf("OpenDocumentFromBytes failed: %v", err)
+	}
+
+	lang := reopened.Language()
+	if lang == nil {
+		t.Fatal("expected Language() to reflect the hydrated language, got nil")
+	}
+	if lang.Val != "en-US" || lang.EastAsia != "ja-JP" {
+		t.Errorf("expected hydrated {Val: en-US, EastAsia: ja-JP}, got %+v", *lang)
+	}
+}
+
+// TestSetLanguage_RejectsRoundTrippedDocument guards against the silent
+// no-op found in code review: SetLanguage returning nil on a document opened
+// from an existing .docx, even though styles.xml/settings.xml are written
+// verbatim on save and the language could never actually reach the file.
+func TestSetLanguage_RejectsRoundTrippedDocument(t *testing.T) {
+	builder := NewDocumentBuilder(WithLanguage("en-US"))
+	builder.AddParagraph().Text("Test").End()
+	doc, err := builder.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo failed: %v", err)
+	}
+
+	reopened, err := OpenDocumentFromBytes(buf.Bytes())
+	if err != nil {
+		t.Fatalf("OpenDocumentFromBytes failed: %v", err)
+	}
+
+	if err := reopened.SetLanguage(&domain.Language{Val: "fr-FR"}); err == nil {
+		t.Fatal("expected SetLanguage to error on a round-tripped document, got nil")
+	}
+
+	// Confirm the rejection is loud, not a silent partial-apply: the
+	// original language must survive a save untouched.
+	var buf2 bytes.Buffer
+	if _, err := reopened.WriteTo(&buf2); err != nil {
+		t.Fatalf("WriteTo failed: %v", err)
+	}
+	reopened2, err := OpenDocumentFromBytes(buf2.Bytes())
+	if err != nil {
+		t.Fatalf("OpenDocumentFromBytes failed: %v", err)
+	}
+	if lang := reopened2.Language(); lang == nil || lang.Val != "en-US" {
+		t.Errorf("expected original en-US to survive untouched, got %+v", lang)
+	}
+}
+
+// TestSetLanguage_RejectsPartiallyPreservedDocument guards against the
+// mismatched-gate bug found in code review: styles.xml and settings.xml used
+// different preservation checks, so a document with styles.xml preserved but
+// no settings.xml part (settings.xml is optional; non-Word producers omit
+// it) applied a new language to only one of the two parts. SetLanguage must
+// now reject uniformly, regardless of which specific part is preserved.
+func TestSetLanguage_RejectsPartiallyPreservedDocument(t *testing.T) {
+	builder := NewDocumentBuilder(WithLanguage("en-US"))
+	builder.AddParagraph().Text("Test").End()
+	doc, err := builder.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo failed: %v", err)
+	}
+
+	stripped := removeZipEntry(t, buf.Bytes(), "word/settings.xml")
+
+	reopened, err := OpenDocumentFromBytes(stripped)
+	if err != nil {
+		t.Fatalf("OpenDocumentFromBytes failed: %v", err)
+	}
+
+	if err := reopened.SetLanguage(&domain.Language{Val: "fr-FR"}); err == nil {
+		t.Fatal("expected SetLanguage to error when styles.xml is preserved even without settings.xml, got nil")
+	}
+}
+
+// removeZipEntry returns a copy of a ZIP archive's bytes with the named
+// entry removed, for constructing a .docx missing an optional part.
+func removeZipEntry(t *testing.T, data []byte, name string) []byte {
+	t.Helper()
+
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("failed to read source ZIP: %v", err)
+	}
+
+	var out bytes.Buffer
+	zw := zip.NewWriter(&out)
+	for _, f := range zr.File {
+		if f.Name == name {
+			continue
+		}
+		w, err := zw.Create(f.Name)
+		if err != nil {
+			t.Fatalf("failed to create entry %s: %v", f.Name, err)
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("failed to open entry %s: %v", f.Name, err)
+		}
+		if _, err := io.Copy(w, rc); err != nil {
+			rc.Close()
+			t.Fatalf("failed to copy entry %s: %v", f.Name, err)
+		}
+		rc.Close()
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("failed to finalize ZIP: %v", err)
+	}
+	return out.Bytes()
+}

--- a/domain/document.go
+++ b/domain/document.go
@@ -161,10 +161,17 @@ type Document interface {
 	BackgroundColor() (Color, bool)
 
 	// SetLanguage sets the document's default proofing language, used by Word
-	// for spell-checking, grammar-checking, and hyphenation. Pass nil to clear it.
+	// for spell-checking, grammar-checking, and hyphenation. Pass nil to clear
+	// it. Returns an error if lang is non-nil but has no tag set (Val,
+	// EastAsia, and Bidi all empty), and on a document opened via
+	// OpenDocument/OpenDocumentFromBytes/OpenDocumentFromReader whose
+	// styles.xml or settings.xml were preserved verbatim for round-trip
+	// fidelity — on such a document the language could never actually reach
+	// the saved file, so SetLanguage refuses rather than silently no-op.
 	SetLanguage(lang *Language) error
 
-	// Language returns the document's default proofing language, or nil if unset.
+	// Language returns a copy of the document's default proofing language, or
+	// nil if unset. Mutating the returned value has no effect on the document.
 	Language() *Language
 }
 

--- a/domain/document.go
+++ b/domain/document.go
@@ -159,6 +159,13 @@ type Document interface {
 	// BackgroundColor returns the configured page background color.
 	// The boolean result indicates whether a background color is explicitly set.
 	BackgroundColor() (Color, bool)
+
+	// SetLanguage sets the document's default proofing language, used by Word
+	// for spell-checking, grammar-checking, and hyphenation. Pass nil to clear it.
+	SetLanguage(lang *Language) error
+
+	// Language returns the document's default proofing language, or nil if unset.
+	Language() *Language
 }
 
 // Metadata contains document properties like title, author, etc.
@@ -170,4 +177,12 @@ type Metadata struct {
 	Description string
 	Created     string // ISO 8601 format
 	Modified    string // ISO 8601 format
+}
+
+// Language represents a document's default proofing language, expressed as
+// BCP 47 language tags (e.g. "es-MX", "en-US").
+type Language struct {
+	Val      string // primary language, applied to Latin-script text
+	EastAsia string // optional, for East Asian scripts (Chinese, Japanese, Korean)
+	Bidi     string // optional, for right-to-left scripts (Arabic, Hebrew)
 }

--- a/internal/core/document.go
+++ b/internal/core/document.go
@@ -70,21 +70,22 @@ type document struct {
 	numberingPart   []byte
 	numberingTarget string
 	backgroundColor *domain.Color
+	language        *domain.Language
 
 	// Preserved parts for round-trip operations (read-modify-write).
 	// When set, these parts are written verbatim to preserve original content.
-	preservedStylesPart      []byte            // Original styles.xml
-	preservedHeaders         map[string][]byte // Original headers (e.g., "header1.xml" -> bytes)
-	preservedFooters         map[string][]byte // Original footers (e.g., "footer1.xml" -> bytes)
-	preservedDocRels         []byte            // Original word/_rels/document.xml.rels
-	preservedContentTypes    []byte            // Original [Content_Types].xml
-	preservedAdditional      map[string][]byte // Additional parts (comments, footnotes, customXml, etc.)
-	preservedThemes          map[string][]byte // Original theme parts
-	preservedFontTable       []byte            // Original fontTable.xml
-	preservedSettings        []byte            // Original settings.xml
-	preservedWebSettings     []byte            // Original webSettings.xml
-	preservedCustomProps     []byte            // Original docProps/custom.xml
-	preservedRootRels        []byte            // Original _rels/.rels
+	preservedStylesPart   []byte            // Original styles.xml
+	preservedHeaders      map[string][]byte // Original headers (e.g., "header1.xml" -> bytes)
+	preservedFooters      map[string][]byte // Original footers (e.g., "footer1.xml" -> bytes)
+	preservedDocRels      []byte            // Original word/_rels/document.xml.rels
+	preservedContentTypes []byte            // Original [Content_Types].xml
+	preservedAdditional   map[string][]byte // Additional parts (comments, footnotes, customXml, etc.)
+	preservedThemes       map[string][]byte // Original theme parts
+	preservedFontTable    []byte            // Original fontTable.xml
+	preservedSettings     []byte            // Original settings.xml
+	preservedWebSettings  []byte            // Original webSettings.xml
+	preservedCustomProps  []byte            // Original docProps/custom.xml
+	preservedRootRels     []byte            // Original _rels/.rels
 }
 
 // NewDocument creates a new Document.
@@ -399,6 +400,7 @@ func (d *document) WriteTo(w io.Writer) (int64, error) {
 
 	// Create ZIP writer
 	zipWriter := writer.NewZipWriter(w)
+	zipWriter.SetLanguage(d.language)
 	defer func() {
 		if err := zipWriter.Close(); err != nil {
 			// Log error but don't override return value as document may have been partially written
@@ -414,7 +416,7 @@ func (d *document) WriteTo(w io.Writer) (int64, error) {
 	appProps := ser.SerializeAppProperties(d)
 
 	// Serialize styles (used only if no preserved styles are available)
-	styles := ser.SerializeStyles(d.styleManager)
+	styles := ser.SerializeStyles(d.styleManager, d.language)
 
 	mediaFiles := d.mediaManager.All()
 
@@ -538,6 +540,26 @@ func (d *document) BackgroundColor() (domain.Color, bool) {
 		return domain.Color{}, false
 	}
 	return *d.backgroundColor, true
+}
+
+// SetLanguage sets the document's default proofing language.
+func (d *document) SetLanguage(lang *domain.Language) error {
+	if d == nil {
+		return errors.InvalidState("Document.SetLanguage", "document is nil")
+	}
+	if lang != nil && lang.Val == "" {
+		return errors.InvalidArgument("Document.SetLanguage", "lang.Val", lang.Val, "language tag cannot be empty")
+	}
+	d.language = lang
+	return nil
+}
+
+// Language returns the document's default proofing language, or nil if unset.
+func (d *document) Language() *domain.Language {
+	if d == nil {
+		return nil
+	}
+	return d.language
 }
 
 // StyleManager returns the style manager for this document.

--- a/internal/core/document.go
+++ b/internal/core/document.go
@@ -542,24 +542,57 @@ func (d *document) BackgroundColor() (domain.Color, bool) {
 	return *d.backgroundColor, true
 }
 
-// SetLanguage sets the document's default proofing language.
+// SetLanguage sets the document's default proofing language. It returns an
+// error on a document opened via OpenDocument/OpenDocumentFromBytes/
+// OpenDocumentFromReader whose styles.xml or settings.xml were preserved for
+// round-trip fidelity: WriteTo writes those parts verbatim, so a language set
+// here would silently never reach the saved file. Only documents created with
+// NewDocument (including via NewDocumentBuilder) support SetLanguage.
 func (d *document) SetLanguage(lang *domain.Language) error {
 	if d == nil {
 		return errors.InvalidState("Document.SetLanguage", "document is nil")
 	}
-	if lang != nil && lang.Val == "" {
-		return errors.InvalidArgument("Document.SetLanguage", "lang.Val", lang.Val, "language tag cannot be empty")
+	if len(d.preservedStylesPart) > 0 || len(d.preservedSettings) > 0 {
+		return errors.InvalidState("Document.SetLanguage",
+			"cannot set the proofing language on a document whose styles.xml/settings.xml are preserved from round-trip; only documents created with NewDocument support SetLanguage")
 	}
-	d.language = lang
+	if lang != nil && lang.Val == "" && lang.EastAsia == "" && lang.Bidi == "" {
+		return errors.InvalidArgument("Document.SetLanguage", "lang", lang, "at least one of Val, EastAsia, or Bidi must be set")
+	}
+	if lang == nil {
+		d.language = nil
+		return nil
+	}
+	langCopy := *lang
+	d.language = &langCopy
 	return nil
 }
 
-// Language returns the document's default proofing language, or nil if unset.
+// Language returns a copy of the document's default proofing language, or
+// nil if unset. Mutating the returned value has no effect on the document.
 func (d *document) Language() *domain.Language {
-	if d == nil {
+	if d == nil || d.language == nil {
 		return nil
 	}
-	return d.language
+	langCopy := *d.language
+	return &langCopy
+}
+
+// SetLanguageRaw hydrates the document's language field directly, bypassing
+// SetLanguage's round-trip guard. Used exclusively by the reader package
+// during OpenDocument to reflect a language already present in the source
+// file's styles.xml — not part of domain.Document, reached only via the
+// reader's own type-assertion (mirrors SetPreservedStylesPart/SetNumberingPart).
+func (d *document) SetLanguageRaw(lang *domain.Language) {
+	if d == nil {
+		return
+	}
+	if lang == nil {
+		d.language = nil
+		return
+	}
+	langCopy := *lang
+	d.language = &langCopy
 }
 
 // StyleManager returns the style manager for this document.

--- a/internal/reader/reconstruct.go
+++ b/internal/reader/reconstruct.go
@@ -23,6 +23,7 @@
 package reader
 
 import (
+	"encoding/xml"
 	"fmt"
 	"strconv"
 	"strings"
@@ -133,6 +134,19 @@ func ReconstructDocument(parsed *ParsedPackage) (domain.Document, error) {
 	// Preserve all original parts for complete round-trip fidelity.
 	if parsed.Package != nil {
 		preserveOriginalParts(doc, parsed.Package)
+	}
+
+	// Hydrate the default proofing language from styles.xml's docDefaults so
+	// Document.Language() reflects a document opened with one already set.
+	// Uses SetLanguageRaw, not SetLanguage: preserveOriginalParts above has
+	// already given this document preserved styles.xml/settings.xml bytes,
+	// which would trip SetLanguage's round-trip guard.
+	if parsed.Package != nil && len(parsed.Package.Styles) > 0 {
+		if lang, err := parseStylesLanguage(parsed.Package.Styles); err == nil && lang != nil {
+			if setter, ok := doc.(interface{ SetLanguageRaw(*domain.Language) }); ok {
+				setter.SetLanguageRaw(lang)
+			}
+		}
 	}
 
 	for _, child := range body.Children {
@@ -2193,4 +2207,56 @@ func preserveOriginalParts(doc domain.Document, pkg *Package) {
 	}
 
 	setter.SetPreservedParts(parts)
+}
+
+// stylesLanguageRead is a read-only mirror of styles.xml's
+// docDefaults/rPrDefault/rPr/lang path, used only for Unmarshal. It can't
+// reuse internal/xml's Styles/DocDefaults/RunDefaults/RunProperties/Language
+// (marshal-only structs with literal "w:"-prefixed tags): Go's encoding/xml
+// resolves namespace prefixes to their URIs during decode, so a struct meant
+// for Unmarshal needs "namespace-URI element"/"namespace-URI attr,attr" tags
+// instead of the literal "w:"-prefixed ones the write-side structs use.
+type stylesLanguageRead struct {
+	DocDefaults *docDefaultsRead `xml:"http://schemas.openxmlformats.org/wordprocessingml/2006/main docDefaults"`
+}
+
+type docDefaultsRead struct {
+	RunDefaults *rPrDefaultRead `xml:"http://schemas.openxmlformats.org/wordprocessingml/2006/main rPrDefault"`
+}
+
+type rPrDefaultRead struct {
+	Properties *rPrLangRead `xml:"http://schemas.openxmlformats.org/wordprocessingml/2006/main rPr"`
+}
+
+type rPrLangRead struct {
+	Lang *langRead `xml:"http://schemas.openxmlformats.org/wordprocessingml/2006/main lang"`
+}
+
+type langRead struct {
+	Val      string `xml:"http://schemas.openxmlformats.org/wordprocessingml/2006/main val,attr"`
+	EastAsia string `xml:"http://schemas.openxmlformats.org/wordprocessingml/2006/main eastAsia,attr"`
+	Bidi     string `xml:"http://schemas.openxmlformats.org/wordprocessingml/2006/main bidi,attr"`
+}
+
+// parseStylesLanguage unmarshals word/styles.xml bytes and extracts the
+// document's default proofing language from
+// w:docDefaults/w:rPrDefault/w:rPr/w:lang, if present. Returns nil (with no
+// error) when styles.xml doesn't declare one.
+func parseStylesLanguage(data []byte) (*domain.Language, error) {
+	var styles stylesLanguageRead
+	if err := xml.Unmarshal(data, &styles); err != nil {
+		return nil, err
+	}
+
+	if styles.DocDefaults == nil || styles.DocDefaults.RunDefaults == nil ||
+		styles.DocDefaults.RunDefaults.Properties == nil {
+		return nil, nil
+	}
+
+	lang := styles.DocDefaults.RunDefaults.Properties.Lang
+	if lang == nil || (lang.Val == "" && lang.EastAsia == "" && lang.Bidi == "") {
+		return nil, nil
+	}
+
+	return &domain.Language{Val: lang.Val, EastAsia: lang.EastAsia, Bidi: lang.Bidi}, nil
 }

--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -1228,13 +1228,24 @@ func (s *DocumentSerializer) DebugPrint(doc domain.Document) {
 		len(doc.Paragraphs()), len(doc.Tables()))
 }
 
-// SerializeStyles converts a domain.StyleManager to xml.Styles.
-func (s *DocumentSerializer) SerializeStyles(styleManager domain.StyleManager) *xml.Styles {
+// SerializeStyles converts a domain.StyleManager to xml.Styles. When lang is
+// non-nil, it is written as the document's default proofing language
+// (w:docDefaults/w:rPrDefault/w:rPr/w:lang).
+func (s *DocumentSerializer) SerializeStyles(styleManager domain.StyleManager, lang *domain.Language) *xml.Styles {
 	xmlStyles := xml.NewStyles()
 
-	// Set doc defaults
 	// Include Word's latent style catalog to avoid auto-added styles during repair
 	xmlStyles.LatentStyles = defaultLatentStyles
+
+	if lang != nil {
+		xmlStyles.DocDefaults = &xml.DocDefaults{
+			RunDefaults: &xml.RunDefaults{
+				Properties: &xml.RunProperties{
+					Lang: &xml.Language{Val: lang.Val, EastAsia: lang.EastAsia, Bidi: lang.Bidi},
+				},
+			},
+		}
+	}
 
 	// Serialize all styles from the style manager
 	for _, style := range styleManager.ListStyles() {

--- a/internal/serializer/serializer_test.go
+++ b/internal/serializer/serializer_test.go
@@ -807,7 +807,7 @@ func TestDocumentSerializer_TableStyleBorders(t *testing.T) {
 	sm := doc.StyleManager()
 
 	ser := serializer.NewDocumentSerializer()
-	xmlStyles := ser.SerializeStyles(sm)
+	xmlStyles := ser.SerializeStyles(sm, nil)
 
 	// Find the TableGrid style
 	var tableGridStyle *xmlstructs.Style

--- a/internal/writer/zip.go
+++ b/internal/writer/zip.go
@@ -28,6 +28,7 @@ package writer
 
 import (
 	"archive/zip"
+	"bytes"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -36,6 +37,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mmonterroca/docxgo/v2/domain"
 	"github.com/mmonterroca/docxgo/v2/internal/manager"
 	"github.com/mmonterroca/docxgo/v2/internal/serializer"
 	xmlstructs "github.com/mmonterroca/docxgo/v2/internal/xml"
@@ -46,6 +48,7 @@ import (
 type ZipWriter struct {
 	zipWriter  *zip.Writer
 	serializer *serializer.DocumentSerializer
+	language   *domain.Language
 }
 
 // NumberingPart represents numbering.xml data that should be preserved in the DOCX package.
@@ -76,6 +79,13 @@ func NewZipWriter(w io.Writer) *ZipWriter {
 		zipWriter:  zip.NewWriter(w),
 		serializer: serializer.NewDocumentSerializer(),
 	}
+}
+
+// SetLanguage sets the document's default proofing language, written to
+// word/settings.xml as w:themeFontLang when the default (non-preserved)
+// settings part is generated.
+func (zw *ZipWriter) SetLanguage(lang *domain.Language) {
+	zw.language = lang
 }
 
 // WriteDocument writes a complete .docx document structure.
@@ -600,9 +610,34 @@ func (zw *ZipWriter) writeDefaultSettings() error {
 	<w:characterSpacingControl w:val="doNotCompress"/>
 	<w:compat>
 		<w:compatSetting w:name="compatibilityMode" w:uri="http://schemas.microsoft.com/office/word" w:val="15"/>
-	</w:compat>
+	</w:compat>` + zw.themeFontLangXML() + `
 </w:settings>`
 	return zw.writeRaw("word/settings.xml", []byte(settings))
+}
+
+// themeFontLangXML returns the w:themeFontLang element reflecting the
+// configured language, or an empty string when no language is set. It is
+// placed immediately after w:compat, which is schema-valid since no elements
+// between them (w:docVars, w:rsids, m:mathPr, w:attachedSchema) are emitted.
+func (zw *ZipWriter) themeFontLangXML() string {
+	if zw.language == nil || zw.language.Val == "" {
+		return ""
+	}
+	attrs := ` w:val="` + xmlEscapeAttr(zw.language.Val) + `"`
+	if zw.language.EastAsia != "" {
+		attrs += ` w:eastAsia="` + xmlEscapeAttr(zw.language.EastAsia) + `"`
+	}
+	if zw.language.Bidi != "" {
+		attrs += ` w:bidi="` + xmlEscapeAttr(zw.language.Bidi) + `"`
+	}
+	return "\n\t<w:themeFontLang" + attrs + "/>"
+}
+
+// xmlEscapeAttr escapes a string for safe use as an XML attribute value.
+func xmlEscapeAttr(s string) string {
+	var buf bytes.Buffer
+	_ = xml.EscapeText(&buf, []byte(s))
+	return buf.String()
 }
 
 // writeDefaultWebSettings writes a baseline word/webSettings.xml part.

--- a/internal/writer/zip.go
+++ b/internal/writer/zip.go
@@ -620,10 +620,14 @@ func (zw *ZipWriter) writeDefaultSettings() error {
 // placed immediately after w:compat, which is schema-valid since no elements
 // between them (w:docVars, w:rsids, m:mathPr, w:attachedSchema) are emitted.
 func (zw *ZipWriter) themeFontLangXML() string {
-	if zw.language == nil || zw.language.Val == "" {
+	if zw.language == nil ||
+		(zw.language.Val == "" && zw.language.EastAsia == "" && zw.language.Bidi == "") {
 		return ""
 	}
-	attrs := ` w:val="` + xmlEscapeAttr(zw.language.Val) + `"`
+	var attrs string
+	if zw.language.Val != "" {
+		attrs += ` w:val="` + xmlEscapeAttr(zw.language.Val) + `"`
+	}
 	if zw.language.EastAsia != "" {
 		attrs += ` w:eastAsia="` + xmlEscapeAttr(zw.language.EastAsia) + `"`
 	}

--- a/internal/xml/style.go
+++ b/internal/xml/style.go
@@ -28,11 +28,15 @@ package xml
 import "encoding/xml"
 
 // Styles represents the styles.xml document.
+//
+// Field order matches the CT_Styles content model (docDefaults, then
+// latentStyles, then style*) — encoding/xml marshals in struct field order,
+// and Word rejects a docDefaults that appears after latentStyles.
 type Styles struct {
 	XMLName      xml.Name      `xml:"w:styles"`
 	Xmlns        string        `xml:"xmlns:w,attr"`
-	LatentStyles *LatentStyles `xml:"w:latentStyles,omitempty"`
 	DocDefaults  *DocDefaults  `xml:"w:docDefaults,omitempty"`
+	LatentStyles *LatentStyles `xml:"w:latentStyles,omitempty"`
 	Styles       []*Style      `xml:"w:style"`
 }
 

--- a/options.go
+++ b/options.go
@@ -239,9 +239,11 @@ func WithSubject(subject string) Option {
 // language tag. Word uses this to select the spell-checking and grammar
 // dictionaries, and to apply the correct hyphenation rules.
 //
-// This only takes effect when building a new document. When reading and
-// re-saving an existing .docx file, the original styles.xml and settings.xml
-// are preserved verbatim and WithLanguage has no effect.
+// NewDocumentBuilder always starts from a new, empty document, so this always
+// takes effect. To change the language of an existing .docx opened via
+// OpenDocument, use its SetLanguage method instead — note that it errors on a
+// document whose styles.xml/settings.xml were preserved for round-trip
+// fidelity, since the language could never actually reach the saved file.
 //
 // Example:
 //
@@ -257,9 +259,10 @@ func WithLanguage(lang string) Option {
 // WithLanguageEx sets the document's default proofing language, including
 // optional language tags for East Asian (CJK) and right-to-left (bidi)
 // scripts. Use this over WithLanguage when the document mixes scripts, e.g.
-// Latin text with embedded Japanese or Arabic.
+// Latin text with embedded Japanese or Arabic. At least one of Val, EastAsia,
+// or Bidi must be set.
 //
-// See WithLanguage for the same round-trip caveat.
+// See WithLanguage regarding existing documents opened via OpenDocument.
 //
 // Example:
 //
@@ -272,7 +275,10 @@ func WithLanguage(lang string) Option {
 //	)
 func WithLanguageEx(lang Language) Option {
 	return func(c *Config) {
-		c.Language = &lang
+		// Copy so that reusing this Option across multiple builders doesn't
+		// leave their Configs aliasing the same *Language.
+		langCopy := lang
+		c.Language = &langCopy
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -38,8 +38,14 @@ type Config struct {
 	Margins          Margins
 	StrictValidation bool
 	Metadata         *domain.Metadata
+	Language         *Language
 	Theme            interface{} // Theme to apply (using interface{} to avoid import cycle)
 }
+
+// Language represents a document's default proofing language, expressed as
+// BCP 47 language tags (e.g. "es-MX", "en-US"). See docx.WithLanguage and
+// docx.WithLanguageEx.
+type Language = domain.Language
 
 // PageSize represents paper dimensions.
 type PageSize struct {
@@ -226,6 +232,47 @@ func WithSubject(subject string) Option {
 			c.Metadata = &domain.Metadata{}
 		}
 		c.Metadata.Subject = subject
+	}
+}
+
+// WithLanguage sets the document's default proofing language, using a BCP 47
+// language tag. Word uses this to select the spell-checking and grammar
+// dictionaries, and to apply the correct hyphenation rules.
+//
+// This only takes effect when building a new document. When reading and
+// re-saving an existing .docx file, the original styles.xml and settings.xml
+// are preserved verbatim and WithLanguage has no effect.
+//
+// Example:
+//
+//	builder := docx.NewDocumentBuilder(
+//	    docx.WithLanguage("es-MX"),
+//	)
+func WithLanguage(lang string) Option {
+	return func(c *Config) {
+		c.Language = &Language{Val: lang}
+	}
+}
+
+// WithLanguageEx sets the document's default proofing language, including
+// optional language tags for East Asian (CJK) and right-to-left (bidi)
+// scripts. Use this over WithLanguage when the document mixes scripts, e.g.
+// Latin text with embedded Japanese or Arabic.
+//
+// See WithLanguage for the same round-trip caveat.
+//
+// Example:
+//
+//	builder := docx.NewDocumentBuilder(
+//	    docx.WithLanguageEx(docx.Language{
+//	        Val:      "en-US",
+//	        EastAsia: "ja-JP",
+//	        Bidi:     "ar-SA",
+//	    }),
+//	)
+func WithLanguageEx(lang Language) Option {
+	return func(c *Config) {
+		c.Language = &lang
 	}
 }
 


### PR DESCRIPTION
Closes #44. Adds `WithLanguage`/`WithLanguageEx` so generated documents declare a default proofing language — without it, Word assumes the local install's language and misspell-flags every word in a non-English document.

```go
builder := docx.NewDocumentBuilder(
    docx.WithLanguage("es-MX"),
)
```

### What's included
- `WithLanguage(lang string)` — sets the primary language (BCP 47 tag).
- `WithLanguageEx(docx.Language{Val, EastAsia, Bidi})` — additionally sets East Asian (CJK) and right-to-left (bidi) script languages, for mixed-script documents. At least one of the three must be set.
- Written as `w:lang` in `word/styles.xml`'s `docDefaults/rPrDefault/rPr`, and as `w:themeFontLang` in `word/settings.xml`.
- `OpenDocument`/`OpenDocumentFromBytes`/`OpenDocumentFromReader` now hydrate `Language()` from an existing document's `styles.xml`, if it declares one.
- `SetLanguage` returns an error (instead of silently no-op) on a document opened via `OpenDocument` whose `styles.xml`/`settings.xml` were preserved verbatim for round-trip fidelity — the language could never actually reach the saved file in that case, so it refuses rather than silently doing nothing.

### `domain.Document` interface change
`SetLanguage`/`Language()` were added to the `domain.Document` interface. If you implement it directly with your own type (most commonly a hand-written test double), you'll need to add both methods — embedding `domain.Document` is unaffected, since new methods are promoted automatically. No exported docxgo API accepts a `domain.Document` from a caller (only returns one), so in practice this only affects direct implementers. This is the same kind of change as `SetBackgroundColor`/`BackgroundColor`, added to this same interface in the `v2.0.1` patch release — called out explicitly in the CHANGELOG under `### Changed` rather than buried under `### Added`.

### Also fixed along the way
- `internal/xml.Styles` was marshaling `w:latentStyles` before `w:docDefaults`, which violates the `CT_Styles` schema — invisible until now because `DocDefaults` was never populated. Field order corrected.
- A private code review caught and fixed several edge cases before this reached master: `WithLanguageEx` rejecting an EastAsia/Bidi-only language, `themeFontLang` being silently dropped for the same case, `Language()` handing out a mutable internal pointer, and `WithLanguageEx`'s closure aliasing one `*Language` across multiple builders.

### Not in scope
While tracing how `Config` options reach the document, found that `WithDefaultFont`, `WithDefaultFontSize`, `WithPageSize`, `WithMargins`, and `WithStrictValidation` are pre-existing silent no-ops — `NewDocumentBuilder` never reads those `Config` fields. Filed separately as #45 so it doesn't block this PR.

### Notes
- Cherry-picked onto `master` (instead of routing through `dev`) so it can ship independently of the in-progress CLI/npm work on `dev` (#24), which currently has a failing CI check and no human review.
- `go build`, `go vet`, `gofmt`, `golangci-lint`, the full test suite, and the .NET Open XML validator are all green on this branch.