### PR TITLE
fix(ci): accept explicit version input for manual npm-publish dispatch

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,9 +7,18 @@ on:
   # GITHUB_TOKEN, and GitHub does not let GITHUB_TOKEN-authored events trigger
   # other workflows (anti-recursion protection) — so "release: published"
   # above never actually fires. Until release.yml is updated to create the
-  # release with a PAT instead, run this manually after each release, picking
-  # the release's tag (e.g. v2.7.0) as the ref to run the workflow from.
+  # release with a PAT instead, run this manually after each release.
+  #
+  # workflow_dispatch is only usable against a ref where the workflow file
+  # itself already declares this trigger, so the release tag (created before
+  # this fallback existed, and every future tag, which is cut before this
+  # workflow can be edited from it) can't be used directly as the dispatch
+  # ref. Run this from the default branch instead and pass the version input.
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 2.7.0, no "v" prefix)'
+        required: true
 
 permissions:
   contents: read
@@ -55,7 +64,12 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Build binary
         env:
@@ -107,7 +121,12 @@ jobs:
 
       - name: Extract version from tag
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Install dependencies
         run: cd npm && npm ci


### PR DESCRIPTION
Follow-up to #49: \`workflow_dispatch\` is only offered against a ref whose own copy of the workflow file already declares the trigger, so \`v2.7.0\` (and every future release tag, cut before this workflow can be edited from it) can't be used as the dispatch ref. Dispatching from \`master\` instead means \`GITHUB_REF\` is \`refs/heads/master\`, so the existing tag-based version extraction would silently break.

Adds a required \`version\` input used when present, falling back to the \`GITHUB_REF\`-based extraction for the (currently non-functional) release-triggered path.

Needed immediately to actually publish v2.7.0 to npm.