### PR TITLE
fix(ci): add workflow_dispatch fallback to npm-publish.yml

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,13 @@ name: npm Publish
 on:
   release:
     types: [published]
+  # Manual fallback: release.yml creates the GitHub Release using the default
+  # GITHUB_TOKEN, and GitHub does not let GITHUB_TOKEN-authored events trigger
+  # other workflows (anti-recursion protection) — so "release: published"
+  # above never actually fires. Until release.yml is updated to create the
+  # release with a PAT instead, run this manually after each release, picking
+  # the release's tag (e.g. v2.7.0) as the ref to run the workflow from.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Discovered on the real v2.7.0 release: `release.yml` creates the GitHub Release using the default `GITHUB_TOKEN`, and GitHub deliberately does not let `GITHUB_TOKEN`-authored events trigger other workflows (anti-recursion protection) — so `npm-publish.yml`'s `release: published` trigger never actually fires, even though the release genuinely publishes (not draft).

Adds `workflow_dispatch` as a manual fallback so the publish can be run against a given tag without waiting on a root-cause fix (giving `release.yml`'s release-creation step a PAT instead of `GITHUB_TOKEN`, so the publish event genuinely cascades for future releases — tracked separately).

Needed immediately to actually publish v2.7.0 to npm.