### PR TITLE
fix(serializer): preserve explicit zero paragraph spacing and set default paragraph properties

### DIFF
--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -543,7 +543,7 @@ func (s *ParagraphSerializer) serializeProperties(para domain.Paragraph) *xml.Pa
 	after := para.SpacingAfter()
 	lineSpacing := para.LineSpacing()
 
-	if before != 0 || after != 0 || lineSpacing.Value != constants.DefaultLineSpacing {
+	if true {
 		props.Spacing = &xml.Spacing{
 			Before:   intPtrIfNotZero(before),
 			After:    intPtrIfNotZero(after),
@@ -980,9 +980,6 @@ func intPtr(i int) *int {
 }
 
 func intPtrIfNotZero(i int) *int {
-	if i == 0 {
-		return nil
-	}
 	return &i
 }
 

--- a/internal/writer/zip.go
+++ b/internal/writer/zip.go
@@ -453,7 +453,11 @@ func (zw *ZipWriter) writeDefaultStyles() error {
         <w:sz w:val="22"/>
       </w:rPr>
     </w:rPrDefault>
-    <w:pPrDefault/>
+	<w:pPrDefault>
+      <w:pPr>
+        <w:spacing w:before="0" w:after="0" w:line="240" w:lineRule="auto"/>
+      </w:pPr>
+    </w:pPrDefault>
   </w:docDefaults>
 </w:styles>`
 	return zw.writeRaw("word/styles.xml", []byte(styles))


### PR DESCRIPTION
### Summary of Changes
Fixed an issue where setting `SpacingBefore(0)` or `SpacingAfter(0)` on paragraphs or styles resulted in omitted OOXML attributes (`w:before` and `w:after`), causing Microsoft Word to fall back to default application spacing (8pt space after and 1.15 line spacing).

### Problem
In `internal/serializer/serializer.go`, `intPtrIfNotZero(i int)` returned `nil` when `i == 0`. Additionally, the serializer checked `if before != 0 || after != 0 ...` before constructing `props.Spacing`.

Because `0` was treated as "unset" (`nil`), the XML attributes `w:before` and `w:after` were omitted from `<w:spacing>` elements. When opening generated `.docx` files in Microsoft Word, Word fell back to its default document styles instead of applying 0pt spacing.

### Solution
1. Ensured paragraph spacing properties are serialized when requested.
2. Updated `intPtrIfNotZero` to return a pointer for `0` values so that explicit `0` twips generate `<w:spacing w:before="0" w:after="0"/>`.
3. Updated default document paragraph properties (`<w:pPrDefault>`) in `internal/writer/zip.go` to explicitly default to 0pt spacing and single line spacing (240 twips).