### PR TITLE
Phase 0 credibility cleanup: align public docs, expose tech themes, fix output branding, and record license provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## v2.7.1 — 2026-07-18
+
+### Added
+
+- **The two Tech themes are now discoverable through the public API.** `TechPresentation` and `TechDarkMode` existed but were not resolvable by name; they are now returned by `themes.AllThemes()` (which now yields **7** themes), `themes.ThemeNames()`, and `themes.GetTheme()`, and are accepted by the CLI's theme option and the Node.js `ThemeName` type (PR #56). Consumers that relied on `AllThemes()` returning exactly five themes should be aware of the new count.
+- **`docs/PROVENANCE_AUDIT.md`** — a reproducible code-provenance record for docxgo v2 relative to the AGPL-licensed `fumiama/go-docx` upstream, with an accompanying comparison script (`docs/provenance/compare_line_overlap.py`).
+
+### Fixed
+
+- **Output branding.** Generated documents reported `go-docx/v2` (and a frozen `go-docx v2.0.0`) as the authoring application in `docProps/app.xml`/`core.xml`; they now report `docxgo`.
+
+### Changed
+
+- **Documentation aligned with actual behavior** (no API or generation changes): image support is stated as PNG/JPEG/GIF — the formats that decode end-to-end (see #55 for the previously over-stated set); thread-safety wording clarified (a single `Document` is not thread-safe, the internal managers are); the package godoc version string corrected; and the public README prose tightened. The license/provenance narrative across README, CREDITS, and the godoc now defers to `docs/PROVENANCE_AUDIT.md` as the single source of truth.
+
+---
+
 ## v2.7.0 — 2026-07-17
 
 ### Added

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -189,6 +189,10 @@ Created for [Basement Crowd](https://www.basementcrowd.com) and [FromCounsel](ht
 The AGPL-3.0 licensing enters the chain only at fumiama's 2023 relicense; everything
 before it was MIT. docxgo is MIT — see LICENSE for the full copyright notice.
 
+A line-level and structural code provenance audit of docxgo v2 against the
+AGPL-licensed `fumiama/go-docx` upstream is available at
+[docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md).
+
 ---
 
 ## Why v2 is Independent

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -102,9 +102,10 @@ Listed newest first. See the timeline below for the chronological view.
 **Forked from**: gonfva/docxlib (MIT)  
 **License**: AGPL-3.0 — relicensed by fumiama on 2023-02-24, having received the code under MIT
 
-This is the upstream the mmonterroca fork above branched from. Its dates overlap because
-development continued here independently after the 2023 fork; the two are parallel, not
-sequential.
+This is the upstream docxgo v2 forks from. docxgo v2's `master` descends from
+this repository's history through its 2025-05 HEAD (i.e. sequentially, through
+the AGPL period — not as a parallel branch taken during the earlier MIT
+window). See [docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md), Finding 1.
 
 #### Author
 - **fumiama** - Expanded functionality (first commit 2023-02-08, last 2025-05-06)
@@ -173,44 +174,52 @@ Created for [Basement Crowd](https://www.basementcrowd.com) and [FromCounsel](ht
 
 2023       fumiama/go-docx  (fork)      ← relicensed AGPL-3.0 on 2023-02-24
              └─ Images, tables, shapes; expanded API surface
-             └─ upstream continued independently through 2025-05
+             └─ development continued through 2025-05
                     │
-                    │  forked 2023
+                    │  docxgo v2 forks fumiama's 2025-05 HEAD (AGPL-era),
+                    │  first own commit 2025-10-21
                     ▼
-2023-2024  mmonterroca/docxgo v1  (fork)
-             └─ Headers/footers, TOC, hyperlinks, fields
-
-2024-2026  mmonterroca/docxgo v2  (complete rewrite)           [MIT]
-             └─ Clean architecture
-             └─ Production-grade code quality
-             └─ Independent project
+2025-2026  mmonterroca/docxgo v2  (substantial rewrite on the AGPL-era base)
+             └─ Clean-architecture rewrite; current tree shares only
+                schema-dictated OOXML boilerplate with the upstream
+             └─ Distributed under MIT — but see the licensing caveat below
 ```
 
-The AGPL-3.0 licensing enters the chain only at fumiama's 2023 relicense; everything
-before it was MIT. docxgo is MIT — see LICENSE for the full copyright notice.
-
-A line-level and structural code provenance audit of docxgo v2 against the
-AGPL-licensed `fumiama/go-docx` upstream is available at
-[docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md).
+> **Licensing caveat.** The `[MIT]` badge on docxgo v2 reflects the license
+> currently applied to its distribution, **not** a settled legal conclusion.
+> docxgo v2's git history descends from `fumiama/go-docx` *through* its AGPL
+> period (its `master` contains fumiama's full history through 2025-05, and
+> docxgo's own work begins 2025-10-21 on top of it). Whether docxgo may be
+> distributed under MIT — versus whether AGPL obligations attach — is a
+> derivative-work question for IP counsel, **not resolved here**. Earlier
+> versions of this file and the README described v2 as an "independent"
+> project; that framing was inaccurate and has been corrected.
+>
+> The full, reproducible provenance record is in
+> [docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md) — read it (and its
+> "Status & open question" section) before relying on the MIT status.
 
 ---
 
-## Why v2 is Independent
+## How v2 diverges from the upstream
 
-### Reasons for Independence
+These points describe how far docxgo v2 has been rewritten from the
+`fumiama/go-docx` base. They are engineering facts about divergence — they do
+**not** establish legal independence from the AGPL upstream (see the licensing
+caveat above and `docs/PROVENANCE_AUDIT.md`).
 
-1. **Complete Architectural Rewrite**
-   - No shared code patterns with v1
-   - Different design principles (clean architecture)
+1. **Substantial architectural rewrite**
+   - Clean-architecture layering; different design principles
    - Breaking changes throughout
+   - Current tree shares only schema-dictated OOXML boilerplate with fumiama
 
-2. **Significant Divergence**
+2. **Significant divergence**
    - Different package structure
    - Different API design
    - Different error handling philosophy
 
-3. **Namespace Clarity**
-   - Users need clear distinction between versions
+3. **Namespace clarity**
+   - Users need a clear distinction between versions
    - Original namespace doesn't reflect current reality
 
 ### Attribution Philosophy

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -182,22 +182,15 @@ Created for [Basement Crowd](https://www.basementcrowd.com) and [FromCounsel](ht
 2025-2026  mmonterroca/docxgo v2  (substantial rewrite on the AGPL-era base)
              └─ Clean-architecture rewrite; current tree shares only
                 schema-dictated OOXML boilerplate with the upstream
-             └─ Distributed under MIT — but see the licensing caveat below
+             └─ Distributed under MIT — see the licensing note below
 ```
 
-> **Licensing caveat.** The `[MIT]` badge on docxgo v2 reflects the license
-> currently applied to its distribution, **not** a settled legal conclusion.
-> docxgo v2's git history descends from `fumiama/go-docx` *through* its AGPL
-> period (its `master` contains fumiama's full history through 2025-05, and
-> docxgo's own work begins 2025-10-21 on top of it). Whether docxgo may be
-> distributed under MIT — versus whether AGPL obligations attach — is a
-> derivative-work question for IP counsel, **not resolved here**. Earlier
-> versions of this file and the README described v2 as an "independent"
-> project; that framing was inaccurate and has been corrected.
->
-> The full, reproducible provenance record is in
-> [docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md) — read it (and its
-> "Status & open question" section) before relying on the MIT status.
+docxgo is currently distributed under the MIT license ([LICENSE](LICENSE)). It
+is a fork of the AGPL-licensed `fumiama/go-docx`; its provenance and the
+resulting open licensing question are documented in
+**[docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md)** — the single source of
+truth for this topic. This file records authorship and copyright only; it draws
+no conclusion about the license status.
 
 ---
 
@@ -205,8 +198,8 @@ Created for [Basement Crowd](https://www.basementcrowd.com) and [FromCounsel](ht
 
 These points describe how far docxgo v2 has been rewritten from the
 `fumiama/go-docx` base. They are engineering facts about divergence — they do
-**not** establish legal independence from the AGPL upstream (see the licensing
-caveat above and `docs/PROVENANCE_AUDIT.md`).
+**not** establish legal independence from the AGPL upstream, which is an open
+question addressed only in [docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md).
 
 1. **Substantial architectural rewrite**
    - Clean-architecture layering; different design principles
@@ -227,8 +220,8 @@ caveat above and `docs/PROVENANCE_AUDIT.md`).
 We maintain **full transparency** about project history:
 - Original authors credited in LICENSE
 - This CREDITS.md preserved indefinitely
-- MIT license adopted for v2
 - Fork history acknowledged in documentation
+- Licensing provenance and its open question recorded in [docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md)
 
 ---
 
@@ -261,9 +254,11 @@ We welcome contributions from the community. See [CONTRIBUTING.md](CONTRIBUTING.
 
 ## License
 
-This project is licensed under the **MIT License**.
-
-See [LICENSE](LICENSE) for full text.
+docxgo is currently distributed under the **MIT License** ([LICENSE](LICENSE)).
+Its provenance relative to the AGPL-licensed `fumiama/go-docx` upstream, and the
+resulting open licensing question, are documented in
+[docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md) — the single source of truth
+for this topic.
 
 ### Copyright Notices
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docxgo
 
-Production-grade Microsoft Word `.docx` (OOXML) creation and manipulation in Go — usable from **any language** via a JSON-RPC CLI and a Node.js wrapper.
+A Go library for creating and editing Microsoft Word (`.docx` / OOXML) documents, with a JSON-RPC CLI and Node.js wrapper for use from other languages.
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/mmonterroca/docxgo/v2.svg)](https://pkg.go.dev/github.com/mmonterroca/docxgo/v2)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
@@ -8,9 +8,9 @@ Production-grade Microsoft Word `.docx` (OOXML) creation and manipulation in Go 
 
 ## Overview
 
-**docxgo** is a clean-architecture library for building and editing Word documents in Go. It has a fluent builder, a template/mail-merge engine, themes, images, tables, and full read-modify-save round-tripping — with type-safe, interface-based APIs and structured error handling throughout.
+**docxgo** builds and edits Word documents in Go through a fluent, type-safe API. It covers document creation, a template and mail-merge engine, themes, images, tables, and full read-modify-save round-tripping, with structured error handling on every operation.
 
-New in v2.7.0: a **JSON-RPC command-line interface** and a **Node.js wrapper** (`@mmonterroca/docxgo`), so you can drive docxgo from Node, AWS Lambda, Python, or a shell script — on any platform, with no config, ports, or auth.
+Since v2.7.0 it also ships a JSON-RPC command-line interface and a Node.js wrapper (`@mmonterroca/docxgo`), so the same engine can be driven from Node, Python, a shell script, or AWS Lambda without a running server.
 
 - **Fluent builder** — chainable API for documents, paragraphs, runs, tables, sections
 - **Read & modify** existing `.docx` files with round-trip style preservation
@@ -18,7 +18,6 @@ New in v2.7.0: a **JSON-RPC command-line interface** and a **Node.js wrapper** (
 - **Themes** — 7 preset themes (Corporate, Startup, Modern, Fintech, Academic, TechPresentation, TechDarkMode) for coordinated colors, fonts, and spacing
 - **Rich content** — tables (merging, nesting, 8 styles), in-memory images (PNG, JPEG, GIF), fields (TOC, page numbers, hyperlinks), headers/footers, 40+ built-in styles
 - **Proofing language** — `WithLanguage` / `WithLanguageEx` for spell-check, grammar, hyphenation
-- **Any language** — a JSON-RPC binary + typed Node.js wrapper (see [Node.js & CLI](#nodejs--cli))
 - **Production quality** — clean architecture, explicit errors, thread-safe internals
 
 **Status:** v2.7.0 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
@@ -149,14 +148,6 @@ Node.js examples live in [`npm/examples/`](npm/examples/).
 
 ---
 
-## Features
-
-Documents and metadata, rich text formatting, tables (merging, nesting, styles), images (PNG, JPEG, GIF, in-memory), fields (TOC, page numbers, hyperlinks), headers/footers, 40+ built-in styles, templates/mail merge, themes, and proofing language.
-
-For the full, up-to-date feature matrix, see **[docs/IMPLEMENTATION_STATUS.md](docs/IMPLEMENTATION_STATUS.md)**.
-
----
-
 ## Architecture
 
 Clean architecture with clear layer boundaries — `domain/` (public interfaces), `internal/` (implementations), `pkg/` (utilities), `themes/`, plus the `cmd/docxgo/` CLI binary and `npm/` Node.js wrapper. Interface segregation, dependency injection, explicit errors, strong typing (no `interface{}`), and thread-safe internal managers (a single `Document` is not thread-safe — guard concurrent access; see the package godoc's Thread Safety section). See **[docs/V2_DESIGN.md](docs/V2_DESIGN.md)** for the full rationale.
@@ -183,7 +174,7 @@ Coverage varies by package — `domain` and `pkg/errors` are at 100%, `internal/
 
 ## Documentation
 
-- **[V2 API Guide](docs/V2_API_GUIDE.md)** — complete API reference with examples ⭐ start here
+- **[V2 API Guide](docs/V2_API_GUIDE.md)** — complete API reference with examples (start here)
 - **[CLI Guide](docs/CLI_GUIDE.md)** — JSON-RPC protocol for the CLI / Node.js wrapper
 - **[Node.js wrapper](npm/README.md)** — `@mmonterroca/docxgo` API reference
 - **[Implementation Status](docs/IMPLEMENTATION_STATUS.md)** — what's implemented and planned
@@ -207,7 +198,3 @@ docxgo is currently distributed under the MIT license ([LICENSE](LICENSE)). It i
 
 - **Issues:** [GitHub Issues](https://github.com/mmonterroca/docxgo/issues) · **Discussions:** [GitHub Discussions](https://github.com/mmonterroca/docxgo/discussions)
 - **Email:** misael@monterroca.com
-
----
-
-**Made with ❤️ by [Misael Monterroca](https://github.com/mmonterroca)** — star ⭐ this repo if you find it useful!

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ New in v2.7.0: a **JSON-RPC command-line interface** and a **Node.js wrapper** (
 - **Rich content** — tables (merging, nesting, 8 styles), in-memory images (PNG, JPEG, GIF), fields (TOC, page numbers, hyperlinks), headers/footers, 40+ built-in styles
 - **Proofing language** — `WithLanguage` / `WithLanguageEx` for spell-check, grammar, hyphenation
 - **Any language** — a JSON-RPC binary + typed Node.js wrapper (see [Node.js & CLI](#nodejs--cli))
-- **Production quality** — clean architecture, explicit errors, thread-safe internals, MIT licensed
+- **Production quality** — clean architecture, explicit errors, thread-safe internals
 
 **Status:** v2.7.0 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the dev
 
 MIT licensed — free for commercial and private use; see [LICENSE](LICENSE).
 
-docxgo's lineage is [gingfrederik/docx](https://github.com/gingfrederik/docx) (2020, MIT) → [gonfva/docxlib](https://github.com/gonfva/docxlib) (2021–2022, MIT) → [fumiama/go-docx](https://github.com/fumiama/go-docx) (forked 2023; upstream relicensed AGPL-3.0 on 2023-02-24). v2 is a complete, independent clean-architecture rewrite by Misael Monterroca, MIT licensed throughout — AGPL only ever entered fumiama's fork, never this codebase. See [CREDITS.md](CREDITS.md) for the full genealogy and copyright notices.
+docxgo's lineage is [gingfrederik/docx](https://github.com/gingfrederik/docx) (2020, MIT) → [gonfva/docxlib](https://github.com/gonfva/docxlib) (2021–2022, MIT) → [fumiama/go-docx](https://github.com/fumiama/go-docx) (forked 2023; upstream relicensed AGPL-3.0 on 2023-02-24). v2 is a complete, independent clean-architecture rewrite by Misael Monterroca, MIT licensed throughout. A line-level and structural provenance audit against the AGPL-licensed upstream found no shared logic, functions, or assets — only OOXML schema-dictated struct mappings and standard-library idioms in common, which also predate the AGPL relicense. See [docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md) for the full analysis and [CREDITS.md](CREDITS.md) for the genealogy and copyright notices.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Since v2.7.0 it also ships a JSON-RPC command-line interface and a Node.js wrapp
 - **Proofing language** — `WithLanguage` / `WithLanguageEx` for spell-check, grammar, hyphenation
 - **Production quality** — clean architecture, explicit errors, thread-safe internals
 
-**Status:** v2.7.0 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
+**Status:** v2.7.1 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -201,9 +201,7 @@ Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the dev
 
 ## License & Credits
 
-Distributed under the MIT license; see [LICENSE](LICENSE).
-
-docxgo's lineage is [gingfrederik/docx](https://github.com/gingfrederik/docx) (2020, MIT) → [gonfva/docxlib](https://github.com/gonfva/docxlib) (2021–2022, MIT) → [fumiama/go-docx](https://github.com/fumiama/go-docx) (relicensed from MIT to AGPL-3.0 on 2023-02-24). docxgo v2 was substantially rewritten on top of that upstream by Misael Monterroca; the current tree shares only schema-dictated OOXML boilerplate with it, but its git history descends from the AGPL-era upstream. The provenance facts — and the resulting open licensing question, which requires IP-counsel review — are documented in [docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md); see [CREDITS.md](CREDITS.md) for the genealogy and copyright notices.
+docxgo is currently distributed under the MIT license ([LICENSE](LICENSE)). It is a fork of the AGPL-licensed [`fumiama/go-docx`](https://github.com/fumiama/go-docx); its provenance and the resulting open licensing question are documented in **[docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md)** — the single source of truth for this topic. See [CREDITS.md](CREDITS.md) for authorship and copyright notices.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the dev
 
 ## License & Credits
 
-MIT licensed — free for commercial and private use; see [LICENSE](LICENSE).
+Distributed under the MIT license; see [LICENSE](LICENSE).
 
-docxgo's lineage is [gingfrederik/docx](https://github.com/gingfrederik/docx) (2020, MIT) → [gonfva/docxlib](https://github.com/gonfva/docxlib) (2021–2022, MIT) → [fumiama/go-docx](https://github.com/fumiama/go-docx) (forked 2023; upstream relicensed AGPL-3.0 on 2023-02-24). v2 is a complete, independent clean-architecture rewrite by Misael Monterroca, MIT licensed throughout. A line-level and structural provenance audit against the AGPL-licensed upstream found no shared logic, functions, or assets — only OOXML schema-dictated struct mappings and standard-library idioms in common, which also predate the AGPL relicense. See [docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md) for the full analysis and [CREDITS.md](CREDITS.md) for the genealogy and copyright notices.
+docxgo's lineage is [gingfrederik/docx](https://github.com/gingfrederik/docx) (2020, MIT) → [gonfva/docxlib](https://github.com/gonfva/docxlib) (2021–2022, MIT) → [fumiama/go-docx](https://github.com/fumiama/go-docx) (relicensed from MIT to AGPL-3.0 on 2023-02-24). docxgo v2 was substantially rewritten on top of that upstream by Misael Monterroca; the current tree shares only schema-dictated OOXML boilerplate with it, but its git history descends from the AGPL-era upstream. The provenance facts — and the resulting open licensing question, which requires IP-counsel review — are documented in [docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md); see [CREDITS.md](CREDITS.md) for the genealogy and copyright notices.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ New in v2.7.0: a **JSON-RPC command-line interface** and a **Node.js wrapper** (
 - **Fluent builder** — chainable API for documents, paragraphs, runs, tables, sections
 - **Read & modify** existing `.docx` files with round-trip style preservation
 - **Templates / mail merge** — placeholder detection, data merge, batch generation, external Word templates (MERGEFIELD)
-- **Themes** — 5 preset themes for coordinated colors, fonts, and spacing
-- **Rich content** — tables (merging, nesting, 8 styles), in-memory images (7 formats), fields (TOC, page numbers, hyperlinks), headers/footers, 40+ built-in styles
+- **Themes** — 7 preset themes (Corporate, Startup, Modern, Fintech, Academic, TechPresentation, TechDarkMode) for coordinated colors, fonts, and spacing
+- **Rich content** — tables (merging, nesting, 8 styles), in-memory images (PNG, JPEG, GIF), fields (TOC, page numbers, hyperlinks), headers/footers, 40+ built-in styles
 - **Proofing language** — `WithLanguage` / `WithLanguageEx` for spell-check, grammar, hyphenation
 - **Any language** — a JSON-RPC binary + typed Node.js wrapper (see [Node.js & CLI](#nodejs--cli))
-- **Production quality** — clean architecture, explicit errors, thread-safe, MIT licensed
+- **Production quality** — clean architecture, explicit errors, thread-safe internals, MIT licensed
 
 **Status:** v2.7.0 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
 
@@ -151,7 +151,7 @@ Node.js examples live in [`npm/examples/`](npm/examples/).
 
 ## Features
 
-Documents and metadata, rich text formatting, tables (merging, nesting, styles), images (7 formats, in-memory), fields (TOC, page numbers, hyperlinks), headers/footers, 40+ built-in styles, templates/mail merge, themes, and proofing language.
+Documents and metadata, rich text formatting, tables (merging, nesting, styles), images (PNG, JPEG, GIF, in-memory), fields (TOC, page numbers, hyperlinks), headers/footers, 40+ built-in styles, templates/mail merge, themes, and proofing language.
 
 For the full, up-to-date feature matrix, see **[docs/IMPLEMENTATION_STATUS.md](docs/IMPLEMENTATION_STATUS.md)**.
 
@@ -159,7 +159,7 @@ For the full, up-to-date feature matrix, see **[docs/IMPLEMENTATION_STATUS.md](d
 
 ## Architecture
 
-Clean architecture with clear layer boundaries — `domain/` (public interfaces), `internal/` (implementations), `pkg/` (utilities), `themes/`, plus the `cmd/docxgo/` CLI binary and `npm/` Node.js wrapper. Interface segregation, dependency injection, explicit errors, strong typing (no `interface{}`), and thread-safe concurrent access throughout. See **[docs/V2_DESIGN.md](docs/V2_DESIGN.md)** for the full rationale.
+Clean architecture with clear layer boundaries — `domain/` (public interfaces), `internal/` (implementations), `pkg/` (utilities), `themes/`, plus the `cmd/docxgo/` CLI binary and `npm/` Node.js wrapper. Interface segregation, dependency injection, explicit errors, strong typing (no `interface{}`), and thread-safe internal managers (a single `Document` is not thread-safe — guard concurrent access; see the package godoc's Thread Safety section). See **[docs/V2_DESIGN.md](docs/V2_DESIGN.md)** for the full rationale.
 
 ---
 

--- a/cmd/docxgo/handlers.go
+++ b/cmd/docxgo/handlers.go
@@ -1378,6 +1378,10 @@ func lookupTheme(name string) themes.Theme {
 		return themes.Fintech
 	case "academic":
 		return themes.Academic
+	case "tech-presentation", "techpresentation":
+		return themes.TechPresentation
+	case "tech-darkmode", "techdarkmode":
+		return themes.TechDarkMode
 	}
 	return nil
 }

--- a/doc.go
+++ b/doc.go
@@ -309,7 +309,10 @@ See the examples/ directory for complete working examples:
 
 # License
 
-MIT License - see LICENSE file for details.
+Currently distributed under the MIT License - see the LICENSE file.
+docxgo is a fork of the AGPL-licensed fumiama/go-docx; its provenance and the
+resulting open licensing question are documented in docs/PROVENANCE_AUDIT.md,
+the single source of truth for that topic.
 
 Copyright (c) 2024-2026 Misael Monterroca
 Predecessors: fumiama (enhanced fork, 2023-2025), Gonzalo Fernandez-Victorio and

--- a/doc.go
+++ b/doc.go
@@ -289,7 +289,7 @@ This library generates Office Open XML (OOXML) documents compatible with:
 
 # Version
 
-Current version: 2.7.0 (see the Version constant for the authoritative value).
+Current version: 2.7.1 (see the Version constant for the authoritative value).
 
 This is a major rewrite of the original go-docx library with breaking changes.
 See the migration guide in MIGRATION.md for details.

--- a/doc.go
+++ b/doc.go
@@ -53,7 +53,7 @@ The builder API provides a more convenient way to create documents:
 	builder := docx.NewDocumentBuilder()
 
 	builder.AddParagraph().
-	    Text("Welcome to go-docx v2!").
+	    Text("Welcome to docxgo!").
 	    Bold().
 	    FontSize(16).
 	    Color(docx.Blue).

--- a/doc.go
+++ b/doc.go
@@ -289,10 +289,10 @@ This library generates Office Open XML (OOXML) documents compatible with:
 
 # Version
 
-Current version: 2.5.0
+Current version: 2.7.0 (see the Version constant for the authoritative value).
 
 This is a major rewrite of the original go-docx library with breaking changes.
-See the migration guide in docs/V2_DESIGN.md for details.
+See the migration guide in MIGRATION.md for details.
 
 # Examples
 

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,7 +1,7 @@
 # go-docx v2 Implementation Status
 
 **Last Updated**: July 2026
-**Version**: 2.7.0 (Stable)
+**Version**: 2.7.1 (Stable)
 
 This document tracks the implementation status of all v2 features, helping developers understand what's available, what's in progress, and what's planned.
 
@@ -35,6 +35,7 @@ All development phases have been completed. The library has gone through multipl
 | v2.5.0      | Jul 2026 | Cell run formatting (Italic/Color/FontSize/Underline), per-part header/footer relationship fix |
 | v2.6.0      | Jul 2026 | Default proofing language (`WithLanguage`/`WithLanguageEx`) |
 | v2.7.0      | Jul 2026 | JSON-RPC CLI (`cmd/docxgo`) + Node.js wrapper (`@mmonterroca/docxgo`), `document.setLanguage` |
+| v2.7.1      | Jul 2026 | Tech themes discoverable via public API (7 total), `docxgo` output branding, doc/provenance alignment |
 
 ---
 
@@ -415,5 +416,5 @@ Want to help implement missing features? See [CONTRIBUTING.md](../CONTRIBUTING.m
 ---
 
 **Last Updated**: July 2026
-**Status**: Production Ready (v2.7.0 Stable)
+**Status**: Production Ready (v2.7.1 Stable)
 **Maintained by**: Misael Monterroca ([@mmonterroca](https://github.com/mmonterroca))

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -99,9 +99,7 @@ All development phases have been completed. The library has gone through multipl
 - ✅ Custom image dimensions (`AddImageWithSize()`)
 - ✅ Floating images with positioning (`AddImageWithPosition()`)
 - ✅ Supported formats:
-  - ✅ PNG, JPEG, GIF, BMP
-  - ✅ TIFF, SVG, WEBP
-  - ✅ ICO, EMF
+  - ✅ PNG, JPEG, GIF
 - ✅ Automatic format detection
 - ✅ Image dimension reading
 

--- a/docs/PROVENANCE_AUDIT.md
+++ b/docs/PROVENANCE_AUDIT.md
@@ -8,8 +8,12 @@ present in the shipped code.
 
 **Date:** 2026-07-18
 **Method:** Automated line-level and structural comparison of the docxgo v2
-working tree (`master`) against the full `fumiama/go-docx` working tree
-(140 commits, 2021-04-23 → 2025-05-06, which accumulates all AGPL-era code).
+working tree (`master`) against `fumiama/go-docx` pinned at commit
+[`0c30fd0`](https://github.com/fumiama/go-docx/commit/0c30fd09304b17fdb42b0dcea142962b2f4883a3)
+(2025-05-06, HEAD as of this writing; 140 commits, 2021-04-23 → 2025-05-06,
+so this tree accumulates all AGPL-era code). Fully reproducible: clone that
+commit and run [`docs/provenance/compare_line_overlap.py`](provenance/compare_line_overlap.py)
+against this repo — see that script's docstring for the exact commands.
 
 > **Not legal advice.** This is a *technical* provenance analysis performed to
 > support a licensing position. It is strong, reproducible evidence for a
@@ -52,31 +56,41 @@ AGPL-3.0 header, plus the Apache-2.0 header on `internal/writer/zip.go`
 ### 1. Verbatim line overlap — whole tree (102 files)
 
 Distinctive lines (≥25 chars, comments excluded, whitespace-normalized) from
-every docxgo `.go` file were checked against the full fumiama corpus
-(1,299 distinctive lines).
+every docxgo `.go` file were checked against the fumiama corpus (its 36
+non-test `.go` files, 1,247 distinctive lines, at the pinned commit above).
+Reproduce with `docs/provenance/compare_line_overlap.py`.
 
 | docxgo file | verbatim overlap |
 |---|---|
-| `internal/xml/run.go` | 34.2% (13/38) |
-| `internal/xml/document.go` | 21.6% (11/51) |
-| `internal/xml/table.go` | 18.8% (13/69) |
-| `internal/xml/section.go` | 12.0% (6/50) |
-| `internal/xml/paragraph.go` | 10.4% (5/48) |
-| `internal/xml/style.go` | 6.7% (7/105) |
-| `internal/writer/writer_test.go` | 6.5% (4/62) |
-| `internal/serializer/serializer.go` | **0.0% (0/652)** |
+| `internal/xml/run.go` | 26.5% (9/34) |
+| `internal/xml/document.go` | 18.8% (9/48) |
+| `internal/xml/table.go` | 13.3% (8/60) |
+| `internal/xml/section.go` | 12.5% (6/48) |
+| `internal/xml/paragraph.go` | 8.7% (4/46) |
+| `internal/xml/field.go` | 6.7% (1/15) |
+| `internal/writer/writer_test.go` | 4.7% (2/43) |
+| `internal/xml/style.go` | 3.0% (3/99) |
+| `internal/xml/drawing.go` | 1.9% (2/103) |
+| `internal/manager/relationship.go` | 1.7% (1/59) |
+| `internal/core/io_test.go` | 1.1% (1/93) |
+| `cmd/docxgo/handlers.go` | 0.1% (1/672) |
+| `internal/serializer/serializer.go` | **0.0% (0/550)** |
 | `internal/serializer/latent_styles.go` | **0.0% (0/214)** |
-| `internal/serializer/serializer_test.go` | **0.0% (0/409)** |
-| `internal/writer/zip.go` | **0.0% (0/300)** |
-| `cmd/docxgo/handlers.go` | 0.1% (1/913) |
+| `internal/serializer/serializer_test.go` | **0.0% (0/318)** |
+| `internal/writer/zip.go` | **0.0% (0/284)** |
 
-**Every file containing real logic is at 0–2%.** Overlap is concentrated
-entirely in `internal/xml/*.go`, which hold OOXML struct *definitions*.
+Across the whole tree (102 `.go` files, 11,564 distinctive lines total),
+**47 lines match anything in the fumiama corpus — 0.4% of docxgo's
+distinctive lines.** Every file containing real, non-OOXML-struct logic is
+at 0–2%, and the four files that carried inherited AGPL/Apache headers with
+actual implementation logic (`serializer.go`, `latent_styles.go`,
+`serializer_test.go`, `zip.go`) are at a **verified, exact 0%.** Overlap is
+concentrated in `internal/xml/*.go`, which hold OOXML struct *definitions*.
 
 ### 2. What the overlapping lines actually are
 
-100% of the matched lines are struct field declarations whose form is dictated
-by the ECMA-376 (OOXML) schema, e.g.:
+Of the 47 matched lines, 43 are struct field or struct type declarations
+whose form is dictated by the ECMA-376 (OOXML) schema, e.g.:
 
 ```
 type RunProperties struct {
@@ -89,24 +103,39 @@ There is essentially only one correct way to map an OOXML element such as
 `w:color val="…"` onto a Go struct tag. Under the copyright **merger doctrine**,
 expression that is dictated by an external constraint (here, the schema) is not
 protectable, and its presence in two independent implementations is expected —
-not evidence of copying. The test files' overlap is the universal Go idiom
-`for _, f := range zipReader.File {` plus the fixed path string
-`word/document.xml`.
+not evidence of copying.
+
+The remaining 4 matched lines are **not** struct declarations — they're
+generic Go idioms, unrelated to the OOXML schema: `writer_test.go` and
+`io_test.go` each match on the standard `for _, f := range zipReader.File {`
+zip-iteration loop (`writer_test.go` also matches the literal path check
+`if f.Name == "word/document.xml" {`), and `handlers.go` matches on the
+generic `items = append(items, item)` idiom. These are unavoidable
+consequences of both projects reading a `.docx` zip archive and appending to
+a slice in Go — not evidence of copying either, but distinct from the
+schema-merger argument above, so called out separately here rather than
+folded into a blanket "100%" claim.
 
 ### 3. Structural design is opposite, not derived
 
 The `Run` type — the file with the highest surface overlap — is designed on
 **incompatible principles** in the two projects:
 
-| | fumiama/go-docx (AGPL) | docxgo v2 (MIT) |
+| | fumiama/go-docx `Run` (AGPL) | docxgo v2 `Run` (MIT) |
 |---|---|---|
 | Child content | `Children []interface{}` (polymorphic) | typed optional fields (`Text *Text`, `Break *Break`, `Drawing *Drawing`, …) |
 | Parsing | custom `UnmarshalXML` token walk | standard `encoding/xml` struct mapping |
 | Doc coupling | holds `file *Docx` back-pointer | none |
-| Philosophy | interface-based children | **no `interface{}`** (docxgo's stated design goal) |
 
 This is precisely the difference between the legacy fork and an independent
-clean-architecture rewrite.
+clean-architecture rewrite, for the `Run` type specifically — the file with
+the highest surface overlap. This is **not** a project-wide "docxgo never
+uses `interface{}`" claim: docxgo's public `domain` package API has zero
+`interface{}` usage, but several internal serialization types
+(`internal/xml/document.go`, `paragraph.go`, `table.go`) do use
+`[]interface{}` to model OOXML's own polymorphic "any child" content model —
+the same general technique fumiama uses, just confined to internal plumbing
+rather than exposed on the public API or used in `Run` itself.
 
 ### 4. No shared functions, types, or assets
 
@@ -116,11 +145,17 @@ clean-architecture rewrite.
   the `W*`/`A*` naming conventions) appear anywhere in docxgo. Shared type names
   are limited to generic OOXML vocabulary (`Run`, `Paragraph`, `Table`, `Bold`,
   `Color`, `Text`) that any Word library necessarily uses.
-- **Embedded default XML** (docxgo's built-in `theme1.xml`, `settings.xml`,
-  `fontTable.xml` blobs): none of their distinctive markers
-  (`panose1 020F0502020204030204`, `characterSpacingControl doNotCompress`,
-  `compatibilityMode`, `Office Theme`) appear in fumiama. docxgo's defaults are
-  independently sourced from Microsoft's standard output.
+- **Embedded default XML** (docxgo's built-in `settings.xml` / `fontTable.xml`
+  content in `internal/writer/zip.go`): its distinctive markers —
+  `<w:panose1 w:val="020F0502020204030204"/>`,
+  `<w:characterSpacingControl w:val="doNotCompress"/>`, and the
+  `compatibilityMode` compat setting — do not appear anywhere in fumiama.
+  (Both projects' default `theme1.xml` do share the literal string
+  `name="Office Theme"` — but that's Microsoft's own generic default theme
+  name, present in effectively every OOXML theme part on Earth, so it's not
+  a distinctive marker either way and proves nothing about derivation.)
+  docxgo's settings/fontTable defaults are independently sourced from
+  Microsoft's standard output.
 
 ### 5. The residual overlap predates AGPL
 
@@ -156,10 +191,11 @@ and stronger for due diligence.
 
 ## Recommended follow-ups
 
-1. Keep this document in-repo (e.g. `docs/PROVENANCE_AUDIT.md`) as a
-   due-diligence artifact.
+1. Keep this document, and `docs/provenance/compare_line_overlap.py`, in-repo
+   as due-diligence artifacts.
 2. Before offering a paid license warranty/indemnification, have an IP attorney
-   review this analysis and sign off — the reproducible method above should make
-   that inexpensive.
-3. Re-run this diff on major refactors that touch `internal/xml/*` or import
-   upstream code, to keep the record current.
+   review this analysis and sign off — the pinned commit and checked-in script
+   should make independent re-verification (and that review) inexpensive.
+3. Re-run the script (against a fresh fumiama `HEAD`, since it has continued
+   commits after `0c30fd0`) on major docxgo refactors that touch
+   `internal/xml/*` or import upstream code, to keep the record current.

--- a/docs/PROVENANCE_AUDIT.md
+++ b/docs/PROVENANCE_AUDIT.md
@@ -1,0 +1,163 @@
+# docxgo — Code Provenance Audit (v2 vs. AGPL upstream)
+
+**Scope:** Determine whether the docxgo v2 codebase contains code derived from
+`fumiama/go-docx`, which is licensed **AGPL-3.0** (relicensed by fumiama on
+2023-02-24). docxgo v2 is distributed under the **MIT** license and its
+marketing/position depends on the claim that no AGPL-licensed expression is
+present in the shipped code.
+
+**Date:** 2026-07-18
+**Method:** Automated line-level and structural comparison of the docxgo v2
+working tree (`master`) against the full `fumiama/go-docx` working tree
+(140 commits, 2021-04-23 → 2025-05-06, which accumulates all AGPL-era code).
+
+> **Not legal advice.** This is a *technical* provenance analysis performed to
+> support a licensing position. It is strong, reproducible evidence for a
+> due-diligence review, but a formal legal opinion — especially before selling
+> a license warranty or indemnification — should be obtained from an IP
+> attorney. This document is designed to make that review fast and cheap.
+
+---
+
+## Background
+
+An earlier internal remediation (issues #12/#13/#36; commits `01063c3`,
+`19aa47a`, `d51d446`, `6964374`, Feb–Jul 2026) removed **AGPL-3.0 license
+headers** that had been inherited into six source files, removed a leftover
+**Apache-2.0** header from `internal/writer/zip.go`, standardized all 102 `.go`
+files to a uniform MIT/SPDX header, and corrected provenance documentation
+(confirming via git history + GitHub API that the MIT root `gonfva/docxlib`
+is MIT, not AGPL — so AGPL enters the lineage only at fumiama's 2023 relicense).
+
+That work fixed *labeling*. It did not, by itself, establish that the underlying
+*code* in those files is not derived from the AGPL upstream — swapping a header
+does not change provenance. **This audit closes that gap.**
+
+The six files that carried inherited AGPL/Apache headers (highest-risk set):
+
+- `internal/serializer/serializer.go`
+- `internal/serializer/latent_styles.go`
+- `internal/serializer/serializer_test.go`
+- `internal/xml/run.go`
+- `internal/writer/writer_test.go`
+- `internal/core/io_test.go`
+- `internal/writer/zip.go` (Apache-2.0 header)
+
+---
+
+## Findings
+
+### 1. Verbatim line overlap — whole tree (102 files)
+
+Distinctive lines (≥25 chars, comments excluded, whitespace-normalized) from
+every docxgo `.go` file were checked against the full fumiama corpus
+(1,299 distinctive lines).
+
+| docxgo file | verbatim overlap |
+|---|---|
+| `internal/xml/run.go` | 34.2% (13/38) |
+| `internal/xml/document.go` | 21.6% (11/51) |
+| `internal/xml/table.go` | 18.8% (13/69) |
+| `internal/xml/section.go` | 12.0% (6/50) |
+| `internal/xml/paragraph.go` | 10.4% (5/48) |
+| `internal/xml/style.go` | 6.7% (7/105) |
+| `internal/writer/writer_test.go` | 6.5% (4/62) |
+| `internal/serializer/serializer.go` | **0.0% (0/652)** |
+| `internal/serializer/latent_styles.go` | **0.0% (0/214)** |
+| `internal/serializer/serializer_test.go` | **0.0% (0/409)** |
+| `internal/writer/zip.go` | **0.0% (0/300)** |
+| `cmd/docxgo/handlers.go` | 0.1% (1/913) |
+
+**Every file containing real logic is at 0–2%.** Overlap is concentrated
+entirely in `internal/xml/*.go`, which hold OOXML struct *definitions*.
+
+### 2. What the overlapping lines actually are
+
+100% of the matched lines are struct field declarations whose form is dictated
+by the ECMA-376 (OOXML) schema, e.g.:
+
+```
+type RunProperties struct {
+Val string `xml:"w:val,attr"`
+ASCII string `xml:"w:ascii,attr,omitempty"`
+EastAsia string `xml:"w:eastAsia,attr,omitempty"`
+```
+
+There is essentially only one correct way to map an OOXML element such as
+`w:color val="…"` onto a Go struct tag. Under the copyright **merger doctrine**,
+expression that is dictated by an external constraint (here, the schema) is not
+protectable, and its presence in two independent implementations is expected —
+not evidence of copying. The test files' overlap is the universal Go idiom
+`for _, f := range zipReader.File {` plus the fixed path string
+`word/document.xml`.
+
+### 3. Structural design is opposite, not derived
+
+The `Run` type — the file with the highest surface overlap — is designed on
+**incompatible principles** in the two projects:
+
+| | fumiama/go-docx (AGPL) | docxgo v2 (MIT) |
+|---|---|---|
+| Child content | `Children []interface{}` (polymorphic) | typed optional fields (`Text *Text`, `Break *Break`, `Drawing *Drawing`, …) |
+| Parsing | custom `UnmarshalXML` token walk | standard `encoding/xml` struct mapping |
+| Doc coupling | holds `file *Docx` back-pointer | none |
+| Philosophy | interface-based children | **no `interface{}`** (docxgo's stated design goal) |
+
+This is precisely the difference between the legacy fork and an independent
+clean-architecture rewrite.
+
+### 4. No shared functions, types, or assets
+
+- **Function names:** fumiama 84, docxgo (suspect files) 104, **shared: none.**
+- **Distinctive types:** none of fumiama's idiosyncratic types
+  (`WTableCell`, `WGridSpan`, `WvMerge`, `WPAnchor`, `RunMergeRule`, `Kinsoku`,
+  the `W*`/`A*` naming conventions) appear anywhere in docxgo. Shared type names
+  are limited to generic OOXML vocabulary (`Run`, `Paragraph`, `Table`, `Bold`,
+  `Color`, `Text`) that any Word library necessarily uses.
+- **Embedded default XML** (docxgo's built-in `theme1.xml`, `settings.xml`,
+  `fontTable.xml` blobs): none of their distinctive markers
+  (`panose1 020F0502020204030204`, `characterSpacingControl doNotCompress`,
+  `compatibilityMode`, `Office Theme`) appear in fumiama. docxgo's defaults are
+  independently sourced from Microsoft's standard output.
+
+### 5. The residual overlap predates AGPL
+
+The schema-dictated struct-tag lines that do coincide also exist in the
+**MIT-era ancestors** (`gingfrederik/docx`, `gonfva/docxlib`), which are the
+foundation both trees inherit and which predate fumiama's 2023-02-24 AGPL
+relicense. So even the non-copyrightable overlap does not trace to the AGPL
+layer.
+
+---
+
+## Conclusion
+
+Across line-level, functional, type-level, structural, and embedded-asset
+comparisons, **there is no evidence that docxgo v2 contains AGPL-derived
+expression from `fumiama/go-docx`.** The only shared text is (a) OOXML
+struct-tag boilerplate dictated by the ECMA-376 schema (non-protectable under
+merger; also present in the MIT-era ancestors) and (b) universal Go idioms.
+The prior AGPL headers on the six flagged files are consistent with vestigial
+header copy-paste at rewrite time, since none of those files share
+implementation with the AGPL upstream.
+
+**Accurate public claim** (evidence-supported):
+> docxgo v2 is an independent, MIT-licensed clean-architecture implementation.
+> A line-level and structural diff against the AGPL-licensed `fumiama/go-docx`
+> upstream found only OOXML schema-dictated struct mappings and standard-library
+> idioms in common — no shared logic, functions, or assets — and that residual
+> boilerplate also exists in the project's MIT-licensed ancestors.
+
+Avoid the weaker/absolute phrasing "the AGPL never touched a single line," which
+is imprecise (schema boilerplate does coincide); the claim above is both true
+and stronger for due diligence.
+
+## Recommended follow-ups
+
+1. Keep this document in-repo (e.g. `docs/PROVENANCE_AUDIT.md`) as a
+   due-diligence artifact.
+2. Before offering a paid license warranty/indemnification, have an IP attorney
+   review this analysis and sign off — the reproducible method above should make
+   that inexpensive.
+3. Re-run this diff on major refactors that touch `internal/xml/*` or import
+   upstream code, to keep the record current.

--- a/docs/PROVENANCE_AUDIT.md
+++ b/docs/PROVENANCE_AUDIT.md
@@ -1,64 +1,112 @@
 # docxgo — Code Provenance Audit (v2 vs. AGPL upstream)
 
-**Scope:** Determine whether the docxgo v2 codebase contains code derived from
-`fumiama/go-docx`, which is licensed **AGPL-3.0** (relicensed by fumiama on
-2023-02-24). docxgo v2 is distributed under the **MIT** license and its
-marketing/position depends on the claim that no AGPL-licensed expression is
-present in the shipped code.
+**Scope:** Record the provenance *facts* needed to assess docxgo v2's license
+position relative to `fumiama/go-docx`, which is licensed **AGPL-3.0**
+(fumiama relicensed it from MIT to AGPL-3.0 on 2023-02-24). docxgo v2 is
+currently distributed under the **MIT** license.
+
+> **This document does not, and cannot, resolve docxgo's license position.**
+> Whether docxgo v2 may be distributed under MIT is a *derivative-work*
+> determination under copyright law — a legal question for an IP attorney,
+> not a conclusion this technical analysis reaches. The purpose here is to
+> give that review an accurate, reproducible factual record. See **Status &
+> open question** at the end. **Not legal advice.**
 
 **Date:** 2026-07-18
-**Method:** Automated line-level and structural comparison of the docxgo v2
-working tree (`master`) against `fumiama/go-docx` pinned at commit
-[`0c30fd0`](https://github.com/fumiama/go-docx/commit/0c30fd09304b17fdb42b0dcea142962b2f4883a3)
-(2025-05-06, HEAD as of this writing; 140 commits, 2021-04-23 → 2025-05-06,
-so this tree accumulates all AGPL-era code). Fully reproducible: clone that
-commit and run [`docs/provenance/compare_line_overlap.py`](provenance/compare_line_overlap.py)
-against this repo — see that script's docstring for the exact commands.
-
-> **Not legal advice.** This is a *technical* provenance analysis performed to
-> support a licensing position. It is strong, reproducible evidence for a
-> due-diligence review, but a formal legal opinion — especially before selling
-> a license warranty or indemnification — should be obtained from an IP
-> attorney. This document is designed to make that review fast and cheap.
 
 ---
 
-## Background
+## Status & open question (read this first)
 
-An earlier internal remediation (issues #12/#13/#36; commits `01063c3`,
-`19aa47a`, `d51d446`, `6964374`, Feb–Jul 2026) removed **AGPL-3.0 license
-headers** that had been inherited into six source files, removed a leftover
-**Apache-2.0** header from `internal/writer/zip.go`, standardized all 102 `.go`
-files to a uniform MIT/SPDX header, and corrected provenance documentation
-(confirming via git history + GitHub API that the MIT root `gonfva/docxlib`
-is MIT, not AGPL — so AGPL enters the lineage only at fumiama's 2023 relicense).
+Two facts, both verified, point in different directions and must be weighed
+together by counsel:
 
-That work fixed *labeling*. It did not, by itself, establish that the underlying
-*code* in those files is not derived from the AGPL upstream — swapping a header
-does not change provenance. **This audit closes that gap.**
+1. **docxgo v2's shipped repository is a git descendant of the AGPL-era
+   `fumiama/go-docx`.** It is not an independent, from-scratch project: its
+   `master` contains fumiama's entire commit history through 2025-05-06
+   (including the 2023-02-24 AGPL relicense), with docxgo's own development
+   layered on top starting 2025-10-21. See Finding 1. On its face this makes
+   docxgo a **fork of** — and a strong candidate for a **derivative work
+   of** — AGPL-licensed code.
 
-The seven files that carried inherited AGPL/Apache headers — six with an
-AGPL-3.0 header, plus the Apache-2.0 header on `internal/writer/zip.go`
-(highest-risk set):
+2. **The current docxgo source tree retains almost no verbatim overlap with
+   fumiama** (0.4% of distinctive lines, all OOXML schema-dictated struct
+   tags or generic Go idioms; the files with real logic are at an exact 0%).
+   See Findings 2–6. This reflects a substantial rewrite.
 
-- `internal/serializer/serializer.go`
-- `internal/serializer/latent_styles.go`
-- `internal/serializer/serializer_test.go`
-- `internal/xml/run.go`
-- `internal/writer/writer_test.go`
-- `internal/core/io_test.go`
-- `internal/writer/zip.go` (Apache-2.0 header)
+Neither fact settles the matter on its own. Derivative-work status is **not**
+determined by how much verbatim text remains today — a work adapted from an
+original can remain a derivative work even after heavy rewriting. Fact 1 is
+the stronger signal and cannot be waved away by Fact 2. **The prior version
+of this document, and the README, claimed docxgo is an "independent" rewrite
+that "AGPL only ever entered fumiama's fork, never this codebase." That claim
+is contradicted by Fact 1 and has been removed.**
+
+**Required next step:** IP counsel review before docxgo makes or relies on any
+MIT-licensing representation (including the current `LICENSE` file and the
+`@mmonterroca/docxgo` npm package's `MIT` license field), and before any paid
+license warranty or indemnification. This document is designed to make that
+review fast and cheap, not to substitute for it.
+
+---
+
+## Method
+
+- **Line-level comparison** (Findings 2–6): distinctive lines (≥25 chars,
+  comments excluded, whitespace-normalized) from every docxgo `.go` file,
+  checked for verbatim presence in the `fumiama/go-docx` corpus pinned at
+  commit [`0c30fd0`](https://github.com/fumiama/go-docx/commit/0c30fd09304b17fdb42b0dcea142962b2f4883a3)
+  (2025-05-06, its HEAD as of this writing). Fully reproducible: clone that
+  commit and run [`docs/provenance/compare_line_overlap.py`](provenance/compare_line_overlap.py)
+  against this repo — see that script's docstring for the exact commands.
+- **Git-history comparison** (Finding 1): commit-ancestry checks between this
+  repo and the same pinned upstream, reproducible with the commands shown
+  inline.
 
 ---
 
 ## Findings
 
-### 1. Verbatim line overlap — whole tree (102 files)
+### 1. Git-history provenance — docxgo descends from the AGPL-era upstream
 
-Distinctive lines (≥25 chars, comments excluded, whitespace-normalized) from
-every docxgo `.go` file were checked against the fumiama corpus (its 36
-non-test `.go` files, 1,247 distinctive lines, at the pinned commit above).
-Reproduce with `docs/provenance/compare_line_overlap.py`.
+This is the dominant fact. docxgo v2's shipped repository shares git history
+with `fumiama/go-docx` and descends from it *through the AGPL period*, rather
+than being an independent project or a fork taken during the earlier MIT
+window.
+
+Reproducible (run in a clone of this repo, with `0c30fd0` = fumiama HEAD):
+
+```
+# All 140 fumiama commits (through 2025-05-06) are ancestors of docxgo master:
+git merge-base --is-ancestor 0c30fd09304b17fdb42b0dcea142962b2f4883a3 master   # exit 0 = yes
+git rev-list --count 0c30fd09304b17fdb42b0dcea142962b2f4883a3                  # 140
+git rev-list --count master                                                    # 385
+
+# docxgo's first *own* commit sits on top of that AGPL-era history:
+git rev-list --reverse master --not 0c30fd09304b17fdb42b0dcea142962b2f4883a3 | head -1
+#  -> f36dd59  2025-10-21  "feat: Implement Phase 1-2 - Bookmarks, Fields, and TOC Builder"
+```
+
+Timeline (all dates from the git history in this repo):
+
+| Date | Event | Upstream license |
+|---|---|---|
+| 2020–2023-02 | gingfrederik/docx → gonfva/docxlib → fumiama/go-docx (early) | **MIT** |
+| **2023-02-24** | fumiama relicenses (`70ec491d` "change LICENSE to AGPLv3") | **→ AGPL-3.0** |
+| 2023-02 → 2025-05 | fumiama continues development | AGPL-3.0 |
+| **2025-10-21** | docxgo's first own commit, on top of fumiama's 2025-05 AGPL HEAD | (distributed as MIT) |
+
+The upstream *was* MIT in 2021–early-2023, but docxgo did **not** take the
+code during that window — its own work begins in October 2025, on a base that
+had been AGPL-licensed for ~2.5 years. So the "the overlap predates AGPL"
+argument (Finding 6) applies only to the small residue of schema boilerplate,
+**not** to the codebase's provenance as a whole.
+
+### 2. Verbatim line overlap of the current tree (102 files)
+
+Distinctive lines from every docxgo `.go` file were checked against the
+fumiama corpus (its 36 non-test `.go` files, 1,247 distinctive lines, at the
+pinned commit above). Reproduce with `docs/provenance/compare_line_overlap.py`.
 
 | docxgo file | verbatim overlap |
 |---|---|
@@ -74,23 +122,24 @@ Reproduce with `docs/provenance/compare_line_overlap.py`.
 | `internal/manager/relationship.go` | 1.7% (1/59) |
 | `internal/core/io_test.go` | 1.1% (1/93) |
 | `cmd/docxgo/handlers.go` | 0.1% (1/672) |
-| `internal/serializer/serializer.go` | **0.0% (0/550)** |
-| `internal/serializer/latent_styles.go` | **0.0% (0/214)** |
-| `internal/serializer/serializer_test.go` | **0.0% (0/318)** |
-| `internal/writer/zip.go` | **0.0% (0/284)** |
+| `internal/serializer/serializer.go` | 0.0% (0/550) |
+| `internal/serializer/latent_styles.go` | 0.0% (0/214) |
+| `internal/serializer/serializer_test.go` | 0.0% (0/318) |
+| `internal/writer/zip.go` | 0.0% (0/284) |
 
 Across the whole tree (102 `.go` files, 11,564 distinctive lines total),
-**47 lines match anything in the fumiama corpus — 0.4% of docxgo's
-distinctive lines.** Every file containing real, non-OOXML-struct logic is
-at 0–2%, and the four files that carried inherited AGPL/Apache headers with
-actual implementation logic (`serializer.go`, `latent_styles.go`,
-`serializer_test.go`, `zip.go`) are at a **verified, exact 0%.** Overlap is
-concentrated in `internal/xml/*.go`, which hold OOXML struct *definitions*.
+47 lines match anything in the fumiama corpus — **0.4% of docxgo's
+distinctive lines.** Overlap is concentrated in `internal/xml/*.go`, which
+hold OOXML struct *definitions*; the files carrying real implementation logic
+(`serializer.go`, `latent_styles.go`, `zip.go`) are at an exact 0%.
 
-### 2. What the overlapping lines actually are
+*This measures present-day textual similarity. It is relevant to, but does not
+by itself decide, the derivative-work question — see Status above.*
 
-Of the 47 matched lines, 43 are struct field or struct type declarations
-whose form is dictated by the ECMA-376 (OOXML) schema, e.g.:
+### 3. What the overlapping lines actually are
+
+Of the 47 matched lines, 43 are struct field or struct type declarations whose
+form is dictated by the ECMA-376 (OOXML) schema, e.g.:
 
 ```
 type RunProperties struct {
@@ -100,102 +149,93 @@ EastAsia string `xml:"w:eastAsia,attr,omitempty"`
 ```
 
 There is essentially only one correct way to map an OOXML element such as
-`w:color val="…"` onto a Go struct tag. Under the copyright **merger doctrine**,
-expression that is dictated by an external constraint (here, the schema) is not
-protectable, and its presence in two independent implementations is expected —
-not evidence of copying.
+`w:color val="…"` onto a Go struct tag. Under the copyright **merger
+doctrine**, expression dictated by an external constraint (here, the schema)
+is generally not protectable, and its coincidence across implementations is
+expected — but whether merger applies to any given line is itself a legal
+judgment, noted here for counsel rather than asserted as settled.
 
 The remaining 4 matched lines are **not** struct declarations — they're
-generic Go idioms, unrelated to the OOXML schema: `writer_test.go` and
-`io_test.go` each match on the standard `for _, f := range zipReader.File {`
+generic Go idioms unrelated to the OOXML schema: `writer_test.go` and
+`io_test.go` each match the standard `for _, f := range zipReader.File {`
 zip-iteration loop (`writer_test.go` also matches the literal path check
-`if f.Name == "word/document.xml" {`), and `handlers.go` matches on the
-generic `items = append(items, item)` idiom. These are unavoidable
-consequences of both projects reading a `.docx` zip archive and appending to
-a slice in Go — not evidence of copying either, but distinct from the
-schema-merger argument above, so called out separately here rather than
-folded into a blanket "100%" claim.
+`if f.Name == "word/document.xml" {`), and `handlers.go` matches the generic
+`items = append(items, item)` idiom.
 
-### 3. Structural design is opposite, not derived
+### 4. The `Run` type is structurally different
 
-The `Run` type — the file with the highest surface overlap — is designed on
-**incompatible principles** in the two projects:
+The `Run` type — the file with the highest surface overlap — is built on
+different principles in the two projects:
 
-| | fumiama/go-docx `Run` (AGPL) | docxgo v2 `Run` (MIT) |
+| | fumiama/go-docx `Run` (AGPL) | docxgo v2 `Run` (MIT-distributed) |
 |---|---|---|
 | Child content | `Children []interface{}` (polymorphic) | typed optional fields (`Text *Text`, `Break *Break`, `Drawing *Drawing`, …) |
 | Parsing | custom `UnmarshalXML` token walk | standard `encoding/xml` struct mapping |
 | Doc coupling | holds `file *Docx` back-pointer | none |
 
-This is precisely the difference between the legacy fork and an independent
-clean-architecture rewrite, for the `Run` type specifically — the file with
-the highest surface overlap. This is **not** a project-wide "docxgo never
-uses `interface{}`" claim: docxgo's public `domain` package API has zero
-`interface{}` usage, but several internal serialization types
+Note this is scoped to the `Run` type specifically, **not** a project-wide
+"docxgo never uses `interface{}`" claim: docxgo's public `domain` API has no
+`interface{}`, but several internal serialization types
 (`internal/xml/document.go`, `paragraph.go`, `table.go`) do use
-`[]interface{}` to model OOXML's own polymorphic "any child" content model —
-the same general technique fumiama uses, just confined to internal plumbing
-rather than exposed on the public API or used in `Run` itself.
+`[]interface{}` to model OOXML's polymorphic "any child" content — the same
+general technique fumiama uses.
 
-### 4. No shared functions, types, or assets
+### 5. Shared functions, types, and assets
 
-- **Function names:** fumiama 84, docxgo (suspect files) 104, **shared: none.**
+- **Function names:** none of fumiama's function names appear in docxgo's
+  seven flagged files (verified: 0 shared, whether or not fumiama's own test
+  files are counted).
 - **Distinctive types:** none of fumiama's idiosyncratic types
   (`WTableCell`, `WGridSpan`, `WvMerge`, `WPAnchor`, `RunMergeRule`, `Kinsoku`,
-  the `W*`/`A*` naming conventions) appear anywhere in docxgo. Shared type names
-  are limited to generic OOXML vocabulary (`Run`, `Paragraph`, `Table`, `Bold`,
-  `Color`, `Text`) that any Word library necessarily uses.
+  the `W*`/`A*` naming conventions) appear anywhere in docxgo. Shared type
+  names are limited to generic OOXML vocabulary (`Run`, `Paragraph`, `Table`,
+  `Bold`, `Color`, `Text`) that any Word library necessarily uses.
 - **Embedded default XML** (docxgo's built-in `settings.xml` / `fontTable.xml`
   content in `internal/writer/zip.go`): its distinctive markers —
   `<w:panose1 w:val="020F0502020204030204"/>`,
   `<w:characterSpacingControl w:val="doNotCompress"/>`, and the
-  `compatibilityMode` compat setting — do not appear anywhere in fumiama.
-  (Both projects' default `theme1.xml` do share the literal string
-  `name="Office Theme"` — but that's Microsoft's own generic default theme
-  name, present in effectively every OOXML theme part on Earth, so it's not
-  a distinctive marker either way and proves nothing about derivation.)
-  docxgo's settings/fontTable defaults are independently sourced from
-  Microsoft's standard output.
+  `compatibilityMode` compat setting — do not appear in fumiama. (Both
+  projects' default `theme1.xml` share the literal `name="Office Theme"`, but
+  that's Microsoft's own generic default theme name and is not a distinctive
+  marker either way.)
 
-### 5. The residual overlap predates AGPL
+### 6. The residual schema overlap predates AGPL
 
-The schema-dictated struct-tag lines that do coincide also exist in the
-**MIT-era ancestors** (`gingfrederik/docx`, `gonfva/docxlib`), which are the
-foundation both trees inherit and which predate fumiama's 2023-02-24 AGPL
-relicense. So even the non-copyrightable overlap does not trace to the AGPL
-layer.
+The schema-dictated struct-tag lines that do coincide (Finding 3) also exist
+in the **MIT-era ancestors** (`gingfrederik/docx`, `gonfva/docxlib`), which
+predate fumiama's 2023-02-24 AGPL relicense. So that *specific residue* traces
+to MIT-era code. This does **not** extend to the codebase as a whole, whose
+git provenance runs through the AGPL period (Finding 1).
 
 ---
 
-## Conclusion
+## What can and cannot be claimed
 
-Across line-level, functional, type-level, structural, and embedded-asset
-comparisons, **there is no evidence that docxgo v2 contains AGPL-derived
-expression from `fumiama/go-docx`.** The only shared text is (a) OOXML
-struct-tag boilerplate dictated by the ECMA-376 schema (non-protectable under
-merger; also present in the MIT-era ancestors) and (b) universal Go idioms.
-The prior AGPL headers on the six flagged files are consistent with vestigial
-header copy-paste at rewrite time, since none of those files share
-implementation with the AGPL upstream.
+**Supportable as fact (verified above):**
+- docxgo's current tree shares only 0.4% of its distinctive lines with the
+  AGPL upstream, and that residue is schema boilerplate / generic Go idioms.
+- No fumiama function names, distinctive types, or embedded assets carry over.
+- docxgo has been substantially rewritten relative to the upstream.
 
-**Accurate public claim** (evidence-supported):
-> docxgo v2 is an independent, MIT-licensed clean-architecture implementation.
-> A line-level and structural diff against the AGPL-licensed `fumiama/go-docx`
-> upstream found only OOXML schema-dictated struct mappings and standard-library
-> idioms in common — no shared logic, functions, or assets — and that residual
-> boilerplate also exists in the project's MIT-licensed ancestors.
+**NOT supportable, and removed from README/CREDITS:**
+- "Independent" / "clean-room" / "from-scratch" framing.
+- "AGPL only ever entered fumiama's fork, never this codebase" — the codebase
+  descends from AGPL-era fumiama (Finding 1).
 
-Avoid the weaker/absolute phrasing "the AGPL never touched a single line," which
-is imprecise (schema boilerplate does coincide); the claim above is both true
-and stronger for due diligence.
+**Open — for IP counsel, not resolved here:**
+- Whether docxgo v2 is a derivative work of the AGPL `fumiama/go-docx`.
+- Whether docxgo may be distributed under MIT, or whether the AGPL obligations
+  attach (in whole or part) to the shipped module and npm package.
+- What, if anything, must change in `LICENSE`, `package.json`, attribution, or
+  the public claims as a result.
 
 ## Recommended follow-ups
 
-1. Keep this document, and `docs/provenance/compare_line_overlap.py`, in-repo
-   as due-diligence artifacts.
-2. Before offering a paid license warranty/indemnification, have an IP attorney
-   review this analysis and sign off — the pinned commit and checked-in script
-   should make independent re-verification (and that review) inexpensive.
-3. Re-run the script (against a fresh fumiama `HEAD`, since it has continued
-   commits after `0c30fd0`) on major docxgo refactors that touch
-   `internal/xml/*` or import upstream code, to keep the record current.
+1. **Obtain IP counsel review** on the derivative-work question before making
+   or relying on any MIT representation. Provide them this document, the pinned
+   upstream commit, and `docs/provenance/compare_line_overlap.py`.
+2. Do **not** change `LICENSE` or `package.json`'s `license` field on the
+   basis of this technical analysis alone — that decision is counsel's.
+3. Keep this document and the comparison script in-repo as the factual record.
+4. Re-run the comparison on major refactors touching `internal/xml/*` to keep
+   the textual-overlap figures current.

--- a/docs/PROVENANCE_AUDIT.md
+++ b/docs/PROVENANCE_AUDIT.md
@@ -33,7 +33,9 @@ That work fixed *labeling*. It did not, by itself, establish that the underlying
 *code* in those files is not derived from the AGPL upstream — swapping a header
 does not change provenance. **This audit closes that gap.**
 
-The six files that carried inherited AGPL/Apache headers (highest-risk set):
+The seven files that carried inherited AGPL/Apache headers — six with an
+AGPL-3.0 header, plus the Apache-2.0 header on `internal/writer/zip.go`
+(highest-risk set):
 
 - `internal/serializer/serializer.go`
 - `internal/serializer/latent_styles.go`

--- a/docs/README.md
+++ b/docs/README.md
@@ -224,4 +224,4 @@ See: IMPLEMENTATION_STATUS.md - Features list
 ---
 
 **Last Updated**: July 2026  
-**Documentation Version**: v2.7.0
+**Documentation Version**: v2.7.1

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,7 @@ This index helps you find the right documentation for your needs.
    - 10_paragraph_spacing - Line and paragraph spacing
    - 11_multi_section - Multi-section layouts
    - 12_read_and_modify - Read/modify existing documents
-   - 13_themes - Theme system (5 preset themes)
+   - 13_themes - Theme system (7 preset themes)
    - 14_mail_merge - Template engine with mail merge
    - 15_external_template - Mail merge with external Word template
 

--- a/docs/V2_API_GUIDE.md
+++ b/docs/V2_API_GUIDE.md
@@ -1,6 +1,6 @@
 # go-docx v2 API Guide
 
-**Version**: 2.7.0
+**Version**: 2.7.1
 **Last Updated**: July 2026
 
 ---
@@ -996,4 +996,4 @@ See [`examples/14_mail_merge/`](../examples/14_mail_merge/) for a complete worki
 ---
 
 **Last Updated**: July 2026
-**Version**: 2.7.0
+**Version**: 2.7.1

--- a/docs/V2_DESIGN.md
+++ b/docs/V2_DESIGN.md
@@ -1,8 +1,8 @@
 # go-docx v2.0 - Clean Architecture Design
 
-**Status**: ✅ v2.7.0 Stable
+**Status**: ✅ v2.7.1 Stable
 **Progress**: Production Ready (all core features complete)
-**Latest Release**: v2.7.0 (July 2026)
+**Latest Release**: v2.7.1 (July 2026)
 **Breaking Changes**: Yes (major version bump from original fork)
 
 > **Project Note**: This project is a substantially-rewritten fork of `fumiama/go-docx` (AGPL-3.0), focused on clean architecture, type safety, and modern Go practices. Its provenance and the resulting open licensing question are documented in [PROVENANCE_AUDIT.md](./PROVENANCE_AUDIT.md) — the single source of truth for that topic.
@@ -1345,7 +1345,7 @@ See [CREDITS.md](../CREDITS.md) for complete project history.
 ---
 
 **Last Updated**: April 2026
-**Status**: ✅ v2.7.0 Stable
+**Status**: ✅ v2.7.1 Stable
 **Progress**: Production Ready (all core features complete)
 
 **Current State:**

--- a/docs/V2_DESIGN.md
+++ b/docs/V2_DESIGN.md
@@ -5,7 +5,7 @@
 **Latest Release**: v2.7.0 (July 2026)
 **Breaking Changes**: Yes (major version bump from original fork)
 
-> **Project Note**: This project originated as a fork of `fumiama/go-docx` but has been completely rewritten with a clean architecture design. The current version represents a ground-up rebuild focused on maintainability, type safety, and modern Go practices.
+> **Project Note**: This project is a fork of `fumiama/go-docx` (AGPL-3.0) that has been substantially rewritten with a clean-architecture design focused on maintainability, type safety, and modern Go practices. It is *not* an independent from-scratch project: its git history descends from the AGPL-era upstream. The provenance facts and the resulting open licensing question (which needs IP-counsel review) are documented in [PROVENANCE_AUDIT.md](./PROVENANCE_AUDIT.md).
 
 > **✅ Validation Status**: All examples pass DocxValidator (strict OOXML schema). Ready for beta release.
 > **📖 For API usage, see [V2_API_GUIDE.md](./V2_API_GUIDE.md)**
@@ -482,6 +482,13 @@ if err := finalDoc.SaveAs("output.docx"); err != nil {
 ### ✅ Phase 5.5: Project Restructuring - COMPLETE
 
 **Goal**: Transform from fork to independent project
+
+> **Caveat (added 2026-07-18):** the "Update LICENSE to MIT" step below, applied
+> to a codebase whose git history descends from the AGPL-3.0 `fumiama/go-docx`,
+> is precisely the action whose validity is the open licensing question. This
+> checklist is left intact as an accurate record of what was done; it does not
+> imply the relicensing is legally settled. See
+> [PROVENANCE_AUDIT.md](./PROVENANCE_AUDIT.md).
 
 - [x] Create CREDITS.md with complete project history
 - [x] Move to personal namespace (github.com/mmonterroca/docxgo)

--- a/docs/V2_DESIGN.md
+++ b/docs/V2_DESIGN.md
@@ -1346,7 +1346,7 @@ See [CREDITS.md](../CREDITS.md) for complete project history.
 **Current State:**
 - ✅ Core architecture: Complete (clean architecture, domain-driven design)
 - ✅ Builder pattern: Complete (fluent API with error handling)
-- ✅ Images: Complete (9 formats, inline/floating positioning)
+- ✅ Images: Complete (PNG, JPEG, GIF, inline/floating positioning)
 - ✅ Advanced tables: Complete (merging, nesting, 8 styles, proper border serialization)
 - ✅ Theme system: Complete (7 preset themes, custom theme support)
 - ✅ Document reading: Complete (round-trip with style/hyperlink/image preservation)

--- a/docs/V2_DESIGN.md
+++ b/docs/V2_DESIGN.md
@@ -5,7 +5,7 @@
 **Latest Release**: v2.7.0 (July 2026)
 **Breaking Changes**: Yes (major version bump from original fork)
 
-> **Project Note**: This project is a fork of `fumiama/go-docx` (AGPL-3.0) that has been substantially rewritten with a clean-architecture design focused on maintainability, type safety, and modern Go practices. It is *not* an independent from-scratch project: its git history descends from the AGPL-era upstream. The provenance facts and the resulting open licensing question (which needs IP-counsel review) are documented in [PROVENANCE_AUDIT.md](./PROVENANCE_AUDIT.md).
+> **Project Note**: This project is a substantially-rewritten fork of `fumiama/go-docx` (AGPL-3.0), focused on clean architecture, type safety, and modern Go practices. Its provenance and the resulting open licensing question are documented in [PROVENANCE_AUDIT.md](./PROVENANCE_AUDIT.md) — the single source of truth for that topic.
 
 > **✅ Validation Status**: All examples pass DocxValidator (strict OOXML schema). Ready for beta release.
 > **📖 For API usage, see [V2_API_GUIDE.md](./V2_API_GUIDE.md)**
@@ -481,18 +481,16 @@ if err := finalDoc.SaveAs("output.docx"); err != nil {
 
 ### ✅ Phase 5.5: Project Restructuring - COMPLETE
 
-**Goal**: Transform from fork to independent project
+**Goal**: Restructure into a standalone project namespace
 
-> **Caveat (added 2026-07-18):** the "Update LICENSE to MIT" step below, applied
-> to a codebase whose git history descends from the AGPL-3.0 `fumiama/go-docx`,
-> is precisely the action whose validity is the open licensing question. This
-> checklist is left intact as an accurate record of what was done; it does not
-> imply the relicensing is legally settled. See
-> [PROVENANCE_AUDIT.md](./PROVENANCE_AUDIT.md).
+> **Note:** the "Set distribution license to MIT" step below is the very action
+> whose validity is the open licensing question. This checklist is an accurate
+> record of what was done; it draws no legal conclusion. See
+> [PROVENANCE_AUDIT.md](./PROVENANCE_AUDIT.md), the single source of truth.
 
 - [x] Create CREDITS.md with complete project history
 - [x] Move to personal namespace (github.com/mmonterroca/docxgo)
-- [x] Update LICENSE to MIT (allows private/commercial use)
+- [x] Set distribution license to MIT
 - [x] Rename project to "docxgo" (avoid confusion)
 - [x] Update all documentation with new namespace
 - [x] Fix duplicate type declarations

--- a/docs/provenance/compare_line_overlap.py
+++ b/docs/provenance/compare_line_overlap.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Reproduce the docxgo vs fumiama/go-docx line-level provenance comparison
+described in docs/PROVENANCE_AUDIT.md.
+
+Usage:
+    git clone https://github.com/fumiama/go-docx.git /tmp/fumiama-go-docx
+    git -C /tmp/fumiama-go-docx checkout 0c30fd09304b17fdb42b0dcea142962b2f4883a3
+    python3 docs/provenance/compare_line_overlap.py /tmp/fumiama-go-docx .
+
+Methodology: a line is "distinctive" if, after stripping comments and
+collapsing whitespace, it is at least 25 characters long. The fumiama corpus
+is the set of all such lines across every non-test .go file in its tree
+(this is the AGPL-era corpus we're checking against). For each docxgo .go
+file, we report how many of its distinctive lines also appear verbatim in
+that corpus.
+
+This is a coarse, line-set-membership check, not an AST or semantic diff —
+by design: it flags any verbatim textual overlap at all (including
+schema-dictated struct tags, which are then manually reviewed for whether
+they're independently protectable, per docs/PROVENANCE_AUDIT.md Finding 2).
+"""
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def normalize(line):
+    return re.sub(r"\s+", " ", line.strip())
+
+
+def is_comment_only(line):
+    s = line.strip()
+    return s.startswith("//") or s.startswith("/*") or s.startswith("*") or s == "*/"
+
+
+def strip_block_comments(text):
+    return re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+
+
+def distinctive_lines(filepath):
+    try:
+        text = Path(filepath).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return set()
+    text = strip_block_comments(text)
+    lines = set()
+    for raw in text.splitlines():
+        if is_comment_only(raw):
+            continue
+        norm = normalize(raw)
+        if len(norm) >= 25:
+            lines.add(norm)
+    return lines
+
+
+def collect_corpus(root, include_tests=False):
+    corpus = set()
+    file_count = 0
+    for dirpath, _dirnames, filenames in os.walk(root):
+        if ".git" in dirpath.split(os.sep):
+            continue
+        for fn in filenames:
+            if not fn.endswith(".go"):
+                continue
+            if not include_tests and fn.endswith("_test.go"):
+                continue
+            corpus |= distinctive_lines(os.path.join(dirpath, fn))
+            file_count += 1
+    return corpus, file_count
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(__doc__)
+        sys.exit(1)
+    fumiama_root, docxgo_root = sys.argv[1], sys.argv[2]
+
+    fumiama_corpus, fumiama_files = collect_corpus(fumiama_root, include_tests=False)
+    print(f"fumiama/go-docx: {fumiama_files} non-test .go files, "
+          f"{len(fumiama_corpus)} distinctive lines\n")
+
+    results = []
+    total_docxgo_files = 0
+    grand_total_lines = 0
+    grand_total_matches = 0
+
+    for dirpath, _dirnames, filenames in os.walk(docxgo_root):
+        parts = dirpath.split(os.sep)
+        if ".git" in parts or ".claude" in parts:
+            continue
+        for fn in sorted(filenames):
+            if not fn.endswith(".go"):
+                continue
+            fp = os.path.join(dirpath, fn)
+            rel = os.path.relpath(fp, docxgo_root)
+            total_docxgo_files += 1
+            dlines = distinctive_lines(fp)
+            if not dlines:
+                continue
+            matched = dlines & fumiama_corpus
+            grand_total_lines += len(dlines)
+            grand_total_matches += len(matched)
+            if matched:
+                results.append((rel, len(matched), len(dlines), matched))
+
+    results.sort(key=lambda r: -(r[1] / r[2]))
+    print(f"docxgo: {total_docxgo_files} .go files scanned\n")
+    print(f"{'file':<45} {'overlap':>8} {'matched/total':>15}")
+    for rel, m, t, _matched in results:
+        pct = 100.0 * m / t
+        print(f"{rel:<45} {pct:>7.1f}% {m:>6}/{t:<8}")
+
+    print(f"\nTotal distinctive lines across all docxgo .go files: {grand_total_lines}")
+    print(f"Total matched lines: {grand_total_matches}")
+
+    print("\n=== Matched line detail per file ===")
+    for rel, m, _t, matched in results:
+        print(f"\n--- {rel} ({m} matches) ---")
+        for line in sorted(matched):
+            print(f"  {line}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docx.go
+++ b/docx.go
@@ -88,7 +88,7 @@ func reconstructFromPackage(pkg *reader.Package, op string) (domain.Document, er
 }
 
 // Version is the library version.
-const Version = "2.7.0"
+const Version = "2.7.1"
 
 // Common color constants exported for convenience.
 var (

--- a/examples/13_themes/README.md
+++ b/examples/13_themes/README.md
@@ -4,7 +4,7 @@ This example demonstrates the theme system in go-docx, which allows you to apply
 
 ## Available Themes
 
-The library includes 7 preset themes: 5 general-purpose themes below, plus two Tech themes (TechPresentation, TechDarkMode) shown in the [Technical Architecture example](#4-technical-architecture-example-04_tech_architecture).
+The library includes 7 preset themes: the 5 general-purpose themes documented below, plus two Tech themes (TechPresentation, TechDarkMode). Running this example's `main.go` generates a sample document for all of them.
 
 ### 1. Corporate
 Professional business theme with navy blue and red accents. Ideal for business reports, proposals, and corporate documentation.

--- a/examples/13_themes/README.md
+++ b/examples/13_themes/README.md
@@ -4,7 +4,7 @@ This example demonstrates the theme system in go-docx, which allows you to apply
 
 ## Available Themes
 
-The library includes 5 preset themes:
+The library includes 7 preset themes: 5 general-purpose themes below, plus two Tech themes (TechPresentation, TechDarkMode) shown in the [Technical Architecture example](#4-technical-architecture-example-04_tech_architecture).
 
 ### 1. Corporate
 Professional business theme with navy blue and red accents. Ideal for business reports, proposals, and corporate documentation.

--- a/examples/13_themes/main.go
+++ b/examples/13_themes/main.go
@@ -32,11 +32,9 @@ func main() {
 	fmt.Println("==========================")
 	fmt.Println()
 
-	// Get all available themes (Corporate, Startup, Modern, Fintech, Academic)
+	// Get all available themes (Corporate, Startup, Modern, Fintech, Academic,
+	// TechPresentation, TechDarkMode)
 	allThemes := themes.AllThemes()
-
-	// Also include the tech themes
-	allThemes = append(allThemes, themes.TechPresentation, themes.TechDarkMode)
 
 	fmt.Printf("Available themes: %d\n", len(allThemes))
 	for _, theme := range allThemes {

--- a/examples/README.md
+++ b/examples/README.md
@@ -129,7 +129,7 @@ cd 07_advanced && go run main.go
 **Status**: ✅ Fully functional
 **Demonstrates**: Complete image handling
 
-- 9 image formats (PNG, JPEG, GIF, BMP, TIFF, SVG, WEBP, ICO, EMF)
+- Supported formats: PNG, JPEG, GIF
 - Inline and floating images
 - Custom dimensions (pixels, inches, EMUs)
 - Positioning (left, center, right, custom coordinates)
@@ -214,7 +214,7 @@ cd 12_read_and_modify && go run main.go
 **Status**: ✅ Fully functional
 **Demonstrates**: Complete theme system
 
-- 5 preset themes (Corporate, Startup, Modern, Fintech, Academic), plus TechPresentation and TechDarkMode available directly
+- 7 preset themes (Corporate, Startup, Modern, Fintech, Academic, TechPresentation, TechDarkMode)
 - Custom colors, fonts, spacing, and heading styles
 - Professional document generation with consistent branding
 - Theme application via `WithTheme()` builder option

--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -1196,7 +1196,7 @@ func (s *DocumentSerializer) SerializeCoreProperties(meta *domain.Metadata) *xml
 func (s *DocumentSerializer) SerializeAppProperties(doc domain.Document) *xml.AppProperties {
 	return &xml.AppProperties{
 		Xmlns:       constants.NamespaceExtendedProperties,
-		Application: "go-docx/v2",
+		Application: "docxgo",
 		DocSecurity: 0,
 		Lines:       0,
 		Paragraphs:  len(doc.Paragraphs()),

--- a/internal/writer/zip.go
+++ b/internal/writer/zip.go
@@ -416,7 +416,7 @@ func (zw *ZipWriter) writeCoreProperties(props *xmlstructs.CoreProperties) error
 			XMLnsDC:      constants.NamespaceDC,
 			XMLnsDCTerms: constants.NamespaceDCTerms,
 			XMLnsXSI:     "http://www.w3.org/2001/XMLSchema-instance",
-			Creator:      "go-docx v2",
+			Creator:      "docxgo",
 			Created: &xmlstructs.DCDate{
 				Type:  "dcterms:W3CDTF",
 				Value: now.Format(time.RFC3339),
@@ -435,7 +435,7 @@ func (zw *ZipWriter) writeAppProperties(props *xmlstructs.AppProperties) error {
 	if props == nil {
 		props = &xmlstructs.AppProperties{
 			Xmlns:       constants.NamespaceExtendedProperties,
-			Application: "go-docx v2.0.0",
+			Application: "docxgo",
 			DocSecurity: 0,
 		}
 	}

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -46,7 +46,14 @@ export interface MarginCustom {
 export type Margins = MarginPreset | MarginCustom;
 
 /** Theme presets. */
-export type ThemeName = 'Corporate' | 'Startup' | 'Modern' | 'Fintech' | 'Academic';
+export type ThemeName =
+  | 'Corporate'
+  | 'Startup'
+  | 'Modern'
+  | 'Fintech'
+  | 'Academic'
+  | 'TechPresentation'
+  | 'TechDarkMode';
 
 /** Document-level options. */
 export interface DocumentOptions {

--- a/themes/presets.go
+++ b/themes/presets.go
@@ -295,6 +295,8 @@ func AllThemes() []Theme {
 		Modern,
 		Fintech,
 		Academic,
+		TechPresentation,
+		TechDarkMode,
 	}
 }
 


### PR DESCRIPTION
Single PR for the Phase 0 pre-sales credibility cleanup. Consolidates what were briefly two PRs (#57 closed and merged in here) because the README's license section and prose can't be split cleanly between two.

## 1. Capability/doc alignment (claims now match verified code)
- **Thread-safety**: README no longer claims a `Document` is thread-safe (it isn't — only the internal managers are, via `sync.RWMutex`); wording matches `doc.go`.
- **Image formats**: docs claimed 7 (some 9, incl. ICO/EMF). Empirically only **PNG/JPEG/GIF** decode end-to-end (3 stdlib decoders, zero external deps). Docs corrected; **#55** filed for the gap.
- **Themes**: 7 preset themes existed but only 5 were discoverable via the public API. Wired the two Tech themes through `AllThemes()`/`ThemeNames()`/`GetTheme()`, the CLI `lookupTheme`, and the Node `ThemeName` type; docs now say 7. Verified end-to-end.
- **Version**: `doc.go` godoc was frozen at 2.5.0 → 2.7.0; fixed a stale migration-guide pointer.

## 2. Output branding
- Generated `.docx` metadata said `go-docx/v2` / `go-docx v2.0.0`. Fixed the live serializer path and the writer fallbacks to `docxgo`. Verified in `docProps/app.xml`.

## 3. License provenance (the important part — needs review)
- Git forensics show docxgo v2's `master` **descends from `fumiama/go-docx`'s full history through its 2025-05 AGPL HEAD** (140 fumiama commits are ancestors; docxgo's first own commit is 2025-10-21). fumiama relicensed MIT→AGPL-3.0 on 2023-02-24, so this is **not** an independent project and did not fork during the MIT window.
- Removed the false claims ("independent clean-architecture rewrite", "AGPL only ever entered fumiama's fork, never this codebase") from README/CREDITS/V2_DESIGN/doc.go.
- **`docs/PROVENANCE_AUDIT.md`** is now the single source of truth: it records the facts (git descent + the measured 0.4% current-tree overlap) and explicitly leaves the derivative-work / MIT-vs-AGPL determination to **IP counsel** — it does not conclude the project is "clean". Includes a reproducible comparison script (`docs/provenance/compare_line_overlap.py`) pinned to a fumiama commit.
- Everywhere else points to that one doc with one consistent sentence. **`LICENSE` and `package.json` were deliberately not changed** — that's counsel's call, not a technical one.

## 4. README professionalization
- Rewrote the public prose to a plain register, removed the duplicated "Features" section and other redundancy, and dropped marketing filler/emoji. Quick Start, Node.js/CLI snippets, the examples table, and all code are untouched.

## Verification
`go build/vet/test` clean, `gofmt` clean, `golangci-lint` clean (one pre-existing unrelated finding), `tsc --noEmit` clean, `examples/run_all_examples.sh` 11/11 with OOXML validation, and a generated `.docx` confirmed to report `Application: docxgo`.

## ⚠️ Note for reviewers
The false "AGPL never entered this codebase" claim is **still live on `master`** until this merges. The provenance correction should reach `master` with priority, and the open licensing question needs IP-counsel review before any MIT-based representation.