### PR TITLE
fix(ci): make npm-publish.yml idempotent, fix version-bump failure

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -103,7 +103,12 @@ jobs:
       - name: Publish platform package (provenance)
         run: |
           cd npm/platforms/${{ matrix.suffix }}
-          npm publish --access public --provenance
+          PKG="@mmonterroca/docxgo-${{ matrix.suffix }}@${{ steps.version.outputs.version }}"
+          if npm view "$PKG" version >/dev/null 2>&1; then
+            echo "$PKG already published, skipping (safe re-run)"
+          else
+            npm publish --access public --provenance
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -135,7 +140,7 @@ jobs:
         run: cd npm && npm run build
 
       - name: Set version
-        run: cd npm && npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+        run: cd npm && npm version ${{ steps.version.outputs.version }} --no-git-tag-version --allow-same-version
 
       - name: Update optionalDependencies versions
         run: |
@@ -150,7 +155,14 @@ jobs:
           "
 
       - name: Publish (provenance)
-        run: cd npm && npm publish --access public --provenance
+        run: |
+          cd npm
+          PKG="@mmonterroca/docxgo@${{ steps.version.outputs.version }}"
+          if npm view "$PKG" version >/dev/null 2>&1; then
+            echo "$PKG already published, skipping (safe re-run)"
+          else
+            npm publish --access public --provenance
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -17,11 +17,11 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "@mmonterroca/docxgo-darwin-arm64": "0.1.0",
-        "@mmonterroca/docxgo-darwin-x64": "0.1.0",
-        "@mmonterroca/docxgo-linux-arm64": "0.1.0",
-        "@mmonterroca/docxgo-linux-x64": "0.1.0",
-        "@mmonterroca/docxgo-win32-x64": "0.1.0"
+        "@mmonterroca/docxgo-darwin-arm64": "2.7.0",
+        "@mmonterroca/docxgo-darwin-x64": "2.7.0",
+        "@mmonterroca/docxgo-linux-arm64": "2.7.0",
+        "@mmonterroca/docxgo-linux-x64": "2.7.0",
+        "@mmonterroca/docxgo-win32-x64": "2.7.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -467,19 +467,69 @@
       }
     },
     "node_modules/@mmonterroca/docxgo-darwin-arm64": {
-      "optional": true
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-darwin-arm64/-/docxgo-darwin-arm64-2.7.0.tgz",
+      "integrity": "sha512-IA8ONsIrNaqiCOj0hHLA4MNK4PjIbpQzIxQY2qXW8ATda1LTMgT6dTXvsDW3KSpteNUJtQNTCkpzkvYlAHPQlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/@mmonterroca/docxgo-darwin-x64": {
-      "optional": true
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-darwin-x64/-/docxgo-darwin-x64-2.7.0.tgz",
+      "integrity": "sha512-+mzHMD9UWOEkRIFxzMcyV3bH4m65SSRUT482c0EXfI3usD/rQC3HUceg68toZVlh0D+uK9xbAHbUGf2/4lCcaQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
     "node_modules/@mmonterroca/docxgo-linux-arm64": {
-      "optional": true
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-linux-arm64/-/docxgo-linux-arm64-2.7.0.tgz",
+      "integrity": "sha512-rsuUKplabRKCB32gXt+quC0i7ByGpQYjeZ/9UJ63vNuPbUfbVvykSwmBaHofKoDdPgElXT9TMnKV/0FlFW/oIA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@mmonterroca/docxgo-linux-x64": {
-      "optional": true
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-linux-x64/-/docxgo-linux-x64-2.7.0.tgz",
+      "integrity": "sha512-LdR+9DsqfPGH4bE1fAzqEir0wbHmvJ7N1Ifdg9N+6gnCRsm07GO+fDt7EVZ/bJ8xOdlxxy0UGoLq37vHDN+wiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@mmonterroca/docxgo-win32-x64": {
-      "optional": true
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-win32-x64/-/docxgo-win32-x64-2.7.0.tgz",
+      "integrity": "sha512-K3M59OB8RLLptQ+ek2wAivjQKXaX83tT0Aq4FaScXKwRruVjrVyTT6upnTtJrrugG5TZw35NwwU3CzGUpsWp5w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@types/node": {
       "version": "25.3.3",


### PR DESCRIPTION
The real v2.7.0 dispatch failed on "Publish @mmonterroca/docxgo": \`npm version 2.7.0 --no-git-tag-version\` refuses a no-op bump, and npm/package.json already had "2.7.0". The 5 platform packages had already published successfully by this point (confirmed via job logs — provenance signed, transparency log entry present), so only the main package was blocked.

- Set version: add \`--allow-same-version\`.
- Both publish steps: skip via \`npm view <pkg>@<version>\` if that exact version is already live, instead of failing hard on "cannot publish over previously published version". Makes re-dispatching after a partial failure safe.

Needed immediately to finish publishing v2.7.0 — the 5 platform packages are live, only the main package is missing.