### PR TITLE
Fix v2.7.2 npm main-package publication

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -152,6 +152,12 @@ jobs:
             echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
           fi
 
+      # Platform packages are published by the prerequisite job. Refresh the
+      # lock metadata now so a release version that did not exist when the tag
+      # was cut is present before npm ci performs its strict sync check.
+      - name: Sync published platform dependencies
+        run: cd npm && npm install --package-lock-only --ignore-scripts
+
       - name: Install dependencies
         run: cd npm && npm ci
 

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -466,6 +466,71 @@
         "node": ">=18"
       }
     },
+    "node_modules/@mmonterroca/docxgo-darwin-arm64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-darwin-arm64/-/docxgo-darwin-arm64-2.7.2.tgz",
+      "integrity": "sha512-njdIqSIYQQ3diOONXIQpSxX50ySblq2aihwhRHBPz7jzUO6PRAPv1burolXRzUAEasUqf4lxrKBgA6oOCwLD9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@mmonterroca/docxgo-darwin-x64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-darwin-x64/-/docxgo-darwin-x64-2.7.2.tgz",
+      "integrity": "sha512-xaqZpDYZCV9BH0xhWpWy8KH6CMWgCcHFGy0Tn42t6qGwT01okr3e6LT1sm/S8TBpPmLYZLAuwt5/P2/5KfyNbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@mmonterroca/docxgo-linux-arm64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-linux-arm64/-/docxgo-linux-arm64-2.7.2.tgz",
+      "integrity": "sha512-J9RT5LDEgHVK71rW8w/sj9P9rac0rEHwCIPB/jgvA1TsUcJlLB6td1zVf004ZqJTWzYM2nPNBvbzs52RbEUCeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@mmonterroca/docxgo-linux-x64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-linux-x64/-/docxgo-linux-x64-2.7.2.tgz",
+      "integrity": "sha512-UlAubWg4BLV8QWtYV5wyhD0fTDTww+AIVhxWFZkIizXfADKacbVGlDlmyvG/rxVWLM39N7VabJasSm3A4h+L3w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@mmonterroca/docxgo-win32-x64": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-win32-x64/-/docxgo-win32-x64-2.7.2.tgz",
+      "integrity": "sha512-KWU2WOencTwj1I5aJvJK83CKCIGIcl33rgsqxs4c8d316UhEXmld/zhVJGYILu8lGyxOkJwCsPmF37GJ5BHEmg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@types/node": {
       "version": "25.3.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",


### PR DESCRIPTION
## Root cause

The five v2.7.2 platform packages did not exist when the release lockfile was generated, so their package entries were absent. npm 10 performs a strict package/lock sync check and stopped the main-package job at npm ci after the platform packages had already published.

## Fix

- Refresh package-lock metadata after the prerequisite platform publish jobs and before npm ci.
- Record the now-published v2.7.2 platform packages and integrity hashes in the tracked lockfile.

## Validation

- npm 10.8.2 ci succeeds
- npm lint succeeds
- all 35 npm tests pass
- npm audit reports zero vulnerabilities
- actionlint passes

The publish workflow remains idempotent: rerunning skips all five already-published platform packages and publishes only the missing main package.