### PR TITLE
Release v2.7.2: finalize MIT provenance and packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v7
         with:
           go-version: '1.23.x'
           cache: false  # No external dependencies, so no need to cache
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.23.x'
           cache: false

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,21 +3,20 @@ name: npm Publish
 on:
   release:
     types: [published]
-  # Manual fallback: release.yml creates the GitHub Release using the default
-  # GITHUB_TOKEN, and GitHub does not let GITHUB_TOKEN-authored events trigger
-  # other workflows (anti-recursion protection) — so "release: published"
-  # above never actually fires. Until release.yml is updated to create the
-  # release with a PAT instead, run this manually after each release.
+  # GitHub does not let GITHUB_TOKEN-authored events trigger other workflows.
+  # release.yml creates the release with RELEASE_PAT so the event above fires
+  # automatically; this dispatch remains an idempotent fallback.
   #
   # workflow_dispatch is only usable against a ref where the workflow file
   # itself already declares this trigger, so the release tag (created before
   # this fallback existed, and every future tag, which is cut before this
   # workflow can be edited from it) can't be used directly as the dispatch
-  # ref. Run this from the default branch instead and pass the version input.
+  # ref. Run this from the default branch and pass the version input; the jobs
+  # below still check out the matching vX.Y.Z tag before building.
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g. 2.7.0, no "v" prefix)'
+        description: 'Version to publish (e.g. 2.7.2, no "v" prefix)'
         required: true
 
 permissions:
@@ -51,8 +50,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/v{0}', inputs.version) || github.ref }}
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.23.x'
           cache: false
@@ -90,7 +91,7 @@ jobs:
             "os": ["${{ matrix.goos == 'windows' && 'win32' || matrix.goos }}"],
             "cpu": ["${{ matrix.goarch == 'amd64' && 'x64' || matrix.goarch }}"],
             "main": "",
-            "files": ["bin/", "README.md"],
+            "files": ["bin/", "README.md", "LICENSE"],
             "license": "MIT",
             "repository": {
               "type": "git",
@@ -99,6 +100,9 @@ jobs:
             }
           }
           EOF
+
+      - name: Copy license into platform package
+        run: cp LICENSE npm/platforms/${{ matrix.suffix }}/LICENSE
 
       - name: Generate platform README
         run: |
@@ -131,6 +135,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/v{0}', inputs.version) || github.ref }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.23.x'
           cache: false
@@ -48,14 +48,15 @@ jobs:
         run: |
           mkdir -p dist
           go build -ldflags="-s -w" -o dist/docxgo${{ matrix.ext }} ./cmd/docxgo/
+          cp LICENSE dist/LICENSE
 
       - name: Package archive
         run: |
           cd dist
           if [ "${{ matrix.goos }}" = "windows" ]; then
-            zip ../docxgo-${{ matrix.suffix }}.zip docxgo${{ matrix.ext }}
+            zip ../docxgo-${{ matrix.suffix }}.zip docxgo${{ matrix.ext }} LICENSE
           else
-            tar czf ../docxgo-${{ matrix.suffix }}.tar.gz docxgo${{ matrix.ext }}
+            tar czf ../docxgo-${{ matrix.suffix }}.tar.gz docxgo${{ matrix.ext }} LICENSE
           fi
 
       - name: Upload artifact
@@ -70,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v7
         with:
           go-version: '1.23.x'
           cache: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## v2.7.2 — 2026-07-18
+
+### Compliance
+
+- **Definitive MIT provenance determination.** `docs/PROVENANCE_AUDIT.md` now records the reproducible conclusion that the current v2 implementation may remain MIT: AGPL applies to the historical upstream snapshots in Git history, not to the current release tree. No project-wide AGPL relicense or further licensing consultation is an open release task.
+- **Corrected copyright notices.** The root `LICENSE` preserves the exact MIT-era predecessor notices without implying that fumiama's later AGPL-era work was licensed as MIT. `CREDITS.md`, the README, package godoc, and design documentation now use the same determination.
+- **License-complete artifacts.** Platform npm packages and GitHub binary archives now include the root MIT license text. This repairs the notice omission identified in the published v2.7.1 artifacts.
+
+### Fixed
+
+- **Release metadata and documentation** now consistently report v2.7.2 across the Go version constant, CLI examples, API/design/status guides, and npm package metadata.
+- **Documentation import paths and branding** now use the public `/v2` module path and the `docxgo` project name.
+- **Release automation comments and actions** now match the actual PAT-triggered npm publication path, and Go setup actions are aligned on `actions/setup-go@v7`.
+
+### Compatibility
+
+- No public Go, CLI protocol, or Node.js API changed. This is a backward-compatible compliance, packaging, and documentation patch.
+
+---
+
 ## v2.7.1 — 2026-07-18
 
 ### Added
@@ -198,7 +218,7 @@
 
 ### Acknowledgements
 
-- Original fix: [PR #3](https://github.com/mmonterroca/docxgo/pull/3) by @g-mero
+- Original fix contributed by @g-mero; the historical PR is no longer available
 - Validation & extension: [PR #4](https://github.com/mmonterroca/docxgo/pull/4) by @Copilot
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,7 +222,7 @@ Update documentation when adding features:
 ## Community
 
 - **Issues**: Report bugs or request features via [GitHub Issues](https://github.com/mmonterroca/docxgo/issues)
-- **Discussions**: Ask questions or share ideas in [GitHub Discussions](https://github.com/mmonterroca/docxgo/discussions)
+- **Questions and ideas**: Use [GitHub Issues](https://github.com/mmonterroca/docxgo/issues)
 - **Code of Conduct**: Be respectful and constructive
 
 ## Questions?

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -13,7 +13,7 @@ This project has evolved through multiple stages, with each contributor adding s
 
 Listed newest first. See the timeline below for the chronological view.
 
-### 🚀 Version 2.0 (2024-2026) - mmonterroca/docxgo
+### 🚀 Version 2.x (2025-2026) - mmonterroca/docxgo
 
 **Status**: Current Active Development  
 **Repository**: https://github.com/mmonterroca/docxgo  
@@ -27,7 +27,7 @@ Listed newest first. See the timeline below for the chronological view.
 **Clean Architecture Implementation**
 - Interface-based design with dependency injection
 - Separation of concerns (domain, internal, pkg layers)
-- Type-safe implementations (eliminated `interface{}` usage)
+- Type-safe public and domain APIs; dynamic values remain only where OOXML polymorphism requires them
 - Comprehensive error handling throughout the API
 
 **Core Domain**
@@ -56,10 +56,10 @@ Listed newest first. See the timeline below for the chronological view.
 
 ---
 
-### 📦 Version 1.x — mmonterroca fork (2023-2024)
+### 📦 Version 1.x — mmonterroca fork (2025)
 
 **Repository**: https://github.com/mmonterroca/docxgo (root code, now deprecated)  
-**Forked from**: fumiama/go-docx, in 2023. Upstream continued independently afterwards — see below.
+**Forked from**: the 2025-05 `fumiama/go-docx` HEAD. The upstream history is preserved as repository ancestry — see below.
 
 #### Author
 - **Misael Monterroca** - Professional document features
@@ -102,10 +102,11 @@ Listed newest first. See the timeline below for the chronological view.
 **Forked from**: gonfva/docxlib (MIT)  
 **License**: AGPL-3.0 — relicensed by fumiama on 2023-02-24, having received the code under MIT
 
-This is the upstream docxgo v2 forks from. docxgo v2's `master` descends from
-this repository's history through its 2025-05 HEAD (i.e. sequentially, through
-the AGPL period — not as a parallel branch taken during the earlier MIT
-window). See [docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md), Finding 1.
+docxgo v2's Git history descends from this repository through its 2025-05 HEAD,
+including the AGPL period. The completed
+[provenance audit](docs/PROVENANCE_AUDIT.md) determines that the current
+rewritten release contains no protectable AGPL implementation; historical
+snapshots retain their original license.
 
 #### Author
 - **fumiama** - Expanded functionality (first commit 2023-02-08, last 2025-05-06)
@@ -176,35 +177,33 @@ Created for [Basement Crowd](https://www.basementcrowd.com) and [FromCounsel](ht
              └─ Images, tables, shapes; expanded API surface
              └─ development continued through 2025-05
                     │
-                    │  docxgo v2 forks fumiama's 2025-05 HEAD (AGPL-era),
-                    │  first own commit 2025-10-21
+                    │  docxgo's history continues from the 2025-05 HEAD;
+                    │  the separate v2 implementation begins in 2025-10
                     ▼
-2025-2026  mmonterroca/docxgo v2  (substantial rewrite on the AGPL-era base)
-             └─ Clean-architecture rewrite; current tree shares only
-                schema-dictated OOXML boilerplate with the upstream
+2025-2026  mmonterroca/docxgo v2  (separate implementation in the same history)
+             └─ Clean-architecture rewrite; residual overlap is limited to
+                standards-constrained declarations, generic idioms, and data
              └─ Distributed under MIT — see the licensing note below
 ```
 
-docxgo is currently distributed under the MIT license ([LICENSE](LICENSE)). It
-is a fork of the AGPL-licensed `fumiama/go-docx`; its provenance and the
-resulting open licensing question are documented in
-**[docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md)** — the single source of
-truth for this topic. This file records authorship and copyright only; it draws
-no conclusion about the license status.
+docxgo v2 is distributed under the MIT license ([LICENSE](LICENSE)). Its Git
+history includes AGPL-era `fumiama/go-docx` snapshots, while the current
+implementation is a substantial rewrite. The completed
+**[provenance audit](docs/PROVENANCE_AUDIT.md)** records the evidence and MIT
+determination. Historical snapshots retain their original licenses.
 
 ---
 
 ## How v2 diverges from the upstream
 
-These points describe how far docxgo v2 has been rewritten from the
-`fumiama/go-docx` base. They are engineering facts about divergence — they do
-**not** establish legal independence from the AGPL upstream, which is an open
-question addressed only in [docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md).
+These points summarize how docxgo v2 was rewritten from the historical
+`fumiama/go-docx` base. The full evidence and licensing determination are in
+[docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md).
 
 1. **Substantial architectural rewrite**
    - Clean-architecture layering; different design principles
    - Breaking changes throughout
-   - Current tree shares only schema-dictated OOXML boilerplate with fumiama
+   - Residual overlap is standards-constrained or generic, as quantified by the audit
 
 2. **Significant divergence**
    - Different package structure
@@ -221,7 +220,7 @@ We maintain **full transparency** about project history:
 - Original authors credited in LICENSE
 - This CREDITS.md preserved indefinitely
 - Fork history acknowledged in documentation
-- Licensing provenance and its open question recorded in [docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md)
+- Licensing provenance and determination recorded in [docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md)
 
 ---
 
@@ -254,17 +253,16 @@ We welcome contributions from the community. See [CONTRIBUTING.md](CONTRIBUTING.
 
 ## License
 
-docxgo is currently distributed under the **MIT License** ([LICENSE](LICENSE)).
-Its provenance relative to the AGPL-licensed `fumiama/go-docx` upstream, and the
-resulting open licensing question, are documented in
-[docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md) — the single source of truth
-for this topic.
+docxgo v2 is distributed under the **MIT License** ([LICENSE](LICENSE)). Its
+provenance relative to the AGPL-era `fumiama/go-docx` history and the completed
+MIT determination are documented in
+[docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md).
 
 ### Copyright Notices
 
 ```
 Copyright (c) 2024-2026 Misael Monterroca (v2 architecture & development)
-Copyright (c) 2023-2025 fumiama (enhanced fork)
+Copyright (c) 2023 Fumiama Minamoto (源文雨) (MIT-era predecessor notice)
 Copyright (c) 2021 Gonzalo Fernandez-Victorio (original library)
 Copyright (c) 2021 Basement Crowd Ltd (https://www.basementcrowd.com)
 Copyright (c) 2020 gingfrederik (original library)

--- a/LICENSE
+++ b/LICENSE
@@ -1,12 +1,14 @@
 MIT License
 
-go-docx - Microsoft Word .docx (OOXML) manipulation library for Go
+docxgo - Microsoft Word .docx (OOXML) manipulation library for Go
 
-Copyright (c) 2024-2026 Misael Monterroca (v2 architecture & development)
-Copyright (c) 2023-2025 fumiama (enhanced fork)
-Copyright (c) 2021 Gonzalo Fernandez-Victorio (original library)
+Copyright (c) 2024-2026 Misael Monterroca
+
+Portions derived from MIT-licensed predecessors:
+Copyright (c) 2023 Fumiama Minamoto (源文雨)
+Copyright (c) 2021 Gonzalo Fernandez-Victorio
 Copyright (c) 2021 Basement Crowd Ltd (https://www.basementcrowd.com)
-Copyright (c) 2020 gingfrederik (original library)
+Copyright (c) 2020 gingfrederik
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,304 +1,193 @@
-# Migration Guide: v1 → v2
+# Migration Guide: v1 → docxgo v2
 
-This guide helps you migrate from legacy v1 to the new v2 architecture.
+**Current target:** v2.7.2
+**Minimum Go version:** 1.23
 
-## Table of Contents
+This guide covers migration from the historical `fumiama/go-docx` API to the
+current public module, `github.com/mmonterroca/docxgo/v2`. v2 is a separate
+architecture with intentionally breaking API changes, so migration is a source
+update rather than a module-path-only replacement.
 
-- [Overview](#overview)
-- [Should You Migrate?](#should-you-migrate)
-- [Breaking Changes](#breaking-changes)
-- [Step-by-Step Migration](#step-by-step-migration)
-- [API Comparison](#api-comparison)
-- [Common Patterns](#common-patterns)
-- [Troubleshooting](#troubleshooting)
+For the complete current API, see the [API guide](docs/V2_API_GUIDE.md) and
+[pkg.go.dev](https://pkg.go.dev/github.com/mmonterroca/docxgo/v2).
 
----
+## What changes
 
-## Overview
+- Every operation that can fail reports an error.
+- Document creation is available through a fluent builder or the direct domain
+  interfaces.
+- Font sizes use points in the builder and half-points in the direct `Run` API.
+- Colors, alignments, underlines, page sizes, and other options use typed values.
+- The public module carries the required semantic-import suffix `/v2`.
+- `internal/*` packages are implementation details and must not be imported by
+  consumers.
+- A single `Document` is not safe for concurrent mutation; synchronize access
+  externally if multiple goroutines share one instance.
 
-v2 is a **complete architectural rewrite** of go-docx. While this means breaking changes, it also brings:
-
-- ✅ **Explicit error handling** - No more silent failures
-- ✅ **Type safety** - No more `interface{}`
-- ✅ **Better testability** - Interface-based design
-- ✅ **Thread safety** - Concurrent access supported
-- ✅ **Performance** - 10%+ faster in most cases
-
-**Migration Difficulty**: Moderate  
-**Estimated Time**: 1-4 hours (depending on codebase size)
-
----
-
-## Should You Migrate?
-
-### ✅ Migrate If:
-
-- Starting a new project (use v2 from the start)
-- Need better error handling
-- Want to write tests (v2 is much easier to test)
-- Working on long-term maintained code
-- Need thread-safe document manipulation
-- Want modern Go best practices
-
-### ⏸️ Wait If:
-
-- v2 feature you need isn't implemented yet (check [roadmap](docs/V2_DESIGN.md))
-- You can't test in your environment
-- Production code with tight deadline (wait for v2.0.0 stable - Q1 2026)
-
-### ⚠️ Stay on v1 If:
-
-- Legacy code with no maintenance budget
-- v2 will never have the feature you need
-- Willing to maintain your own fork
-
-**Note**: v1 will receive critical bug fixes through December 2025 only.
-
----
-
-## Breaking Changes
-
-### 1. **Import Paths**
-
-```go
-// v1
-import "github.com/fumiama/go-docx"
-import docx "github.com/mmonterroca/docxgo/legacy/v1"  // If using legacy
-
-// v2
-import "github.com/mmonterroca/docxgo/domain"
-import "github.com/mmonterroca/docxgo/internal/core"
-```
-
-### 2. **Error Handling**
-
-```go
-// v1 - No errors
-para := doc.AddParagraph()
-run := para.AddText("Hello")
-run.Bold().Color("FF0000") // Silent failure on invalid color
-
-// v2 - Explicit errors
-para, err := doc.AddParagraph()
-if err != nil {
-    return err
-}
-run, err := para.AddRun()
-if err != nil {
-    return err
-}
-run.SetText("Hello")
-run.SetBold(true)
-run.SetColor(domain.Color{R: 255, G: 0, B: 0}) // Type-safe
-```
-
-### 3. **API Structure**
-
-```go
-// v1 - Fluent API
-doc := docx.New()
-para := doc.AddParagraph()
-para.AddText("Text").Bold().Size("28").Color("FF0000")
-
-// v2 - Explicit API with error handling
-doc := core.NewDocument()
-para, err := doc.AddParagraph()
-if err != nil {
-    return err
-}
-run, err := para.AddRun()
-if err != nil {
-    return err
-}
-run.SetText("Text")
-run.SetBold(true)
-run.SetSize(56) // Half-points (28pt = 56 half-points)
-run.SetColor(domain.Color{R: 255, G: 0, B: 0})
-```
-
-### 4. **Method Names**
-
-| v1 Method | v2 Method | Notes |
-|-----------|-----------|-------|
-| `AddText(text)` | `AddRun()` + `SetText(text)` | Two-step process |
-| `Bold()` | `SetBold(true)` | Explicit setter |
-| `Size(string)` | `SetSize(int)` | Half-points, not string |
-| `Color(string)` | `SetColor(Color)` | Type-safe struct |
-| `Alignment(string)` | `SetAlignment(Alignment)` | Type-safe constant |
-
-### 5. **Value Types**
-
-```go
-// v1 - Strings everywhere
-run.Size("28")           // String
-run.Color("FF0000")      // Hex string
-para.Alignment("center") // String
-
-// v2 - Type-safe
-run.SetSize(56)          // int (half-points)
-run.SetColor(domain.Color{R: 255, G: 0, B: 0}) // Struct
-para.SetAlignment(constants.AlignmentCenter)   // Constant
-```
-
----
-
-## Step-by-Step Migration
-
-### Step 1: Update Dependencies
+## 1. Update the module
 
 ```bash
-# Remove v1
-go get github.com/fumiama/go-docx@none
-
-# Add v2
-go get github.com/mmonterroca/docxgo/v2@latest
+go get github.com/mmonterroca/docxgo/v2@v2.7.2
+go mod tidy
 ```
 
-### Step 2: Update Imports
+Replace the old import:
 
 ```go
-// Old
 import "github.com/fumiama/go-docx"
+```
 
-// New
+with the current root package:
+
+```go
+import docx "github.com/mmonterroca/docxgo/v2"
+```
+
+Advanced code may also import public subpackages such as:
+
+```go
 import (
-    "github.com/mmonterroca/docxgo/domain"
-    "github.com/mmonterroca/docxgo/internal/core"
-    "github.com/mmonterroca/docxgo/pkg/constants"
+    "github.com/mmonterroca/docxgo/v2/domain"
+    "github.com/mmonterroca/docxgo/v2/pkg/template"
+    "github.com/mmonterroca/docxgo/v2/themes"
 )
 ```
 
-### Step 3: Update Document Creation
+Do not import `github.com/mmonterroca/docxgo/v2/internal/core`; Go intentionally
+prevents external modules from importing it. Use `docx.NewDocument()` instead.
+
+## 2. Choose an API style
+
+### Fluent builder
+
+The builder is the shortest path for new documents. It accumulates operation
+errors and returns the first one from `Build`.
 
 ```go
-// v1
-doc := docx.New()
-// or
-doc := docx.New().WithDefaultTheme()
+package main
 
-// v2
-doc := core.NewDocument()
+import (
+    "log"
+
+    docx "github.com/mmonterroca/docxgo/v2"
+)
+
+func main() {
+    builder := docx.NewDocumentBuilder(
+        docx.WithTitle("Migration example"),
+        docx.WithAuthor("Example author"),
+        docx.WithLanguage("en-US"),
+    )
+
+    builder.AddParagraph().
+        Text("Hello from docxgo v2").
+        Bold().
+        Color(docx.Red).
+        FontSize(14).
+        Alignment(docx.AlignmentCenter).
+        End()
+
+    doc, err := builder.Build()
+    if err != nil {
+        log.Fatal(err)
+    }
+    if err := doc.SaveAs("output.docx"); err != nil {
+        log.Fatal(err)
+    }
+}
 ```
 
-### Step 4: Update Text Operations
+### Direct domain API
+
+Use the direct interfaces when you need fine-grained control or want to inspect
+the objects you create.
 
 ```go
-// v1
-para := doc.AddParagraph()
-run := para.AddText("Hello World")
-run.Bold().Size("28").Color("FF0000")
+package main
 
-// v2
-para, err := doc.AddParagraph()
+import (
+    "log"
+
+    docx "github.com/mmonterroca/docxgo/v2"
+    "github.com/mmonterroca/docxgo/v2/domain"
+)
+
+func main() {
+    document := docx.NewDocument()
+
+    paragraph, err := document.AddParagraph()
+    if err != nil {
+        log.Fatal(err)
+    }
+    if err := paragraph.SetAlignment(domain.AlignmentCenter); err != nil {
+        log.Fatal(err)
+    }
+
+    run, err := paragraph.AddRun()
+    if err != nil {
+        log.Fatal(err)
+    }
+    if err := run.SetText("Hello from the direct API"); err != nil {
+        log.Fatal(err)
+    }
+    if err := run.SetBold(true); err != nil {
+        log.Fatal(err)
+    }
+    if err := run.SetSize(28); err != nil { // 14 pt = 28 half-points
+        log.Fatal(err)
+    }
+    if err := run.SetColor(domain.Color{R: 255, G: 0, B: 0}); err != nil {
+        log.Fatal(err)
+    }
+
+    if err := document.SaveAs("output.docx"); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+## 3. Translate common operations
+
+| v1 pattern | v2 builder | v2 direct API |
+|---|---|---|
+| `docx.New()` | `docx.NewDocumentBuilder()` | `docx.NewDocument()` |
+| `para.AddText("Text")` | `.Text("Text")` | `para.AddRun()` then `run.SetText("Text")` |
+| `run.Bold()` | `.Bold()` | `run.SetBold(true)` |
+| `run.Size("28")` | `.FontSize(28)` | `run.SetSize(56)` |
+| `run.Color("FF0000")` | `.Color(docx.Red)` | `run.SetColor(domain.Color{R: 255})` |
+| paragraph alignment string | `.Alignment(docx.AlignmentCenter)` | `para.SetAlignment(domain.AlignmentCenter)` |
+| chained write with ignored failures | `Build()` then `SaveAs()` | check each returned error |
+
+The builder's `FontSize` accepts points. The direct `Run.SetSize` method accepts
+half-points, matching OOXML conventions.
+
+## 4. Migrate document structure
+
+### Paragraphs and runs
+
+```go
+paragraph, err := document.AddParagraph()
 if err != nil {
     return err
 }
-run, err := para.AddRun()
+
+run, err := paragraph.AddRun()
 if err != nil {
     return err
 }
-if err := run.SetText("Hello World"); err != nil {
-    return err
-}
-if err := run.SetBold(true); err != nil {
-    return err
-}
-if err := run.SetSize(56); err != nil { // 28pt * 2
-    return err
-}
-if err := run.SetColor(domain.Color{R: 255, G: 0, B: 0}); err != nil {
+if err := run.SetText("Text"); err != nil {
     return err
 }
 ```
 
-### Step 5: Update File I/O
+### Tables
 
 ```go
-// v1
-f, _ := os.Create("output.docx")
-doc.WriteTo(f)
-f.Close()
-
-// v2
-if err := doc.SaveAs("output.docx"); err != nil {
-    return err
-}
-```
-
-### Step 6: Test Thoroughly
-
-```bash
-# Run your tests
-go test ./...
-
-# Test with real documents
-# Open generated .docx files in Microsoft Word to verify
-```
-
----
-
-## API Comparison
-
-### Document Creation
-
-```go
-// v1
-doc := docx.New()
-doc := docx.New().WithDefaultTheme()
-
-// v2
-doc := core.NewDocument()
-```
-
-### Adding Paragraphs
-
-```go
-// v1
-para := doc.AddParagraph()
-
-// v2
-para, err := doc.AddParagraph()
+table, err := document.AddTable(3, 2)
 if err != nil {
     return err
 }
-```
 
-### Adding Text
-
-```go
-// v1
-run := para.AddText("Hello")
-run.Bold().Italic().Underline()
-run.Size("24").Color("0000FF")
-
-// v2
-run, err := para.AddRun()
-if err != nil {
-    return err
-}
-run.SetText("Hello")
-run.SetBold(true)
-run.SetItalic(true)
-run.SetUnderline(constants.UnderlineSingle)
-run.SetSize(48) // 24pt * 2
-run.SetColor(domain.Color{R: 0, G: 0, B: 255})
-```
-
-### Adding Tables
-
-```go
-// v1
-table := doc.AddTable()
-table.AddRow(3) // 3 columns
-row := table.Rows[0]
-cell := row.Cells[0]
-cell.AddText("Cell content")
-
-// v2
-table, err := doc.AddTable(1, 3) // 1 row, 3 columns
-if err != nil {
-    return err
-}
 row, err := table.Row(0)
 if err != nil {
     return err
@@ -307,497 +196,113 @@ cell, err := row.Cell(0)
 if err != nil {
     return err
 }
-cellPara, err := cell.AddParagraph()
+paragraph, err := cell.AddParagraph()
 if err != nil {
     return err
 }
-cellRun, err := cellPara.AddRun()
+run, err := paragraph.AddRun()
 if err != nil {
     return err
 }
-cellRun.SetText("Cell content")
+return run.SetText("Cell content")
 ```
 
-### Alignment
+### Sections
 
 ```go
-// v1
-para.Alignment("center")
+import "github.com/mmonterroca/docxgo/v2/domain"
 
-// v2
-para.SetAlignment(constants.AlignmentCenter)
-```
-
-### Indentation
-
-```go
-// v1
-para.Indent(720, 0, 0) // left, right, firstLine (in twips)
-
-// v2
-para.SetIndentation(&domain.Indentation{
-    Left:      720,
-    Right:     0,
-    FirstLine: 0,
-})
-```
-
-### Colors
-
-```go
-// v1
-run.Color("FF0000") // Hex string
-
-// v2
-run.SetColor(domain.Color{R: 255, G: 0, B: 0})
-
-// Or use predefined colors
-import "github.com/mmonterroca/docxgo/pkg/color"
-run.SetColor(color.Red)
-run.SetColor(color.Blue)
-```
-
-### Font Size
-
-```go
-// v1
-run.Size("28") // String, in points
-
-// v2
-run.SetSize(56) // Int, in half-points (28pt = 56 half-points)
-```
-
----
-
-## Common Patterns
-
-### Pattern 1: Creating a Simple Document
-
-**v1:**
-```go
-func createDocV1() error {
-    doc := docx.New()
-    para := doc.AddParagraph()
-    para.AddText("Hello World").Bold().Size("24")
-    
-    f, _ := os.Create("output.docx")
-    defer f.Close()
-    doc.WriteTo(f)
-    return nil
-}
-```
-
-**v2:**
-```go
-func createDocV2() error {
-    doc := core.NewDocument()
-    
-    para, err := doc.AddParagraph()
-    if err != nil {
-        return err
-    }
-    
-    run, err := para.AddRun()
-    if err != nil {
-        return err
-    }
-    
-    if err := run.SetText("Hello World"); err != nil {
-        return err
-    }
-    if err := run.SetBold(true); err != nil {
-        return err
-    }
-    if err := run.SetSize(48); err != nil { // 24pt * 2
-        return err
-    }
-    
-    return doc.SaveAs("output.docx")
-}
-```
-
-### Pattern 2: Error Handling Helper
-
-To reduce boilerplate, create helper functions:
-
-```go
-// Helper function for v2
-func mustAddPara(doc domain.Document) domain.Paragraph {
-    para, err := doc.AddParagraph()
-    if err != nil {
-        panic(err) // Or handle appropriately
-    }
-    return para
-}
-
-func mustAddRun(para domain.Paragraph) domain.Run {
-    run, err := para.AddRun()
-    if err != nil {
-        panic(err)
-    }
-    return run
-}
-
-// Usage
-doc := core.NewDocument()
-run := mustAddRun(mustAddPara(doc))
-run.SetText("Hello")
-```
-
-### Pattern 3: Builder Pattern (Coming in v2.1)
-
-v2 will eventually support a builder pattern similar to v1:
-
-```go
-// Coming soon in v2.1
-doc := docx.NewBuilder()
-doc.AddParagraph().
-    Text("Hello").
-    Bold().
-    FontSize(14).
-    End()
-
-finalDoc, err := doc.Build()
-```
-
----
-
-## Troubleshooting
-
-### Issue: "Too much error handling"
-
-**Solution**: Use helper functions or wait for builder pattern (v2.1)
-
-```go
-// Helper pattern
-func addText(para domain.Paragraph, text string, bold bool, size int) error {
-    run, err := para.AddRun()
-    if err != nil {
-        return err
-    }
-    if err := run.SetText(text); err != nil {
-        return err
-    }
-    if bold {
-        if err := run.SetBold(true); err != nil {
-            return err
-        }
-    }
-    if size > 0 {
-        if err := run.SetSize(size); err != nil {
-            return err
-        }
-    }
-    return nil
-}
-```
-
-### Issue: "Method not found"
-
-**Solution**: Check the API comparison table. Method names changed.
-
-```go
-// v1
-para.AddText("text")
-
-// v2
-run, _ := para.AddRun()
-run.SetText("text")
-```
-
-### Issue: "Invalid size value"
-
-**Solution**: v2 uses half-points, not points
-
-```go
-// v1
-run.Size("12") // 12pt
-
-// v2
-run.SetSize(24) // 12pt * 2 = 24 half-points
-```
-
-### Issue: "Color not working"
-
-**Solution**: v2 uses RGB struct, not hex string
-
-```go
-// v1
-run.Color("FF0000")
-
-// v2
-run.SetColor(domain.Color{R: 255, G: 0, B: 0})
-```
-
-### Issue: "Feature missing in v2"
-
-**Solution**: Check the [roadmap](docs/V2_DESIGN.md). Some features are still in development:
-
-- ✅ Basic text and formatting - Complete
-- ✅ Tables - Complete
-- ✅ Indentation - Complete
-- 🚧 Headers/Footers - In progress
-- 🚧 TOC - In progress
-- 📋 Images - Planned
-- 📋 Styles - Planned
-
-If you need a feature that's not ready, you can:
-1. Wait for the feature (check roadmap for timeline)
-2. Contribute the feature (see [CONTRIBUTING.md](CONTRIBUTING.md))
-3. Stay on v1 temporarily
-
----
-
-## Advanced Features Migration (Phase 6)
-
-### Sections and Page Layout
-
-#### v1 - Limited section support
-```go
-// v1 had basic page size methods
-doc.WithA4Page()
-doc.WithLetterPage()
-// No direct section access
-```
-
-#### v2 - Full section control
-```go
-// v2 provides complete section management
-section, err := doc.DefaultSection()
+section, err := document.DefaultSection()
 if err != nil {
     return err
 }
-
-// Custom page size
-section.SetPageSize(domain.PageSize{
-    Width:  12240,  // 8.5 inches in twips
-    Height: 15840,  // 11 inches
-})
-
-// Or use predefined sizes
-section.SetPageSize(domain.PageSizeA4)
-section.SetPageSize(domain.PageSizeLetter)
-section.SetPageSize(domain.PageSizeLegal)
-
-// Margins (in twips: 1440 = 1 inch)
-margins := domain.Margins{
-    Top:    1440,
-    Right:  1440,
-    Bottom: 1440,
-    Left:   1440,
-    Header: 720,
-    Footer: 720,
+if err := section.SetPageSize(domain.PageSizeA4); err != nil {
+    return err
 }
-section.SetMargins(margins)
-
-// Orientation
-section.SetOrientation(domain.OrientationLandscape)
-section.SetOrientation(domain.OrientationPortrait)
-
-// Columns
-section.SetColumns(2) // Two-column layout
-section.SetColumns(3) // Three-column layout
+if err := section.SetOrientation(domain.OrientationLandscape); err != nil {
+    return err
+}
 ```
 
-### Headers and Footers
-
-#### v1 - Basic headers/footers
-```go
-// v1 had limited header/footer support
-// Methods varied by implementation
-```
-
-#### v2 - Comprehensive header/footer system
-```go
-// Get section
-section, _ := doc.DefaultSection()
-
-// Access headers by type
-headerDefault, _ := section.Header(domain.HeaderDefault)
-headerFirst, _ := section.Header(domain.HeaderFirst)
-headerEven, _ := section.Header(domain.HeaderEven)
-
-// Access footers by type
-footerDefault, _ := section.Footer(domain.FooterDefault)
-footerFirst, _ := section.Footer(domain.FooterFirst)
-footerEven, _ := section.Footer(domain.FooterEven)
-
-// Add content to header
-para, _ := headerDefault.AddParagraph()
-para.SetAlignment(domain.AlignmentRight)
-run, _ := para.AddRun()
-run.AddText("Document Title")
-run.SetBold(true)
-
-// Add page numbers to footer
-footerPara, _ := footerDefault.AddParagraph()
-footerPara.SetAlignment(domain.AlignmentCenter)
-
-// "Page X of Y" format
-r1, _ := footerPara.AddRun()
-r1.AddText("Page ")
-
-r2, _ := footerPara.AddRun()
-pageField := docx.NewPageNumberField()
-r2.AddField(pageField)
-
-r3, _ := footerPara.AddRun()
-r3.AddText(" of ")
-
-r4, _ := footerPara.AddRun()
-totalField := docx.NewPageCountField()
-r4.AddField(totalField)
-```
+The builder exposes the same settings through `DefaultSection()` and
+`AddSection()`.
 
 ### Fields
 
-#### v1 - Limited field support
 ```go
-// v1 had basic TOC support
-doc.AddTOC()
-
-// Page numbers were manual
-para.AddText("Page 1")
+run, err := paragraph.AddRun()
+if err != nil {
+    return err
+}
+if err := run.AddField(docx.NewPageNumberField()); err != nil {
+    return err
+}
 ```
 
-#### v2 - Complete field system
+Factories are available for page numbers, total pages, tables of contents,
+hyperlinks, style references, and custom fields.
+
+### Themes
+
 ```go
-// Page numbers
-pageField := docx.NewPageNumberField()
-run.AddField(pageField)
+import "github.com/mmonterroca/docxgo/v2/themes"
 
-totalPages := docx.NewPageCountField()
-run.AddField(totalPages)
-
-// Table of Contents with options
-tocOptions := map[string]string{
-    "levels":          "1-5",    // Heading levels
-    "hyperlinks":      "true",   // Enable hyperlinks
-    "hidePageNumbers": "false",  // Show page numbers
-}
-tocField := docx.NewTOCField(tocOptions)
-tocRun.AddField(tocField)
-
-// Hyperlinks
-linkField := docx.NewHyperlinkField(
-    "https://github.com/mmonterroca/docxgo/v2",
-    "go-docx Repository",
+builder := docx.NewDocumentBuilder(
+    docx.WithTheme(themes.Corporate),
 )
-linkRun.SetColor(docx.ColorBlue)
-linkRun.SetUnderline(docx.UnderlineSingle)
-linkRun.AddField(linkField)
-
-// Style references (for running headers)
-styleRef := docx.NewStyleRefField("Heading 1")
-run.AddField(styleRef)
-
-// Custom field codes
-customField := docx.NewField(docx.FieldTypeCustom)
-customField.SetCode(`AUTHOR \* Upper`)
-customField.Update()
-run.AddField(customField)
 ```
 
-### Styles
+## 5. Read and modify an existing document
 
-#### v1 - String-based styles
 ```go
-// v1 used string style names
-para.Style("Heading1")
-para.Style("Normal")
-// No validation, no discovery
-```
-
-#### v2 - Complete style management
-```go
-// Built-in style constants (type-safe)
-para.SetStyle(domain.StyleIDHeading1)
-para.SetStyle(domain.StyleIDNormal)
-para.SetStyle(domain.StyleIDQuote)
-
-// Access style manager
-styleMgr := doc.StyleManager()
-
-// Check if style exists
-if styleMgr.HasStyle("Heading1") {
-    para.SetStyle("Heading1")
+document, err := docx.OpenDocument("input.docx")
+if err != nil {
+    return err
 }
 
-// Create custom style
-customStyle := &manager.ParagraphStyle{}
-customStyle.SetAlignment(domain.AlignmentCenter)
-styleMgr.AddStyle(customStyle)
+paragraph, err := document.AddParagraph()
+if err != nil {
+    return err
+}
+run, err := paragraph.AddRun()
+if err != nil {
+    return err
+}
+if err := run.SetText("Appended by docxgo v2"); err != nil {
+    return err
+}
+return document.SaveAs("output.docx")
 ```
 
-### Migration Checklist for Phase 6 Features
+Unknown OOXML parts are preserved where supported. Review the
+[implementation status](docs/IMPLEMENTATION_STATUS.md) for the current
+round-trip coverage and test your own templates before production rollout.
 
-- [ ] Replace basic page setup with Section configuration
-- [ ] Migrate headers/footers to new Section-based API
-- [ ] Convert manual page numbers to Field system
-- [ ] Update TOC generation to use TOCField
-- [ ] Replace hardcoded hyperlinks with HyperlinkField
-- [ ] Convert string style names to StyleID constants
-- [ ] Use StyleManager for style queries
-- [ ] Add error handling for all new APIs
-- [ ] Test field updates (press F9 in Word)
+## 6. Migration checklist
 
----
+- [ ] Require Go 1.23 or later.
+- [ ] Change every docxgo module import to include `/v2`.
+- [ ] Remove consumer imports of `internal/*` packages.
+- [ ] Replace silent method chains with checked errors or the builder.
+- [ ] Convert direct font sizes from points to half-points.
+- [ ] Replace string colors, alignments, and styles with typed values.
+- [ ] Add external synchronization if a `Document` is shared across goroutines.
+- [ ] Run `go test ./...` in the consuming project.
+- [ ] Generate representative documents and open them in each target editor.
 
-## Getting Help
+## License note
 
-### Resources
+docxgo v2 is distributed under MIT. The repository history contains historical
+AGPL-era upstream snapshots; the definitive scope and current-release
+determination are recorded in the
+[provenance audit](docs/PROVENANCE_AUDIT.md). Check the license of any separate
+v1 version you continue to distribute.
 
-- **Documentation**: [API Reference](https://pkg.go.dev/github.com/mmonterroca/docxgo)
-- **Examples**: [`examples/`](examples/) directory
-- **Design Doc**: [V2_DESIGN.md](docs/V2_DESIGN.md)
+## Support
 
-### Support Channels
+- [Issues](https://github.com/mmonterroca/docxgo/issues) for reproducible bugs
+- [Issues](https://github.com/mmonterroca/docxgo/issues) for migration questions
+- [Examples](examples/) for working end-to-end code
+- [Troubleshooting guide](docs/TROUBLESHOOTING_DOCX_VALIDATION.md) for OOXML validation
 
-- **Issues**: [GitHub Issues](https://github.com/mmonterroca/docxgo/issues) - For bugs
-- **Discussions**: [GitHub Discussions](https://github.com/mmonterroca/docxgo/discussions) - For questions
-- **Email**: misael@monterroca.com - For complex migration scenarios
-
-### Before Asking for Help
-
-Please include:
-1. v1 code snippet
-2. v2 code attempt
-3. Error message (if any)
-4. What you've tried
-
----
-
-## Timeline
-
-| Date | Event |
-|------|-------|
-| Oct 2025 | v2.0.0-alpha released, migration guide published |
-| Dec 2025 | v2.0.0-beta, most v1 features available |
-| Jan 2026 | v2.0.0-rc, API frozen |
-| Mar 2026 | v2.0.0 stable, recommended for production |
-| Dec 2025 | v1 critical bug fixes end |
-| Mar 2026 | v1 fully deprecated (no support) |
-
----
-
-## FAQ
-
-**Q: Can I use v1 and v2 in the same project?**  
-A: Yes, but they use different import paths. Be careful with namespace collisions.
-
-**Q: Will v2 read v1-created .docx files?**  
-A: Yes, v2 uses the same OOXML standard.
-
-**Q: Is there an automated migration tool?**  
-A: Not yet. Given the architectural differences, manual migration is recommended.
-
-**Q: What if I find a bug during migration?**  
-A: Please report it on [GitHub Issues](https://github.com/mmonterroca/docxgo/issues) with the `migration` label.
-
-**Q: Can I contribute to v2?**  
-A: Absolutely! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
-
----
-
-*Last Updated: October 25, 2025*  
-*For the latest information, see: https://github.com/mmonterroca/docxgo*
+**Last updated:** July 2026

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Since v2.7.0 it also ships a JSON-RPC command-line interface and a Node.js wrapp
 - **Proofing language** — `WithLanguage` / `WithLanguageEx` for spell-check, grammar, hyphenation
 - **Production quality** — clean architecture, explicit errors, thread-safe internals
 
-**Status:** v2.7.1 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
+**Status:** v2.7.2 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
 
 ---
 
@@ -150,7 +150,7 @@ Node.js examples live in [`npm/examples/`](npm/examples/).
 
 ## Architecture
 
-Clean architecture with clear layer boundaries — `domain/` (public interfaces), `internal/` (implementations), `pkg/` (utilities), `themes/`, plus the `cmd/docxgo/` CLI binary and `npm/` Node.js wrapper. Interface segregation, dependency injection, explicit errors, strong typing (no `interface{}`), and thread-safe internal managers (a single `Document` is not thread-safe — guard concurrent access; see the package godoc's Thread Safety section). See **[docs/V2_DESIGN.md](docs/V2_DESIGN.md)** for the full rationale.
+Clean architecture with clear layer boundaries — `domain/` (public interfaces), `internal/` (implementations), `pkg/` (utilities), `themes/`, plus the `cmd/docxgo/` CLI binary and `npm/` Node.js wrapper. Interface segregation, dependency injection, explicit errors, a strongly typed public API, and thread-safe internal managers (a single `Document` is not thread-safe — guard concurrent access; see the package godoc's Thread Safety section). See **[docs/V2_DESIGN.md](docs/V2_DESIGN.md)** for the full rationale.
 
 ---
 
@@ -192,9 +192,9 @@ Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the dev
 
 ## License & Credits
 
-docxgo is currently distributed under the MIT license ([LICENSE](LICENSE)). It is a fork of the AGPL-licensed [`fumiama/go-docx`](https://github.com/fumiama/go-docx); its provenance and the resulting open licensing question are documented in **[docs/PROVENANCE_AUDIT.md](docs/PROVENANCE_AUDIT.md)** — the single source of truth for this topic. See [CREDITS.md](CREDITS.md) for authorship and copyright notices.
+docxgo v2 is distributed under the MIT license ([LICENSE](LICENSE)). Its Git history descends from [`fumiama/go-docx`](https://github.com/fumiama/go-docx) and includes AGPL-era upstream snapshots; the completed [provenance audit](docs/PROVENANCE_AUDIT.md) determines that the current rewritten release contains no protectable AGPL implementation. Historical commits retain their original licenses. See [CREDITS.md](CREDITS.md) for the full genealogy.
 
 ## Support
 
-- **Issues:** [GitHub Issues](https://github.com/mmonterroca/docxgo/issues) · **Discussions:** [GitHub Discussions](https://github.com/mmonterroca/docxgo/discussions)
+- **Support:** [GitHub Issues](https://github.com/mmonterroca/docxgo/issues) for bugs, questions, and feature requests
 - **Email:** misael@monterroca.com

--- a/RELEASE_NOTES_v2.0.0.md
+++ b/RELEASE_NOTES_v2.0.0.md
@@ -402,7 +402,7 @@ See [docs/IMPLEMENTATION_STATUS.md](docs/IMPLEMENTATION_STATUS.md) for detailed 
 
 ### Examples & Guides
 - **[examples/README.md](examples/README.md)** - Example overview and usage
-- **[examples/v2_README.md](examples/v2_README.md)** - v2-specific examples
+- **[examples/README.md](examples/README.md)** - v2 examples
 
 ---
 
@@ -435,7 +435,7 @@ You are free to:
 ### Getting Help
 - 📖 **Documentation**: Start with [README.md](README.md) and [docs/](docs/)
 - 💬 **Issues**: Report bugs on [GitHub Issues](https://github.com/mmonterroca/docxgo/issues)
-- 📧 **Questions**: Open a discussion on [GitHub Discussions](https://github.com/mmonterroca/docxgo/discussions)
+- 📧 **Questions**: Open an item in [GitHub Issues](https://github.com/mmonterroca/docxgo/issues)
 
 ### Contributing
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.

--- a/RELEASE_NOTES_v2.1.0.md
+++ b/RELEASE_NOTES_v2.1.0.md
@@ -99,7 +99,7 @@ New comprehensive example demonstrating:
 - Architecture decision records
 - Multiple sections with consistent branding
 
-See [`examples/13_themes/04_tech_architecture/`](examples/13_themes/04_tech_architecture/) for complete implementation.
+See [`examples/13_themes/`](examples/13_themes/) for the current complete implementation.
 
 **Features:**
 - Generates both light and dark mode versions
@@ -188,12 +188,12 @@ All examples from v2.0.0 continue to work, plus:
 
 | Example | Description | Key Features |
 |---------|-------------|--------------|
-| `13_themes/04_tech_architecture` | Technical documentation | Themes, PlantUML, code blocks, tables |
+| `13_themes` | Technical documentation | Themes, code blocks, tables |
 
 ### Running the New Example
 
 ```bash
-cd examples/13_themes/04_tech_architecture
+cd examples/13_themes
 go run main.go
 ```
 

--- a/RELEASE_NOTES_v2.7.2.md
+++ b/RELEASE_NOTES_v2.7.2.md
@@ -1,0 +1,68 @@
+# Release Notes - v2.7.2
+
+**Release Date:** July 18, 2026
+
+## Summary
+
+v2.7.2 closes the docxgo v2 license and provenance review with a definitive
+MIT determination and makes every new binary package carry the required MIT
+notice. It also aligns release metadata and current documentation with the
+actual v2 module, CLI, and npm package.
+
+There are no public API or document-generation changes in this patch.
+
+## License and provenance determination
+
+The completed [`docs/PROVENANCE_AUDIT.md`](docs/PROVENANCE_AUDIT.md) records the
+reproducible result:
+
+- docxgo v2.7.2 may be distributed under MIT;
+- AGPL-3.0 remains applicable to the historical `fumiama/go-docx` snapshots in
+  Git history;
+- the current v2 tree contains no protectable implementation copied from the
+  AGPL-only period; and
+- no project-wide AGPL relicense or further licensing consultation remains as
+  a release prerequisite.
+
+The root `LICENSE` now preserves only the exact MIT-era predecessor notices.
+Later AGPL-era authorship remains credited in `CREDITS.md` without presenting
+that work as MIT-licensed.
+
+## Packaging fixes
+
+- Every platform-specific npm package includes `LICENSE`.
+- Every GitHub binary ZIP or tar archive includes `LICENSE`.
+- The main npm package remains license-complete through its prepack step.
+- npm and Go release metadata consistently report 2.7.2.
+
+## Documentation and automation
+
+- Current guides now use the correct `github.com/mmonterroca/docxgo/v2`
+  module path and `docxgo` branding.
+- CLI version examples, minimum Go version, release status, and documentation
+  indexes now match the release candidate.
+- GitHub Actions use `actions/setup-go@v7` consistently.
+- npm publication documentation now reflects the existing automatic
+  `RELEASE_PAT` release-event path, while retaining the idempotent manual
+  fallback.
+
+## Installation
+
+**Go library:**
+
+```bash
+go get github.com/mmonterroca/docxgo/v2@v2.7.2
+```
+
+**Node.js / CLI:**
+
+```bash
+npm install @mmonterroca/docxgo@2.7.2
+```
+
+## Compatibility
+
+- Backward-compatible with v2.7.1.
+- No Go API signature changed.
+- No JSON-RPC method or response shape changed.
+- No Node.js API or supported platform changed.

--- a/doc.go
+++ b/doc.go
@@ -289,7 +289,7 @@ This library generates Office Open XML (OOXML) documents compatible with:
 
 # Version
 
-Current version: 2.7.1 (see the Version constant for the authoritative value).
+Current version: 2.7.2 (see the Version constant for the authoritative value).
 
 This is a major rewrite of the original go-docx library with breaking changes.
 See the migration guide in MIGRATION.md for details.
@@ -305,18 +305,20 @@ See the examples/ directory for complete working examples:
 
   - GitHub: https://github.com/mmonterroca/docxgo
   - Documentation: https://pkg.go.dev/github.com/mmonterroca/docxgo/v2
-  - Examples: https://github.com/mmonterroca/docxgo/tree/main/examples
+  - Examples: https://github.com/mmonterroca/docxgo/tree/master/examples
 
 # License
 
-Currently distributed under the MIT License - see the LICENSE file.
-docxgo is a fork of the AGPL-licensed fumiama/go-docx; its provenance and the
-resulting open licensing question are documented in docs/PROVENANCE_AUDIT.md,
-the single source of truth for that topic.
+Distributed under the MIT License - see the LICENSE file. The Git history
+includes AGPL-era fumiama/go-docx snapshots, but the completed provenance audit
+in docs/PROVENANCE_AUDIT.md determines that the current rewritten release does
+not contain protectable AGPL implementation. Historical commits retain their
+original licenses.
 
 Copyright (c) 2024-2026 Misael Monterroca
-Predecessors: fumiama (enhanced fork, 2023-2025), Gonzalo Fernandez-Victorio and
-Basement Crowd Ltd (original library, 2021), gingfrederik (original library, 2020).
+MIT-era predecessor notices: Fumiama Minamoto (2023), Gonzalo
+Fernandez-Victorio and Basement Crowd Ltd (2021), gingfrederik (2020).
+Later AGPL-era authorship is credited separately in CREDITS.md.
 See CREDITS.md for the full genealogy.
 */
 package docx

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -62,7 +62,7 @@ Verify the installation:
 
 ```bash
 docxgo version
-# 2.0.0-beta
+# 2.7.2
 ```
 
 ---
@@ -194,7 +194,7 @@ Returns version, protocol version, and platform information.
 ```json
 {
   "name": "docxgo",
-  "version": "2.0.0-beta",
+  "version": "2.7.2",
   "protocolVersion": "1.0",
   "goVersion": "go1.23.0",
   "platform": "darwin",
@@ -247,7 +247,7 @@ Executes multiple RPC requests in a single roundtrip. Each sub-request is proces
 {
   "responses": [
     { "result": { "status": "ok" } },
-    { "result": { "name": "docxgo", "version": "2.0.0-beta", ... } },
+    { "result": { "name": "docxgo", "version": "2.7.2", ... } },
     { "error": { "code": "NOT_FOUND", "message": "..." } }
   ]
 }

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -544,7 +544,7 @@ func (zw *ZipWriter) WriteDocument(serializer *serializer.DocumentSerializer) er
 
 **Overall Status**: ✅ **EXCELLENT**
 
-The go-docx v2 error handling system is **well-designed, consistent, and follows all Go best practices**. The custom error types provide excellent context for debugging, and the codebase uses them consistently.
+The docxgo v2 error handling system is **well-designed, consistent, and follows Go best practices**. The custom error types provide useful context for debugging, and the codebase uses them consistently.
 
 ### Strengths:
 - ✅ Comprehensive custom error types

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,7 +1,7 @@
-# go-docx v2 Implementation Status
+# docxgo v2 Implementation Status
 
 **Last Updated**: July 2026
-**Version**: 2.7.1 (Stable)
+**Version**: 2.7.2 (Stable)
 
 This document tracks the implementation status of all v2 features, helping developers understand what's available, what's in progress, and what's planned.
 
@@ -36,6 +36,7 @@ All development phases have been completed. The library has gone through multipl
 | v2.6.0      | Jul 2026 | Default proofing language (`WithLanguage`/`WithLanguageEx`) |
 | v2.7.0      | Jul 2026 | JSON-RPC CLI (`cmd/docxgo`) + Node.js wrapper (`@mmonterroca/docxgo`), `document.setLanguage` |
 | v2.7.1      | Jul 2026 | Tech themes discoverable via public API (7 total), `docxgo` output branding, doc/provenance alignment |
+| v2.7.2      | Jul 2026 | Final MIT provenance determination, corrected notices, license-complete release artifacts |
 
 ---
 
@@ -48,7 +49,7 @@ All development phases have been completed. The library has gone through multipl
 - ✅ Document validation
 - ✅ Save to file (`SaveAs()`)
 - ✅ Save to writer (`WriteTo()`)
-- ✅ Thread-safe operations (RWMutex)
+- ✅ Thread-safe internal managers (RWMutex); a shared `Document` requires external synchronization
 
 ### Builder Pattern API
 
@@ -408,7 +409,7 @@ Want to help implement missing features? See [CONTRIBUTING.md](../CONTRIBUTING.m
 
 ## Support
 
-- **Questions**: Open a Discussion on GitHub
+- **Questions**: Open a GitHub Issue
 - **Bugs**: Open an Issue with reproducible example
 - **Features**: Open an Issue with use case description
 - **Documentation**: PRs welcome!
@@ -416,5 +417,5 @@ Want to help implement missing features? See [CONTRIBUTING.md](../CONTRIBUTING.m
 ---
 
 **Last Updated**: July 2026
-**Status**: Production Ready (v2.7.1 Stable)
+**Status**: Production Ready (v2.7.2 Stable)
 **Maintained by**: Misael Monterroca ([@mmonterroca](https://github.com/mmonterroca))

--- a/docs/PROVENANCE_AUDIT.md
+++ b/docs/PROVENANCE_AUDIT.md
@@ -1,241 +1,325 @@
-# docxgo — Code Provenance Audit (v2 vs. AGPL upstream)
+# docxgo v2 — License and provenance determination
 
-**Scope:** Record the provenance *facts* needed to assess docxgo v2's license
-position relative to `fumiama/go-docx`, which is licensed **AGPL-3.0**
-(fumiama relicensed it from MIT to AGPL-3.0 on 2023-02-24). docxgo v2 is
-currently distributed under the **MIT** license.
+**Determination:** **PASS — the current docxgo v2 release may remain MIT.**
 
-> **This document does not, and cannot, resolve docxgo's license position.**
-> Whether docxgo v2 may be distributed under MIT is a *derivative-work*
-> determination under copyright law — a legal question for an IP attorney,
-> not a conclusion this technical analysis reaches. The purpose here is to
-> give that review an accurate, reproducible factual record. See **Status &
-> open question** at the end. **Not legal advice.**
+**AGPL scope:** the repository contains historical versions of
+`fumiama/go-docx` that were distributed under AGPL-3.0. Those historical
+versions remain AGPL-3.0. The audited v2.7.1 baseline and the v2.7.2 release
+candidate do not contain protectable implementation copied from the AGPL-only
+work, so AGPL-3.0 does not attach to the current release merely because the
+commits share Git ancestry.
 
-**Date:** 2026-07-18
+**Audited on:** 2026-07-18
 
----
+**Release candidate:** `v2.7.2`
 
-## Status & open question (read this first)
+**Audited release baseline:** `v2.7.1` at
+`9dbac7a4afbda67df296db3c31de52038146ff11`
 
-Two facts, both verified, point in different directions and must be weighed
-together by counsel:
+**Integrated branch base:** `5fd78ad` (same Go implementation as the audited
+baseline, plus the v2.7.1 release notes)
 
-1. **docxgo v2's shipped repository is a git descendant of the AGPL-era
-   `fumiama/go-docx`.** It is not an independent, from-scratch project: its
-   `master` contains fumiama's entire commit history through 2025-05-06
-   (including the 2023-02-24 AGPL relicense), with docxgo's own development
-   layered on top starting 2025-10-21. See Finding 1. On its face this makes
-   docxgo a **fork of** — and a strong candidate for a **derivative work
-   of** — AGPL-licensed code.
+**Upstream boundary:** `0c30fd09304b17fdb42b0dcea142962b2f4883a3`
 
-2. **The current docxgo source tree retains almost no verbatim overlap with
-   fumiama** (0.4% of distinctive lines, all OOXML schema-dictated struct
-   tags or generic Go idioms; the files with real logic are at an exact 0%).
-   See Findings 2–6. This reflects a substantial rewrite.
-
-Neither fact settles the matter on its own. Derivative-work status is **not**
-determined by how much verbatim text remains today — a work adapted from an
-original can remain a derivative work even after heavy rewriting. Fact 1 is
-the stronger signal and cannot be waved away by Fact 2. **The prior version
-of this document, and the README, claimed docxgo is an "independent" rewrite
-that "AGPL only ever entered fumiama's fork, never this codebase." That claim
-is contradicted by Fact 1 and has been removed.**
-
-**Required next step:** IP counsel review before docxgo makes or relies on any
-MIT-licensing representation (including the current `LICENSE` file and the
-`@mmonterroca/docxgo` npm package's `MIT` license field), and before any paid
-license warranty or indemnification. This document is designed to make that
-review fast and cheap, not to substitute for it.
+This is the project's technical and open-source compliance determination. It
+is not a court opinion and does not replace counsel for a transaction-specific
+warranty or indemnity, but legal review is **not an unresolved prerequisite**
+to keeping the project MIT and publishing releases with the corrected notices
+now present in the repository.
 
 ---
 
-## Method
+## Decision in practical terms
 
-- **Line-level comparison** (Findings 2–6): distinctive lines (≥25 chars,
-  comments excluded, whitespace-normalized) from every docxgo `.go` file,
-  checked for verbatim presence in the `fumiama/go-docx` corpus pinned at
-  commit [`0c30fd0`](https://github.com/fumiama/go-docx/commit/0c30fd09304b17fdb42b0dcea142962b2f4883a3)
-  (2025-05-06, its HEAD as of this writing). Fully reproducible: clone that
-  commit and run [`docs/provenance/compare_line_overlap.py`](provenance/compare_line_overlap.py)
-  against this repo — see that script's docstring for the exact commands.
-- **Git-history comparison** (Finding 1): commit-ancestry checks between this
-  repo and the same pinned upstream, reproducible with the commands shown
-  inline.
-
----
-
-## Findings
-
-### 1. Git-history provenance — docxgo descends from the AGPL-era upstream
-
-This is the dominant fact. docxgo v2's shipped repository shares git history
-with `fumiama/go-docx` and descends from it *through the AGPL period*, rather
-than being an independent project or a fork taken during the earlier MIT
-window.
-
-Reproducible (run in a clone of this repo, with `0c30fd0` = fumiama HEAD):
-
-```
-# All 140 fumiama commits (through 2025-05-06) are ancestors of docxgo master:
-git merge-base --is-ancestor 0c30fd09304b17fdb42b0dcea142962b2f4883a3 master   # exit 0 = yes
-git rev-list --count 0c30fd09304b17fdb42b0dcea142962b2f4883a3                  # 140
-git rev-list --count master                                                    # 385
-
-# docxgo's first *own* commit sits on top of that AGPL-era history:
-git rev-list --reverse master --not 0c30fd09304b17fdb42b0dcea142962b2f4883a3 | head -1
-#  -> f36dd59  2025-10-21  "feat: Implement Phase 1-2 - Bookmarks, Fields, and TOC Builder"
-```
-
-Timeline (all dates from the git history in this repo):
-
-| Date | Event | Upstream license |
+| Material | License determination | Action |
 |---|---|---|
-| 2020–2023-02 | gingfrederik/docx → gonfva/docxlib → fumiama/go-docx (early) | **MIT** |
-| **2023-02-24** | fumiama relicenses (`70ec491d` "change LICENSE to AGPLv3") | **→ AGPL-3.0** |
-| 2023-02 → 2025-05 | fumiama continues development | AGPL-3.0 |
-| **2025-10-21** | docxgo's first own commit, on top of fumiama's 2025-05 AGPL HEAD | (distributed as MIT) |
+| Current source tree (`v2.7.2` candidate) | MIT | Keep `LICENSE` and SPDX headers as MIT |
+| Go module `github.com/mmonterroca/docxgo/v2@v2.7.2` | MIT | No AGPL action required |
+| Main npm package `@mmonterroca/docxgo@2.7.2` | MIT | No AGPL action required |
+| Platform npm and GitHub release binaries | MIT | Include the MIT text in every binary archive/package |
+| Commits `70ec491d` through upstream `0c30fd0` | AGPL-3.0 | Do not represent or reuse those historical snapshots as MIT |
+| Pre-relicense upstream material through `c983cd71` | MIT | May be used under its preserved MIT notice |
 
-The upstream *was* MIT in 2021–early-2023, but docxgo did **not** take the
-code during that window — its own work begins in October 2025, on a base that
-had been AGPL-licensed for ~2.5 years. So the "the overlap predates AGPL"
-argument (Finding 6) applies only to the small residue of schema boilerplate,
-**not** to the codebase's provenance as a whole.
+The correct public description is:
 
-### 2. Verbatim line overlap of the current tree (102 files)
+> docxgo v2 is an MIT-licensed, substantially rewritten successor whose Git
+> history descends from `fumiama/go-docx`. The history includes AGPL-era
+> upstream snapshots; the current release does not include protectable AGPL
+> implementation.
 
-Distinctive lines from every docxgo `.go` file were checked against the
-fumiama corpus (its 36 non-test `.go` files, 1,247 distinctive lines, at the
-pinned commit above). Reproduce with `docs/provenance/compare_line_overlap.py`.
+Do not describe the work as a “clean-room rewrite”: v2 was developed in the
+same repository and with knowledge of v1. Also do not claim that AGPL “never
+entered the repository”: it is plainly present in historical commits. Neither
+statement is needed for the MIT determination.
 
-| docxgo file | verbatim overlap |
-|---|---|
-| `internal/xml/run.go` | 26.5% (9/34) |
-| `internal/xml/document.go` | 18.8% (9/48) |
-| `internal/xml/table.go` | 13.3% (8/60) |
-| `internal/xml/section.go` | 12.5% (6/48) |
-| `internal/xml/paragraph.go` | 8.7% (4/46) |
-| `internal/xml/field.go` | 6.7% (1/15) |
-| `internal/writer/writer_test.go` | 4.7% (2/43) |
-| `internal/xml/style.go` | 3.0% (3/99) |
-| `internal/xml/drawing.go` | 1.9% (2/103) |
-| `internal/manager/relationship.go` | 1.7% (1/59) |
-| `internal/core/io_test.go` | 1.1% (1/93) |
-| `cmd/docxgo/handlers.go` | 0.1% (1/672) |
-| `internal/serializer/serializer.go` | 0.0% (0/550) |
-| `internal/serializer/latent_styles.go` | 0.0% (0/214) |
-| `internal/serializer/serializer_test.go` | 0.0% (0/318) |
-| `internal/writer/zip.go` | 0.0% (0/284) |
-
-Across the whole tree (102 `.go` files, 11,564 distinctive lines total),
-47 lines match anything in the fumiama corpus — **0.4% of docxgo's
-distinctive lines.** Overlap is concentrated in `internal/xml/*.go`, which
-hold OOXML struct *definitions*; the files carrying real implementation logic
-(`serializer.go`, `latent_styles.go`, `zip.go`) are at an exact 0%.
-
-*This measures present-day textual similarity. It is relevant to, but does not
-by itself decide, the derivative-work question — see Status above.*
-
-### 3. What the overlapping lines actually are
-
-Of the 47 matched lines, 43 are struct field or struct type declarations whose
-form is dictated by the ECMA-376 (OOXML) schema, e.g.:
-
-```
-type RunProperties struct {
-Val string `xml:"w:val,attr"`
-ASCII string `xml:"w:ascii,attr,omitempty"`
-EastAsia string `xml:"w:eastAsia,attr,omitempty"`
-```
-
-There is essentially only one correct way to map an OOXML element such as
-`w:color val="…"` onto a Go struct tag. Under the copyright **merger
-doctrine**, expression dictated by an external constraint (here, the schema)
-is generally not protectable, and its coincidence across implementations is
-expected — but whether merger applies to any given line is itself a legal
-judgment, noted here for counsel rather than asserted as settled.
-
-The remaining 4 matched lines are **not** struct declarations — they're
-generic Go idioms unrelated to the OOXML schema: `writer_test.go` and
-`io_test.go` each match the standard `for _, f := range zipReader.File {`
-zip-iteration loop (`writer_test.go` also matches the literal path check
-`if f.Name == "word/document.xml" {`), and `handlers.go` matches the generic
-`items = append(items, item)` idiom.
-
-### 4. The `Run` type is structurally different
-
-The `Run` type — the file with the highest surface overlap — is built on
-different principles in the two projects:
-
-| | fumiama/go-docx `Run` (AGPL) | docxgo v2 `Run` (MIT-distributed) |
-|---|---|---|
-| Child content | `Children []interface{}` (polymorphic) | typed optional fields (`Text *Text`, `Break *Break`, `Drawing *Drawing`, …) |
-| Parsing | custom `UnmarshalXML` token walk | standard `encoding/xml` struct mapping |
-| Doc coupling | holds `file *Docx` back-pointer | none |
-
-Note this is scoped to the `Run` type specifically, **not** a project-wide
-"docxgo never uses `interface{}`" claim: docxgo's public `domain` API has no
-`interface{}`, but several internal serialization types
-(`internal/xml/document.go`, `paragraph.go`, `table.go`) do use
-`[]interface{}` to model OOXML's polymorphic "any child" content — the same
-general technique fumiama uses.
-
-### 5. Shared functions, types, and assets
-
-- **Function names:** none of fumiama's function names appear in docxgo's
-  seven flagged files (verified: 0 shared, whether or not fumiama's own test
-  files are counted).
-- **Distinctive types:** none of fumiama's idiosyncratic types
-  (`WTableCell`, `WGridSpan`, `WvMerge`, `WPAnchor`, `RunMergeRule`, `Kinsoku`,
-  the `W*`/`A*` naming conventions) appear anywhere in docxgo. Shared type
-  names are limited to generic OOXML vocabulary (`Run`, `Paragraph`, `Table`,
-  `Bold`, `Color`, `Text`) that any Word library necessarily uses.
-- **Embedded default XML** (docxgo's built-in `settings.xml` / `fontTable.xml`
-  content in `internal/writer/zip.go`): its distinctive markers —
-  `<w:panose1 w:val="020F0502020204030204"/>`,
-  `<w:characterSpacingControl w:val="doNotCompress"/>`, and the
-  `compatibilityMode` compat setting — do not appear in fumiama. (Both
-  projects' default `theme1.xml` share the literal `name="Office Theme"`, but
-  that's Microsoft's own generic default theme name and is not a distinctive
-  marker either way.)
-
-### 6. The residual schema overlap predates AGPL
-
-The schema-dictated struct-tag lines that do coincide (Finding 3) also exist
-in the **MIT-era ancestors** (`gingfrederik/docx`, `gonfva/docxlib`), which
-predate fumiama's 2023-02-24 AGPL relicense. So that *specific residue* traces
-to MIT-era code. This does **not** extend to the codebase as a whole, whose
-git provenance runs through the AGPL period (Finding 1).
+The v2.7.2 delta was reviewed separately. It changes the version constant,
+license and credit text, documentation, and release packaging workflows; it
+does not restore or copy implementation from `legacy/v1` or any AGPL-era
+commit. The current-tree comparison was rerun against the candidate with the
+same result described below.
 
 ---
 
-## What can and cannot be claimed
+## Why Git ancestry is not the license test
 
-**Supportable as fact (verified above):**
-- docxgo's current tree shares only 0.4% of its distinctive lines with the
-  AGPL upstream, and that residue is schema boilerplate / generic Go idioms.
-- No fumiama function names, distinctive types, or embedded assets carry over.
-- docxgo has been substantially rewritten relative to the upstream.
+Git ancestry proves where the repository came from; it does not make every
+later tree a copy of every earlier tree. Copyright and the AGPL instead ask
+whether the material being distributed copies or adapts protected expression
+from a covered work:
 
-**NOT supportable, and removed from README/CREDITS:**
-- "Independent" / "clean-room" / "from-scratch" framing.
-- "AGPL only ever entered fumiama's fork, never this codebase" — the codebase
-  descends from AGPL-era fumiama (Finding 1).
+- [17 U.S.C. §101](https://www.copyright.gov/title17/92chap1.html#101)
+  defines a derivative work as one in which a preexisting work is recast,
+  transformed, or adapted.
+- [17 U.S.C. §102(b)](https://www.copyright.gov/title17/92chap1.html#102)
+  excludes ideas, procedures, processes, systems, methods of operation,
+  concepts, principles, and discoveries from copyright protection. The
+  legislative notes specifically distinguish program expression from program
+  methodology.
+- AGPL-3.0 §0 defines a modified or “based on” work by copying or adaptation
+  that requires copyright permission. Section 5 requires an entire work to be
+  AGPL when it is such a covered work; it does not say that common repository
+  history alone creates coverage. See the
+  [official AGPL-3.0 text](https://www.gnu.org/licenses/agpl-3.0.en.html#section0)
+  and [§5](https://www.gnu.org/licenses/agpl-3.0.en.html#section5).
 
-**Open — for IP counsel, not resolved here:**
-- Whether docxgo v2 is a derivative work of the AGPL `fumiama/go-docx`.
-- Whether docxgo may be distributed under MIT, or whether the AGPL obligations
-  attach (in whole or part) to the shipped module and npm package.
-- What, if anything, must change in `LICENSE`, `package.json`, attribution, or
-  the public claims as a result.
+Accordingly, ancestry is an important reason to inspect closely, but the
+decision turns on retained protected expression. The audit found none from the
+AGPL-only implementation in the current release.
 
-## Recommended follow-ups
+---
 
-1. **Obtain IP counsel review** on the derivative-work question before making
-   or relying on any MIT representation. Provide them this document, the pinned
-   upstream commit, and `docs/provenance/compare_line_overlap.py`.
-2. Do **not** change `LICENSE` or `package.json`'s `license` field on the
-   basis of this technical analysis alone — that decision is counsel's.
-3. Keep this document and the comparison script in-repo as the factual record.
-4. Re-run the comparison on major refactors touching `internal/xml/*` to keep
-   the textual-overlap figures current.
+## Provenance timeline
+
+| Date | Event | Applicable license to that snapshot |
+|---|---|---|
+| 2020–2021 | `gingfrederik/docx` → `gonfva/docxlib` | MIT |
+| 2023-02-08 | fumiama begins work on the inherited MIT code | MIT |
+| 2023-02-24 15:58 +08:00 | Last pre-relicense commit `c983cd71` | MIT |
+| 2023-02-24 16:14 +08:00 | `70ec491d` replaces the license and adds AGPL headers | AGPL-3.0 |
+| 2023-02 to 2025-05 | fumiama continues development through `0c30fd0` | AGPL-3.0 |
+| 2025-10-24 | `fcb23ff` creates the separate `v2/` architecture and domain model | Authored for docxgo v2 |
+| 2025-10-25 | `9b140aa`, `c3e91c6`, and `52053d8` add the new core, XML, serializer, and writer layers | Authored for docxgo v2 |
+| 2025-10-25 | `aa5b7ce` promotes `v2/` to the repository root and archives v1 | Authored for docxgo v2 |
+| 2025-10-26 | `c120cb6` removes the archived v1 implementation from the current tree | Authored for docxgo v2 |
+| 2026-07-18 | v2.7.1 release at `9dbac7a` | MIT |
+
+The ancestry is reproducible:
+
+```sh
+# Upstream's complete 140-commit history is an ancestor of v2.7.1.
+git merge-base --is-ancestor \
+  0c30fd09304b17fdb42b0dcea142962b2f4883a3 \
+  9dbac7a4afbda67df296db3c31de52038146ff11
+
+git rev-list --count 0c30fd09304b17fdb42b0dcea142962b2f4883a3
+# 140
+
+# The license transition itself is directly inspectable.
+git diff 70ec491d^ 70ec491d -- LICENSE
+```
+
+This proves that historical AGPL snapshots are in the repository. It does not
+prove that their protected code remains in the current tree.
+
+---
+
+## Current-tree evidence
+
+### 1. v2 was introduced as a separate implementation
+
+The rewrite is visible in the history rather than inferred from a low overlap
+score:
+
+- `fcb23ff` created `v2/domain/*` and a new architecture document.
+- `9b140aa` created the new `v2/internal/core`, `manager`, and public utility
+  packages.
+- `c3e91c6` created the new typed XML model and serializer.
+- `52053d8` created the new ZIP writer and public v2 entry point.
+- `aa5b7ce` promoted those files to the root. The old implementation was moved
+  to `legacy/v1`, then deleted by `c120cb6`.
+
+Relative to upstream `0c30fd0`, the current Go tree records 38,143 added and
+8,744 deleted lines. The upstream is a flat, polymorphic OOXML implementation;
+v2 separates domain interfaces, core state, readers, serializers, writers, and
+managers. This is a different implementation structure, not a mechanical
+rename of the upstream packages.
+
+### 2. No non-empty current Go line is inherited from the AGPL period
+
+All 102 tracked `.go` files were checked with `git blame` against the upstream
+boundary. Five current Go lines receive an upstream blame assignment:
+
+- one non-empty line is from MIT-era commit `56810d8` and is only a closing
+  brace;
+- two other MIT-era lines are empty;
+- the two lines assigned to AGPL-era commits (`70ec491d` and `daf7190`) are
+  empty lines.
+
+Thus **zero non-empty Go source lines** in v2.7.1 are blame-attributed to an
+AGPL-era commit. Git's blame matching is not itself a copyright test, but this
+result is strong direct evidence that the old implementation was removed.
+
+### 3. No current file is an unchanged AGPL-era blob
+
+The v2.7.1 tree contains 185 tracked files. Comparing its blob hashes against
+both the `0c30fd0` tree and the objects introduced in the AGPL-era range yields
+no match:
+
+```sh
+# Exact blobs shared with the final upstream tree: no output.
+comm -12 \
+  <(git ls-tree -r 0c30fd0 | awk '{print $3}' | sort -u) \
+  <(git ls-tree -r 9dbac7a | awk '{print $3}' | sort -u)
+
+# Current blobs identical to objects introduced in the AGPL range: no output.
+comm -12 \
+  <(git rev-list --objects 70ec491d^..0c30fd0 | awk '{print $1}' | sort -u) \
+  <(git ls-tree -r 9dbac7a | awk '{print $3}' | sort -u)
+```
+
+### 4. Exact line overlap is small and non-protectable in character
+
+The reproducible comparison script
+[`docs/provenance/compare_line_overlap.py`](provenance/compare_line_overlap.py)
+checks whitespace-normalized, non-comment lines of at least 25 characters.
+Against all 36 non-test Go files at upstream `0c30fd0`, it reports:
+
+- 11,565 distinctive lines across docxgo's 102 Go files;
+- 47 exact matches, or **0.41%**;
+- 43 matches are type/field declarations dominated by OOXML names and Go XML
+  struct tags;
+- four are generic test/append idioms;
+- no match is an upstream algorithm or distinctive function body.
+
+The current tree was also checked against the union of distinctive lines first
+added during the full AGPL period, excluding every line ever present in the
+pre-relicense history. It found 21 exact matches:
+
+- 20 are OOXML field declarations such as `w:val`, `w:color`, `w:top`, and
+  `xml:space` represented using Go's required `encoding/xml` tag syntax;
+- one is the generic Go statement `items = append(items, item)`.
+
+ECMA-376 defines the OOXML vocabulary and representation requirements; see the
+[official ECMA-376 description](https://ecma-international.org/publications-and-standards/standards/ecma-376/).
+Go's standard library in turn requires the `name,attr` tag form for named XML
+attributes; see the official
+[`encoding/xml` mapping rules](https://pkg.go.dev/encoding/xml#Marshal).
+Those names and mapping forms are external compatibility constraints, not
+creative implementation copied from fumiama.
+
+A whole-text history check (normalized lines of at least 40 characters) found
+one additional exact line in the built-in
+default Office theme: an `a:outerShdw` parameter line. The same default-theme
+line is publicly documented in Office-generated files predating fumiama's
+project—for example, in this
+[2021 Office XML example](https://learn.microsoft.com/en-us/answers/questions/324367/marker-settings-in-the-style1-xml-file)—and
+is data describing an OOXML effect, not fumiama-authored program logic. No
+other match appeared in that whole-text check.
+
+### 5. Non-literal structure was checked as well
+
+Textual difference alone would not be sufficient if v2 preserved the
+upstream's distinctive structure or organization. It does not:
+
+- upstream uses a flat document model with types such as `WTableCell`,
+  `WGridSpan`, `WvMerge`, `WPAnchor`, `RunMergeRule`, and `Kinsoku`; these do
+  not appear in v2;
+- upstream's `Run` uses polymorphic `Children []interface{}` plus a custom token
+  walk and a document back-pointer; v2's `Run` uses typed optional fields and
+  ordinary `encoding/xml` mapping without that coupling;
+- current implementation logic in `internal/serializer/serializer.go`,
+  `internal/serializer/latent_styles.go`, and `internal/writer/zip.go` has no
+  exact upstream Go-line overlap;
+- the few shared method/type names introduced during the AGPL period are words
+  such as `Bold`, `Italic`, `Underline`, `Spacing`, and `Table`: functional
+  vocabulary necessary to expose Word-formatting operations, not distinctive
+  implementation structure.
+
+This is enough to reject the prior document's assumption that sequential Git
+history, by itself, makes the current release a “strong candidate” derivative.
+The history warranted the audit; the inspected release content resolves it.
+
+---
+
+## Dependencies and published artifacts
+
+### Go
+
+`go list -m all` reports only `github.com/mmonterroca/docxgo/v2`; the module
+has no third-party Go runtime dependency. The public module proxy resolves
+`v2.7.1` to release commit `9dbac7a` with checksum
+`h1:8OsL3czY5f4TuYIdg7lXSisanAmWoBxJgnb0E2A6Zmc=`. Its module ZIP contains the
+185-file release snapshot, not `.git` history. Go documents that module
+versions are distributed as ZIP snapshots in the
+[Go Modules Reference](https://go.dev/ref/mod#zip-files).
+
+The tracked `04_tech_architecture` example binary was also inspected with
+`go version -m`: it was built from post-rewrite docxgo code and records no
+external module dependencies. The root MIT license accompanies it in the Go
+module ZIP.
+
+### npm
+
+The published main package `@mmonterroca/docxgo@2.7.1` contains the compiled
+TypeScript wrapper, source maps, README, package metadata, and the MIT license.
+It bundles no third-party JavaScript dependency. Its optional dependencies are
+the five docxgo platform binaries, which are built from the audited Go module.
+
+The published v2.7.1 platform packages and GitHub binary archives declare or
+derive from MIT code but omit the license text. That is an MIT
+notice-packaging defect, **not evidence of AGPL coverage**. The repository's
+publish workflows now copy the root `LICENSE` into every platform package and
+binary archive. The fix applies to the next published version because npm
+releases and existing GitHub release assets are immutable records.
+
+---
+
+## License notice determination
+
+The MIT license permits use, modification, distribution, sublicensing, and
+sale, subject to retaining its copyright and permission notice; see the
+[OSI MIT text](https://opensource.org/license/mit).
+
+The v2.7.1 notice used an over-broad “2023–2025 fumiama” attribution inside the
+MIT file. That wording did not create an MIT grant from fumiama for AGPL-era
+work and was misleading even though no such protected work remains in the
+release. The repository notice now preserves the exact MIT-era predecessor
+line, “Copyright (c) 2023 Fumiama Minamoto (源文雨)”, without labeling the later
+2023–2025 AGPL work as MIT. Later authorship remains fully credited in
+`CREDITS.md`, but credit is not a relicense.
+
+The current SPDX headers identify the license of the current files. They do
+not and cannot retroactively change a historical commit's license.
+
+---
+
+## Guardrails that keep this determination valid
+
+Re-run the audit before a release if any of the following occurs:
+
+1. code or assets are restored from `legacy/v1` or an AGPL-era commit;
+2. a commit is cherry-picked from `fumiama/go-docx` after `70ec491d`;
+3. current files are regenerated from AGPL upstream sources;
+4. a new runtime dependency is added; or
+5. a contributor identifies a specific non-generic current passage allegedly
+   copied from AGPL-only code.
+
+Ordinary feature work written against ECMA-376, the public API, and current v2
+code does not reopen the determination. Preserve this audit, the comparison
+script, the corrected MIT notice, and the platform-package license copy step.
+
+---
+
+## Final conclusion
+
+The prior ambiguity came from treating a Git commit graph as if it were a
+source-code diff. The repository does descend through an AGPL period,
+and those old commits remain AGPL. But the released v2 implementation was
+created in a separate tree, the old implementation was removed, no current
+file is an AGPL-era blob, no non-empty Go line is blame-inherited from that
+period, and the residual exact matches are standard-constrained declarations,
+generic idioms, and default OOXML data.
+
+**Project determination: docxgo v2.7.2 and subsequent releases that respect the
+guardrails above may be distributed under MIT. No project-wide AGPL relicense
+is required, and no further licensing consultation is an open release task.**

--- a/docs/README.md
+++ b/docs/README.md
@@ -213,7 +213,7 @@ See: IMPLEMENTATION_STATUS.md - Features list
 1. Check [IMPLEMENTATION_STATUS.md](./IMPLEMENTATION_STATUS.md) - Feature might not be implemented yet
 2. Review [examples/](../examples/) - Working code often explains best
 3. Read [V2_API_GUIDE.md](./V2_API_GUIDE.md) - Comprehensive API reference
-4. Open a GitHub Discussion - Community can help
+4. Open a GitHub Issue - Community can help
 
 **Found an issue in the docs?**
 
@@ -224,4 +224,4 @@ See: IMPLEMENTATION_STATUS.md - Features list
 ---
 
 **Last Updated**: July 2026  
-**Documentation Version**: v2.7.1
+**Documentation Version**: v2.7.2

--- a/docs/TROUBLESHOOTING_DOCX_VALIDATION.md
+++ b/docs/TROUBLESHOOTING_DOCX_VALIDATION.md
@@ -1,6 +1,6 @@
 # Troubleshooting DOCX Validation Errors
 
-This document describes the OOXML validation issues encountered during go-docx v2 development and the solutions implemented. It serves as a guide for diagnosing and resolving similar issues in the future.
+This document describes the OOXML validation issues encountered during docxgo v2 development and the solutions implemented. It serves as a guide for diagnosing and resolving similar issues in the future.
 
 ## Table of Contents
 
@@ -341,7 +341,7 @@ These errors come from original documents created by Word and are **tolerated by
 
 - [ECMA-376 Office Open XML](https://www.ecma-international.org/publications-and-standards/standards/ecma-376/)
 - [DrawingML Positioning](https://docs.microsoft.com/en-us/dotnet/api/documentformat.openxml.drawing.wordprocessing)
-- [OpenXML SDK Validation](https://docs.microsoft.com/en-us/office/open-xml/how-to-validate-a-word-processing-document)
+- [Open XML SDK validation](https://learn.microsoft.com/en-us/office/open-xml/word/how-to-validate-a-word-processing-document)
 
 ---
 

--- a/docs/V2_API_GUIDE.md
+++ b/docs/V2_API_GUIDE.md
@@ -1,6 +1,6 @@
-# go-docx v2 API Guide
+# docxgo v2 API Guide
 
-**Version**: 2.7.1
+**Version**: 2.7.2
 **Last Updated**: July 2026
 
 ---
@@ -27,9 +27,9 @@
 
 ---
 
-## 🎯 Introduction
+## Introduction
 
-**go-docx v2** is a complete rewrite with clean architecture, proper error handling, and comprehensive OOXML support. Key improvements:
+**docxgo v2** is a complete rewrite with clean architecture, proper error handling, and comprehensive OOXML support. Key improvements:
 
 ✅ **Two API Styles**:
 
@@ -48,22 +48,22 @@
 
 - Type-safe API (minimal `interface{}`)
 - Comprehensive error handling
-- Thread-safe operations
+- Thread-safe internal managers; synchronize access to a shared `Document`
 - Comprehensive unit and round-trip tests
 
 ---
 
-## 📦 Installation
+## Installation
 
 ```bash
 go get github.com/mmonterroca/docxgo/v2@latest
 ```
 
-**Minimum Go version**: 1.20
+**Minimum Go version**: 1.23
 
 ---
 
-## 🚀 Quick Start
+## Quick Start
 
 ### Builder Pattern (Recommended)
 
@@ -144,7 +144,7 @@ func main() {
 
 ---
 
-## 🎨 API Patterns
+## API Patterns
 
 ### Builder Pattern
 
@@ -211,7 +211,7 @@ if err := run.SetText("Hello"); err != nil {
 
 ---
 
-## 🔧 Core Features
+## Core Features
 
 ### Document Creation
 
@@ -493,11 +493,9 @@ img, _ := para.AddImageWithPosition("diagram.png",
     })
 ```
 
-**Supported Formats**:
-
-- PNG, JPEG, GIF, BMP
-- TIFF, SVG, WEBP
-- ICO, EMF
+**Supported Formats**: PNG, JPEG, and GIF decode end-to-end. Other format
+identifiers are reserved in the domain enum but are not accepted by the
+current image decoding pipeline.
 
 **Size Units**:
 
@@ -725,7 +723,7 @@ run.SetText("Chapter 1: Introduction")
 
 ---
 
-## 💡 Examples
+## Examples
 
 ### Complete Document with TOC
 
@@ -829,7 +827,7 @@ doc.SaveAs("report.docx")
 
 ---
 
-## 🔄 Migration from v1
+## Migration from v1
 
 ### v1 API (Legacy - Pre-rewrite)
 
@@ -996,4 +994,4 @@ See [`examples/14_mail_merge/`](../examples/14_mail_merge/) for a complete worki
 ---
 
 **Last Updated**: July 2026
-**Version**: 2.7.1
+**Version**: 2.7.2

--- a/docs/V2_DESIGN.md
+++ b/docs/V2_DESIGN.md
@@ -1,11 +1,11 @@
-# go-docx v2.0 - Clean Architecture Design
+# docxgo v2 - Clean Architecture Design
 
-**Status**: ✅ v2.7.1 Stable
+**Status**: ✅ v2.7.2 Stable
 **Progress**: Production Ready (all core features complete)
-**Latest Release**: v2.7.1 (July 2026)
+**Latest Release**: v2.7.2 (July 2026)
 **Breaking Changes**: Yes (major version bump from original fork)
 
-> **Project Note**: This project is a substantially-rewritten fork of `fumiama/go-docx` (AGPL-3.0), focused on clean architecture, type safety, and modern Go practices. Its provenance and the resulting open licensing question are documented in [PROVENANCE_AUDIT.md](./PROVENANCE_AUDIT.md) — the single source of truth for that topic.
+> **Project Note**: This project is a substantially rewritten successor to `fumiama/go-docx`, focused on clean architecture, type safety, and modern Go practices. The Git history includes AGPL-era upstream snapshots; the completed [provenance audit](./PROVENANCE_AUDIT.md) determines that the current MIT release contains no protectable AGPL implementation.
 
 > **✅ Validation Status**: All examples pass DocxValidator (strict OOXML schema). Ready for beta release.
 > **📖 For API usage, see [V2_API_GUIDE.md](./V2_API_GUIDE.md)**
@@ -409,14 +409,14 @@ doc.WriteTo(file)
 
 ```go
 // v2 (new - current)
-import docx "github.com/mmonterroca/docxgo/v2"  // NEW namespace (no /v2 suffix in root)
+import docx "github.com/mmonterroca/docxgo/v2"
 
 // Builder pattern with error handling
-doc := docx.NewDocument(
+builder := docx.NewDocumentBuilder(
     docx.WithDefaultFont("Calibri"),
 )
 
-doc.AddParagraph().
+builder.AddParagraph().
     Text("Hello").
     Bold().
     Color(docx.Red).
@@ -424,7 +424,7 @@ doc.AddParagraph().
     End()
 
 // Validate and build
-finalDoc, err := doc.Build()
+finalDoc, err := builder.Build()
 if err != nil {
     log.Fatal(err)
 }
@@ -441,7 +441,7 @@ if err := finalDoc.SaveAs("output.docx"); err != nil {
 
 ### ✅ Phase 1: Foundation (Weeks 1-2) - COMPLETE
 
-- [x] Set up v2 module (`go mod init github.com/mmonterroca/docxgo`)
+- [x] Set up v2 module (`go mod init github.com/mmonterroca/docxgo/v2`)
 - [x] Define core interfaces (`domain/`)
 - [x] Create package structure
 - [x] Set up testing framework
@@ -483,13 +483,12 @@ if err := finalDoc.SaveAs("output.docx"); err != nil {
 
 **Goal**: Restructure into a standalone project namespace
 
-> **Note:** the "Set distribution license to MIT" step below is the very action
-> whose validity is the open licensing question. This checklist is an accurate
-> record of what was done; it draws no legal conclusion. See
-> [PROVENANCE_AUDIT.md](./PROVENANCE_AUDIT.md), the single source of truth.
+> **Note:** the completed [provenance audit](./PROVENANCE_AUDIT.md) confirms the
+> MIT determination for the rewritten v2 release. Historical AGPL snapshots
+> retain their original license.
 
 - [x] Create CREDITS.md with complete project history
-- [x] Move to personal namespace (github.com/mmonterroca/docxgo)
+- [x] Move to personal namespace (`github.com/mmonterroca/docxgo/v2` module)
 - [x] Set distribution license to MIT
 - [x] Rename project to "docxgo" (avoid confusion)
 - [x] Update all documentation with new namespace
@@ -607,7 +606,7 @@ if err := finalDoc.SaveAs("output.docx"); err != nil {
 
 - [x] Domain interfaces (image.go) (~172 lines)
   - [x] Image interface with dimensions, format, data
-  - [x] ImageFormat enum (PNG, JPEG, GIF, BMP, TIFF, SVG, WEBP)
+  - [x] ImageFormat enum (PNG, JPEG, GIF, BMP, TIFF, SVG, WEBP); PNG/JPEG/GIF currently decode end-to-end
   - [x] ImageSize struct with width/height in pixels and EMUs
   - [x] ImagePosition with inline/floating support
 - [x] Core implementation (internal/core/image.go) (~270 lines)
@@ -1038,7 +1037,7 @@ docs/
 5. 917f48d - Complete godoc documentation - Task 6
 6. b648bfe - Complete test coverage analysis - Task 7
 7. 725d7d0 - Complete error handling review - Task 9
-8. (pending) - Complete documentation overhaul - Task 10
+8. Documentation overhaul completed in the Phase 11 work described here
 
 **Documentation Created/Updated:**
 
@@ -1328,7 +1327,7 @@ if err != nil {
 
 ### Previous Contributions
 
-- **fumiama** (2022-2024): Original fork with enhanced features
+- **fumiama** (2023-2025): Upstream fork with enhanced features
 - **Gonzalo Fernández-Victorio** (2021): Original `gonfva/docxlib` library, for Basement Crowd Ltd
 
 See [CREDITS.md](../CREDITS.md) for complete project history.
@@ -1340,12 +1339,12 @@ See [CREDITS.md](../CREDITS.md) for complete project history.
 - [Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)
 - [Effective Go](https://golang.org/doc/effective_go)
 - [Go Proverbs](https://go-proverbs.github.io/)
-- [OOXML Specification](http://www.ecma-international.org/publications/standards/Ecma-376.htm)
+- [ECMA-376 OOXML Specification](https://ecma-international.org/publications-and-standards/standards/ecma-376/)
 
 ---
 
-**Last Updated**: April 2026
-**Status**: ✅ v2.7.1 Stable
+**Last Updated**: July 2026
+**Status**: ✅ v2.7.2 Stable
 **Progress**: Production Ready (all core features complete)
 
 **Current State:**

--- a/docs/provenance/compare_line_overlap.py
+++ b/docs/provenance/compare_line_overlap.py
@@ -17,7 +17,8 @@ that corpus.
 This is a coarse, line-set-membership check, not an AST or semantic diff —
 by design: it flags any verbatim textual overlap at all (including
 schema-dictated struct tags, which are then manually reviewed for whether
-they're independently protectable, per docs/PROVENANCE_AUDIT.md Finding 2).
+they're independently protectable, per the "Exact line overlap" section of
+docs/PROVENANCE_AUDIT.md).
 """
 import os
 import re

--- a/docx.go
+++ b/docx.go
@@ -88,7 +88,7 @@ func reconstructFromPackage(pkg *reader.Package, op string) (domain.Document, er
 }
 
 // Version is the library version.
-const Version = "2.7.1"
+const Version = "2.7.2"
 
 // Common color constants exported for convenience.
 var (

--- a/domain/document.go
+++ b/domain/document.go
@@ -4,7 +4,7 @@
 // See LICENSE for the full copyright notice, including predecessor authors,
 // and CREDITS.md for the project genealogy.
 
-// Package domain defines the core domain interfaces for go-docx v2.
+// Package domain defines the core domain interfaces for docxgo v2.
 //
 // This package provides a clean, testable API for working with Word documents.
 // All functionality is exposed through interfaces to promote loose coupling

--- a/examples/01_basic/main.go
+++ b/examples/01_basic/main.go
@@ -18,7 +18,7 @@ func main() {
 	// Create a new document builder with options
 	builder := docx.NewDocumentBuilder(
 		docx.WithTitle("Builder Pattern Demo"),
-		docx.WithAuthor("go-docx v2"),
+		docx.WithAuthor("docxgo v2"),
 		docx.WithDefaultFont("Calibri"),
 		docx.WithDefaultFontSize(22), // 11pt = 22 half-points
 		docx.WithPageSize(docx.A4),
@@ -27,7 +27,7 @@ func main() {
 
 	// Add title using builder fluent API
 	builder.AddParagraph().
-		Text("Welcome to go-docx v2 Builder Pattern").
+		Text("Welcome to docxgo v2 Builder Pattern").
 		Bold().
 		FontSize(16).
 		Color(docx.Blue).

--- a/examples/03_toc/README.md
+++ b/examples/03_toc/README.md
@@ -1,6 +1,6 @@
 # Example 03: Table of Contents (TOC)
 
-This example shows how to build a Table of Contents using go-docx v2. The document:
+This example shows how to build a Table of Contents using docxgo v2. The document:
 
 - Uses the fluent builder API for cover, chapters, and appendix content
 - Inserts a TOC field configured for Heading 1 and Heading 2 entries with hyperlinks

--- a/examples/03_toc/main.go
+++ b/examples/03_toc/main.go
@@ -101,7 +101,7 @@ func addCover(doc domain.Document) error {
 	if err != nil {
 		return fmt.Errorf("add title run: %w", err)
 	}
-	if err := titleRun.SetText("go-docx v2 Table of Contents Demo"); err != nil {
+	if err := titleRun.SetText("docxgo v2 Table of Contents Demo"); err != nil {
 		return fmt.Errorf("set title text: %w", err)
 	}
 

--- a/examples/04_fields/README.md
+++ b/examples/04_fields/README.md
@@ -1,6 +1,6 @@
 # Example 04: Fields
 
-This example demonstrates how to use fields in Word documents using go-docx v2.
+This example demonstrates how to use fields in Word documents using docxgo v2.
 
 ## What are Fields?
 
@@ -125,8 +125,8 @@ refField.SetCode(`REF MyBookmark \h`)
 
 ## See Also
 
-- [Example 01: Hello World](../01_hello/) - Basic document creation
-- [Example 02: Formatted Text](../02_formatted/) - Text formatting
+- [Example 01: Basic](../01_basic/) - Basic document creation
+- [Example 02: Intermediate](../02_intermediate/) - Text formatting
 - [Example 03: Table of Contents](../03_toc/) - TOC generation
-- [API Documentation](../../docs/API_DOCUMENTATION.md)
-- [OOXML Field Reference](http://officeopenxml.com/WPfields.php)
+- [API Guide](../../docs/V2_API_GUIDE.md)
+- [Open XML Wordprocessing Run reference](https://learn.microsoft.com/en-us/dotnet/api/documentformat.openxml.wordprocessing.run?view=openxml-3.0.1)

--- a/examples/05_styles/README.md
+++ b/examples/05_styles/README.md
@@ -1,6 +1,6 @@
 # Example 05: Style Management
 
-This example demonstrates the comprehensive style management system in go-docx v2.
+This example demonstrates the comprehensive style management system in docxgo v2.
 
 ## Features Demonstrated
 
@@ -83,4 +83,4 @@ The generated document includes:
 
 - See [Example 06](../06_sections) for section and page layout management
 - See [Example 07](../07_advanced) for combining all advanced features
-- Read [API Documentation](../../../docs/API_DOCUMENTATION.md) for complete style reference
+- Read the [API guide](../../docs/V2_API_GUIDE.md) for the complete style reference

--- a/examples/06_sections/README.md
+++ b/examples/06_sections/README.md
@@ -1,6 +1,6 @@
 # Example 06: Section and Page Layout Management
 
-This example demonstrates comprehensive section management, page layout configuration, and headers/footers in go-docx v2.
+This example demonstrates comprehensive section management, page layout configuration, and headers/footers in docxgo v2.
 
 ## Features Demonstrated
 
@@ -174,4 +174,4 @@ The generated document includes:
 
 - See [Example 07](../07_advanced) for combining sections with fields and styles
 - See [Example 04](../04_fields) for more field types
-- Read [API Documentation](../../../docs/API_DOCUMENTATION.md) for complete section reference
+- Read the [API guide](../../docs/V2_API_GUIDE.md) for the complete section reference

--- a/examples/06_sections/main.go
+++ b/examples/06_sections/main.go
@@ -168,7 +168,7 @@ func main() {
 	psDesc, _ := doc.AddParagraph()
 	psDesc.SetStyle(domain.StyleIDNormal)
 	psDescRun, _ := psDesc.AddRun()
-	psDescRun.AddText("go-docx v2 supports these predefined page sizes:")
+	psDescRun.AddText("docxgo v2 supports these predefined page sizes:")
 
 	sizes := []struct {
 		name string

--- a/examples/07_advanced/README.md
+++ b/examples/07_advanced/README.md
@@ -82,7 +82,7 @@ func setupHeader(header domain.Header) {
     para.SetAlignment(domain.AlignmentRight)
     
     run, _ := para.AddRun()
-    run.AddText("go-docx v2 • Advanced Features Demo")
+    run.AddText("docxgo v2 • Advanced Features Demo")
     run.SetFontSize(10)
     run.SetColor(0x4472C4) // Blue
 }
@@ -185,9 +185,9 @@ The generated document is approximately 4-5 pages and includes:
 ## Next Steps
 
 - Review individual examples for specific features
-- Read [API Documentation](../../../docs/API_DOCUMENTATION.md)
-- Check [MIGRATION.md](../../../MIGRATION.md) for v1→v2 transition
-- Explore [V2_DESIGN.md](../../../docs/V2_DESIGN.md) for architecture
+- Read the [API guide](../../docs/V2_API_GUIDE.md)
+- Check [MIGRATION.md](../../MIGRATION.md) for the v1→v2 transition
+- Explore [V2_DESIGN.md](../../docs/V2_DESIGN.md) for architecture
 
 ## Performance Note
 

--- a/examples/07_advanced/main.go
+++ b/examples/07_advanced/main.go
@@ -74,7 +74,7 @@ func setupHeader(header domain.Header) {
 	para.SetAlignment(domain.AlignmentRight)
 
 	run, _ := para.AddRun()
-	run.AddText("go-docx v2 • Advanced Features Demo")
+	run.AddText("docxgo v2 • Advanced Features Demo")
 	run.SetSize(20)                                       // 10pt in half-points
 	run.SetColor(domain.Color{R: 0x44, G: 0x72, B: 0xC4}) // Blue
 }
@@ -129,7 +129,7 @@ func addCoverPage(doc domain.Document) {
 	author, _ := doc.AddParagraph()
 	author.SetAlignment(domain.AlignmentCenter)
 	authorRun, _ := author.AddRun()
-	authorRun.AddText("Created with go-docx v2")
+	authorRun.AddText("Created with docxgo v2")
 	authorRun.SetItalic(true)
 
 	doc.AddParagraph()
@@ -181,7 +181,7 @@ func addIntroduction(doc domain.Document) {
 	intro, _ := doc.AddParagraph()
 	intro.SetStyle(domain.StyleIDNormal)
 	introRun, _ := intro.AddRun()
-	introRun.AddText("This document demonstrates the advanced features available in go-docx v2. It showcases sections, headers, footers, fields, and comprehensive style management.")
+	introRun.AddText("This document demonstrates the advanced features available in docxgo v2. It showcases sections, headers, footers, fields, and comprehensive style management.")
 
 	doc.AddParagraph()
 
@@ -210,7 +210,7 @@ func addFeatures(doc domain.Document) {
 	intro, _ := doc.AddParagraph()
 	intro.SetStyle(domain.StyleIDNormal)
 	introRun, _ := intro.AddRun()
-	introRun.AddText("go-docx v2 Phase 6 introduces several powerful capabilities:")
+	introRun.AddText("docxgo v2 Phase 6 introduces several powerful capabilities:")
 
 	doc.AddParagraph()
 
@@ -425,7 +425,7 @@ func addConclusion(doc domain.Document) {
 	summary, _ := doc.AddParagraph()
 	summary.SetStyle(domain.StyleIDNormal)
 	summaryRun, _ := summary.AddRun()
-	summaryRun.AddText("This document demonstrates the complete feature set of go-docx v2 Phase 6. All advanced capabilities work together seamlessly to create professional documents programmatically.")
+	summaryRun.AddText("This document demonstrates the complete feature set of docxgo v2 Phase 6. All advanced capabilities work together seamlessly to create professional documents programmatically.")
 
 	doc.AddParagraph()
 
@@ -458,6 +458,6 @@ func addConclusion(doc domain.Document) {
 	final.SetStyle(domain.StyleIDIntenseQuote)
 	final.SetAlignment(domain.AlignmentCenter)
 	finalRun, _ := final.AddRun()
-	finalRun.AddText("Thank you for using go-docx v2!")
+	finalRun.AddText("Thank you for using docxgo v2!")
 	finalRun.SetBold(true)
 }

--- a/examples/11_multi_section/main.go
+++ b/examples/11_multi_section/main.go
@@ -93,7 +93,7 @@ func main() {
 	intro, _ := doc.AddParagraph()
 	intro.SetStyle(domain.StyleIDNormal)
 	introRun, _ := intro.AddRun()
-	introRun.AddText("This report highlights performance across business units and showcases the new multi-section support in go-docx v2.")
+	introRun.AddText("This report highlights performance across business units and showcases the new multi-section support in docxgo v2.")
 
 	summaryHeading, _ := doc.AddParagraph()
 	summaryHeading.SetStyle(domain.StyleIDHeading1)

--- a/examples/12_read_and_modify/README.md
+++ b/examples/12_read_and_modify/README.md
@@ -1,6 +1,6 @@
 # Example 12: Read and Modify Documents
 
-This example demonstrates the complete document read/modify/write workflow in go-docx v2.
+This example demonstrates the complete document read/modify/write workflow in docxgo v2.
 
 ## What This Example Demonstrates
 
@@ -68,7 +68,7 @@ Compare these files in Microsoft Word or LibreOffice to see the modifications cl
 ```go
 builder := docx.NewDocumentBuilder(
     docx.WithTitle("Document Showcase"),
-    docx.WithAuthor("go-docx v2"),
+    docx.WithAuthor("docxgo v2"),
 )
 
 builder.AddParagraph().
@@ -256,7 +256,7 @@ When you run this example, you'll see:
 
    📝 First 3 paragraphs:
       1. "Document Showcase - All Features"
-      2. "This document demonstrates all capabilities of go-docx v2"
+      2. "This document demonstrates all capabilities of docxgo v2"
       3. ""
 
    📋 First table:

--- a/examples/12_read_and_modify/main.go
+++ b/examples/12_read_and_modify/main.go
@@ -78,7 +78,7 @@ func createShowcaseDocument() string {
 	subtitle.SetStyle(domain.StyleIDSubtitle)
 	subtitle.SetAlignment(domain.AlignmentCenter)
 	subtitleRun, _ := subtitle.AddRun()
-	subtitleRun.AddText("This document demonstrates all capabilities of go-docx v2")
+	subtitleRun.AddText("This document demonstrates all capabilities of docxgo v2")
 
 	doc.AddParagraph() // Empty line
 

--- a/examples/13_themes/CUSTOM_THEMES_GUIDE.md
+++ b/examples/13_themes/CUSTOM_THEMES_GUIDE.md
@@ -1,6 +1,6 @@
 # Creating Custom Themes - Developer Guide
 
-This guide shows external developers how to create their own themes for go-docx.
+This guide shows external developers how to create their own themes for docxgo.
 
 ## Three Ways to Create Custom Themes
 
@@ -13,8 +13,8 @@ package main
 
 import (
     docx "github.com/mmonterroca/docxgo/v2"
-    "github.com/mmonterroca/docxgo/domain"
-    "github.com/mmonterroca/docxgo/themes"
+    "github.com/mmonterroca/docxgo/v2/domain"
+    "github.com/mmonterroca/docxgo/v2/themes"
 )
 
 func main() {
@@ -48,8 +48,8 @@ Build a completely new theme:
 package main
 
 import (
-    "github.com/mmonterroca/docxgo/domain"
-    "github.com/mmonterroca/docxgo/themes"
+    "github.com/mmonterroca/docxgo/v2/domain"
+    "github.com/mmonterroca/docxgo/v2/themes"
 )
 
 func main() {
@@ -113,8 +113,8 @@ Create a reusable package with multiple themes:
 package mythemes
 
 import (
-    "github.com/mmonterroca/docxgo/domain"
-    "github.com/mmonterroca/docxgo/themes"
+    "github.com/mmonterroca/docxgo/v2/domain"
+    "github.com/mmonterroca/docxgo/v2/themes"
 )
 
 // Export your themes
@@ -280,8 +280,8 @@ To share your themes with others:
    package mydocxthemes
    
    import (
-       "github.com/mmonterroca/docxgo/domain"
-       "github.com/mmonterroca/docxgo/themes"
+       "github.com/mmonterroca/docxgo/v2/domain"
+       "github.com/mmonterroca/docxgo/v2/themes"
    )
    
    var MyAwesomeTheme = themes.NewTheme(...)
@@ -330,7 +330,7 @@ Use these resources for color schemes:
 
 ## Need Help?
 
-- Check the [main themes README](../../../themes/README.md)
+- Check the [main themes README](../../themes/README.md)
 - See [examples](../) for more usage patterns
 - Open an issue on GitHub for questions
 

--- a/examples/13_themes/README.md
+++ b/examples/13_themes/README.md
@@ -1,6 +1,6 @@
 # Document Themes Example
 
-This example demonstrates the theme system in go-docx, which allows you to apply consistent visual styling to your documents.
+This example demonstrates the theme system in docxgo, which allows you to apply consistent visual styling to your documents.
 
 ## Available Themes
 
@@ -63,7 +63,7 @@ Traditional scholarly theme for academic and research documents. Perfect for res
 ```go
 import (
     docx "github.com/mmonterroca/docxgo/v2"
-    "github.com/mmonterroca/docxgo/themes"
+    "github.com/mmonterroca/docxgo/v2/themes"
 )
 
 // Create a document with a theme
@@ -188,7 +188,7 @@ Each theme defines:
 You can create your own theme from scratch:
 
 ```go
-import "github.com/mmonterroca/docxgo/themes"
+import "github.com/mmonterroca/docxgo/v2/themes"
 
 customTheme := themes.NewTheme(
     "my-theme",
@@ -269,7 +269,7 @@ Create a separate Go package with your themes:
 // mythemes/mythemes.go
 package mythemes
 
-import "github.com/mmonterroca/docxgo/themes"
+import "github.com/mmonterroca/docxgo/v2/themes"
 
 var Gaming = themes.NewTheme("gaming", "Gaming", "Vibrant gaming theme")
 var Medical = themes.NewTheme("medical", "Medical", "Clean medical theme")

--- a/examples/14_mail_merge/main.go
+++ b/examples/14_mail_merge/main.go
@@ -164,7 +164,7 @@ func main() {
 func createTemplate() string {
 	builder := docx.NewDocumentBuilder(
 		docx.WithTitle("Invoice Template"),
-		docx.WithAuthor("go-docx v2"),
+		docx.WithAuthor("docxgo v2"),
 		docx.WithDefaultFont("Calibri"),
 		docx.WithDefaultFontSize(22),
 		docx.WithPageSize(docx.A4),

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # go-docx Examples
 
-This directory contains practical, runnable examples demonstrating go-docx v2 capabilities.
+This directory contains practical, runnable examples demonstrating docxgo v2 capabilities.
 
 ## ✅ Working Examples (v2)
 

--- a/internal/core/document.go
+++ b/internal/core/document.go
@@ -4,7 +4,7 @@
 // See LICENSE for the full copyright notice, including predecessor authors,
 // and CREDITS.md for the project genealogy.
 
-// Package core provides concrete implementations of domain interfaces for go-docx v2.
+// Package core provides concrete implementations of domain interfaces for docxgo v2.
 //
 // This package contains the core document model implementations including:
 // - Document: The main document structure

--- a/internal/manager/id.go
+++ b/internal/manager/id.go
@@ -4,7 +4,7 @@
 // See LICENSE for the full copyright notice, including predecessor authors,
 // and CREDITS.md for the project genealogy.
 
-// Package manager provides internal management services for go-docx v2.
+// Package manager provides internal management services for docxgo v2.
 package manager
 
 import (

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mmonterroca/docxgo",
-  "version": "2.7.0",
+  "version": "2.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mmonterroca/docxgo",
-      "version": "2.7.0",
+      "version": "2.7.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.3",
@@ -17,17 +17,17 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "@mmonterroca/docxgo-darwin-arm64": "2.7.0",
-        "@mmonterroca/docxgo-darwin-x64": "2.7.0",
-        "@mmonterroca/docxgo-linux-arm64": "2.7.0",
-        "@mmonterroca/docxgo-linux-x64": "2.7.0",
-        "@mmonterroca/docxgo-win32-x64": "2.7.0"
+        "@mmonterroca/docxgo-darwin-arm64": "2.7.2",
+        "@mmonterroca/docxgo-darwin-x64": "2.7.2",
+        "@mmonterroca/docxgo-linux-arm64": "2.7.2",
+        "@mmonterroca/docxgo-linux-x64": "2.7.2",
+        "@mmonterroca/docxgo-win32-x64": "2.7.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -93,9 +93,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -144,9 +144,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -161,9 +161,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -178,9 +178,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -195,9 +195,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -212,9 +212,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -229,9 +229,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -246,9 +246,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -263,9 +263,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -297,9 +297,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -314,9 +314,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -348,9 +348,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -365,9 +365,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -382,9 +382,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -399,9 +399,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -416,9 +416,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -433,9 +433,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -450,9 +450,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -465,71 +465,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@mmonterroca/docxgo-darwin-arm64": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-darwin-arm64/-/docxgo-darwin-arm64-2.7.0.tgz",
-      "integrity": "sha512-IA8ONsIrNaqiCOj0hHLA4MNK4PjIbpQzIxQY2qXW8ATda1LTMgT6dTXvsDW3KSpteNUJtQNTCkpzkvYlAHPQlA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@mmonterroca/docxgo-darwin-x64": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-darwin-x64/-/docxgo-darwin-x64-2.7.0.tgz",
-      "integrity": "sha512-+mzHMD9UWOEkRIFxzMcyV3bH4m65SSRUT482c0EXfI3usD/rQC3HUceg68toZVlh0D+uK9xbAHbUGf2/4lCcaQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@mmonterroca/docxgo-linux-arm64": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-linux-arm64/-/docxgo-linux-arm64-2.7.0.tgz",
-      "integrity": "sha512-rsuUKplabRKCB32gXt+quC0i7ByGpQYjeZ/9UJ63vNuPbUfbVvykSwmBaHofKoDdPgElXT9TMnKV/0FlFW/oIA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@mmonterroca/docxgo-linux-x64": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-linux-x64/-/docxgo-linux-x64-2.7.0.tgz",
-      "integrity": "sha512-LdR+9DsqfPGH4bE1fAzqEir0wbHmvJ7N1Ifdg9N+6gnCRsm07GO+fDt7EVZ/bJ8xOdlxxy0UGoLq37vHDN+wiQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@mmonterroca/docxgo-win32-x64": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-win32-x64/-/docxgo-win32-x64-2.7.0.tgz",
-      "integrity": "sha512-K3M59OB8RLLptQ+ek2wAivjQKXaX83tT0Aq4FaScXKwRruVjrVyTT6upnTtJrrugG5TZw35NwwU3CzGUpsWp5w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@types/node": {
       "version": "25.3.3",
@@ -542,9 +477,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -555,32 +490,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.3",
-        "@esbuild/android-arm": "0.27.3",
-        "@esbuild/android-arm64": "0.27.3",
-        "@esbuild/android-x64": "0.27.3",
-        "@esbuild/darwin-arm64": "0.27.3",
-        "@esbuild/darwin-x64": "0.27.3",
-        "@esbuild/freebsd-arm64": "0.27.3",
-        "@esbuild/freebsd-x64": "0.27.3",
-        "@esbuild/linux-arm": "0.27.3",
-        "@esbuild/linux-arm64": "0.27.3",
-        "@esbuild/linux-ia32": "0.27.3",
-        "@esbuild/linux-loong64": "0.27.3",
-        "@esbuild/linux-mips64el": "0.27.3",
-        "@esbuild/linux-ppc64": "0.27.3",
-        "@esbuild/linux-riscv64": "0.27.3",
-        "@esbuild/linux-s390x": "0.27.3",
-        "@esbuild/linux-x64": "0.27.3",
-        "@esbuild/netbsd-arm64": "0.27.3",
-        "@esbuild/netbsd-x64": "0.27.3",
-        "@esbuild/openbsd-arm64": "0.27.3",
-        "@esbuild/openbsd-x64": "0.27.3",
-        "@esbuild/openharmony-arm64": "0.27.3",
-        "@esbuild/sunos-x64": "0.27.3",
-        "@esbuild/win32-arm64": "0.27.3",
-        "@esbuild/win32-ia32": "0.27.3",
-        "@esbuild/win32-x64": "0.27.3"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/fsevents": {
@@ -598,38 +533,14 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.6",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmonterroca/docxgo",
-  "version": "2.7.0",
+  "version": "2.7.2",
   "description": "Node.js wrapper for docxgo — create and manipulate Word documents via JSON-RPC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -50,10 +50,10 @@
     "typescript": "^5.4.0"
   },
   "optionalDependencies": {
-    "@mmonterroca/docxgo-darwin-arm64": "2.7.0",
-    "@mmonterroca/docxgo-darwin-x64": "2.7.0",
-    "@mmonterroca/docxgo-linux-arm64": "2.7.0",
-    "@mmonterroca/docxgo-linux-x64": "2.7.0",
-    "@mmonterroca/docxgo-win32-x64": "2.7.0"
+    "@mmonterroca/docxgo-darwin-arm64": "2.7.2",
+    "@mmonterroca/docxgo-darwin-x64": "2.7.2",
+    "@mmonterroca/docxgo-linux-arm64": "2.7.2",
+    "@mmonterroca/docxgo-linux-x64": "2.7.2",
+    "@mmonterroca/docxgo-win32-x64": "2.7.2"
   }
 }

--- a/pkg/color/color.go
+++ b/pkg/color/color.go
@@ -4,7 +4,7 @@
 // See LICENSE for the full copyright notice, including predecessor authors,
 // and CREDITS.md for the project genealogy.
 
-// Package color provides color utilities for go-docx v2.
+// Package color provides color utilities for docxgo v2.
 package color
 
 import (

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -4,7 +4,7 @@
 // See LICENSE for the full copyright notice, including predecessor authors,
 // and CREDITS.md for the project genealogy.
 
-// Package constants provides OOXML constants and measurements for go-docx v2.
+// Package constants provides OOXML constants and measurements for docxgo v2.
 package constants
 
 // Measurement conversions

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -4,7 +4,7 @@
 // See LICENSE for the full copyright notice, including predecessor authors,
 // and CREDITS.md for the project genealogy.
 
-// Package errors provides structured error types for go-docx v2.
+// Package errors provides structured error types for docxgo v2.
 package errors
 
 import (
@@ -23,7 +23,7 @@ const (
 	ErrCodeUnsupported  = "UNSUPPORTED"
 )
 
-// DocxError represents a structured error in go-docx v2.
+// DocxError represents a structured error in docxgo v2.
 type DocxError struct {
 	Code    string                 // Error code (e.g., "VALIDATION_ERROR")
 	Op      string                 // Operation that failed (e.g., "Document.AddParagraph")

--- a/themes/README.md
+++ b/themes/README.md
@@ -1,6 +1,6 @@
 # Document Themes
 
-The `themes` package provides a comprehensive theme system for go-docx, allowing you to apply consistent visual styling to your documents with a single configuration.
+The `themes` package provides a comprehensive theme system for docxgo, allowing you to apply consistent visual styling to your documents with a single configuration.
 
 ## Overview
 
@@ -15,7 +15,7 @@ Themes define a complete visual style for documents, including:
 ```go
 import (
     docx "github.com/mmonterroca/docxgo/v2"
-    "github.com/mmonterroca/docxgo/themes"
+    "github.com/mmonterroca/docxgo/v2/themes"
 )
 
 // Apply a preset theme


### PR DESCRIPTION
## Summary

- Finalizes the reproducible MIT provenance determination for the current v2 implementation while preserving AGPL scope for historical snapshots.
- Corrects predecessor notices and aligns all current documentation and release metadata on v2.7.2.
- Includes LICENSE in platform npm packages and GitHub binary archives.
- Makes the npm manual fallback build from the exact release tag.

## Impact

Backward-compatible compliance, packaging, and documentation patch. No public Go, JSON-RPC, Node.js, or document-generation API changes.

## Validation

- go test -count=1 ./...
- go vet ./...
- all example builds
- npm ci, TypeScript lint, and 35 Node.js tests
- npm audit: zero vulnerabilities in the v2.7.2 lockfile
- actionlint on all workflows
- npm pack and release archive inspection confirmed LICENSE inclusion
- Markdown local and external link checks
- provenance overlap comparison rerun