### PR TITLE
fix(ci): create the release with a PAT so npm-publish.yml auto-triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,4 +115,11 @@ jobs:
           generate_release_notes: true
           files: release-assets/*
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Must be a real PAT (repo-scoped "Contents: Read and write" is
+          # enough), not the default GITHUB_TOKEN: GitHub does not let events
+          # created by GITHUB_TOKEN trigger other workflows (anti-recursion
+          # protection), so npm-publish.yml's "release: published" trigger
+          # would never fire if this stayed as GITHUB_TOKEN. See
+          # npm-publish.yml's workflow_dispatch fallback for the manual path
+          # this replaces.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
\`release.yml\` created the GitHub Release using the default \`GITHUB_TOKEN\`. GitHub does not let \`GITHUB_TOKEN\`-authored events trigger other workflows (anti-recursion protection), so \`npm-publish.yml\`'s \`release: published\` trigger never fired for the real v2.7.0 release — it had to be dispatched manually.

Switches to a real PAT (\`secrets.RELEASE_PAT\`), which GitHub treats as a human-authored event, so future releases cascade to \`npm-publish.yml\` automatically.

**Requires the \`RELEASE_PAT\` repo secret to be added** — a fine-grained PAT scoped to this repo with "Contents: Read and write" — before the next tag is pushed, or \`release.yml\` will fail to create the release.