### PR TITLE
feat: in-place editing RPC methods (replaceText, setText, get/setCell)

### DIFF
--- a/cmd/docxgo/handlers.go
+++ b/cmd/docxgo/handlers.go
@@ -109,6 +109,8 @@ func (s *server) dispatch(req *Request) Response {
 		return s.handleAddPageBreak(req)
 	case "document.applyPatch":
 		return s.handleApplyPatch(req)
+	case "document.replaceText":
+		return s.handleReplaceText(req)
 	case "document.close":
 		return s.handleClose(req)
 	// paragraph.*
@@ -116,11 +118,17 @@ func (s *server) dispatch(req *Request) Response {
 		return s.handleParagraphAdd(req)
 	case "paragraph.list":
 		return s.handleParagraphList(req)
+	case "paragraph.setText":
+		return s.handleParagraphSetText(req)
 	// table.*
 	case "table.add":
 		return s.handleTableAdd(req)
 	case "table.list":
 		return s.handleTableList(req)
+	case "table.getCell":
+		return s.handleTableGetCell(req)
+	case "table.setCell":
+		return s.handleTableSetCell(req)
 	// section.*
 	case "section.add":
 		return s.handleSectionAdd(req)
@@ -289,6 +297,40 @@ type tableListParams struct {
 type sectionAddParams struct {
 	DocumentID string `json:"documentId"`
 	sectionItem
+}
+
+// replaceTextParams are the parameters for document.replaceText.
+type replaceTextParams struct {
+	DocumentID string `json:"documentId"`
+	Find       string `json:"find"`
+	Replace    string `json:"replace"`
+}
+
+// paragraphSetTextParams are the parameters for paragraph.setText. Index is
+// the body-paragraph index as reported by paragraph.list; the embedded
+// paragraphItem carries the new content (text or runs) and any style fields
+// to apply.
+type paragraphSetTextParams struct {
+	DocumentID string `json:"documentId"`
+	Index      int    `json:"index"`
+	paragraphItem
+}
+
+// tableCellRef addresses a single cell, shared by table.getCell and
+// table.setCell. Indices follow table.list ordering.
+type tableCellRef struct {
+	DocumentID  string `json:"documentId"`
+	TableIndex  int    `json:"tableIndex"`
+	RowIndex    int    `json:"rowIndex"`
+	ColumnIndex int    `json:"columnIndex"`
+}
+
+// tableSetCellParams are the parameters for table.setCell. Text is a shortcut
+// for a single plain paragraph; Paragraphs carries rich content items.
+type tableSetCellParams struct {
+	tableCellRef
+	Text       string            `json:"text,omitempty"`
+	Paragraphs []json.RawMessage `json:"paragraphs,omitempty"`
 }
 
 // applyPatchParams are the parameters for document.applyPatch.
@@ -913,6 +955,185 @@ func (s *server) handleTableList(req *Request) Response {
 	return Response{ID: req.ID, Result: map[string]interface{}{
 		"tables": items,
 		"count":  len(items),
+	}}
+}
+
+func (s *server) handleReplaceText(req *Request) Response {
+	const op = "document.replaceText"
+
+	var params replaceTextParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, "invalid params: "+err.Error(), op)
+	}
+
+	doc, ok := s.getDoc(params.DocumentID)
+	if !ok {
+		return errorResponse(req.ID, errors.ErrCodeNotFound,
+			fmt.Sprintf("document %q not found", params.DocumentID), op)
+	}
+
+	if params.Find == "" {
+		return errorResponse(req.ID, errors.ErrCodeValidation, "find is required and must not be empty", op)
+	}
+
+	result, err := template.ReplaceText(doc, params.Find, params.Replace)
+	if err != nil {
+		return errorResponse(req.ID, errors.ErrCodeInternal, "replace failed: "+err.Error(), op)
+	}
+
+	return Response{ID: req.ID, Result: map[string]interface{}{
+		"replaced": result.Replaced,
+		"skipped":  result.Skipped,
+	}}
+}
+
+func (s *server) handleParagraphSetText(req *Request) Response {
+	const op = "paragraph.setText"
+
+	var params paragraphSetTextParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, "invalid params: "+err.Error(), op)
+	}
+
+	doc, ok := s.getDoc(params.DocumentID)
+	if !ok {
+		return errorResponse(req.ID, errors.ErrCodeNotFound,
+			fmt.Sprintf("document %q not found", params.DocumentID), op)
+	}
+
+	paragraphs := doc.Paragraphs()
+	if params.Index < 0 || params.Index >= len(paragraphs) {
+		return errorResponse(req.ID, errors.ErrCodeValidation,
+			fmt.Sprintf("paragraph index %d out of range (document has %d paragraphs)",
+				params.Index, len(paragraphs)), op)
+	}
+
+	para := paragraphs[params.Index]
+	para.ClearRuns()
+	if err := applyParagraph(para, params.paragraphItem); err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
+	}
+
+	return Response{ID: req.ID, Result: map[string]interface{}{
+		"ok":    true,
+		"index": params.Index,
+	}}
+}
+
+// resolveCell resolves a tableCellRef to a cell, with range-checked indices.
+func resolveCell(doc domain.Document, ref tableCellRef) (domain.TableCell, error) {
+	tables := doc.Tables()
+	if ref.TableIndex < 0 || ref.TableIndex >= len(tables) {
+		return nil, fmt.Errorf("table index %d out of range (document has %d tables)",
+			ref.TableIndex, len(tables))
+	}
+	row, err := tables[ref.TableIndex].Row(ref.RowIndex)
+	if err != nil {
+		return nil, fmt.Errorf("row %d: %w", ref.RowIndex, err)
+	}
+	cell, err := row.Cell(ref.ColumnIndex)
+	if err != nil {
+		return nil, fmt.Errorf("column %d: %w", ref.ColumnIndex, err)
+	}
+	return cell, nil
+}
+
+func (s *server) handleTableGetCell(req *Request) Response {
+	const op = "table.getCell"
+
+	var params tableCellRef
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, "invalid params: "+err.Error(), op)
+	}
+
+	doc, ok := s.getDoc(params.DocumentID)
+	if !ok {
+		return errorResponse(req.ID, errors.ErrCodeNotFound,
+			fmt.Sprintf("document %q not found", params.DocumentID), op)
+	}
+
+	cell, err := resolveCell(doc, params)
+	if err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
+	}
+
+	paragraphs := cell.Paragraphs()
+	texts := make([]string, 0, len(paragraphs))
+	for _, p := range paragraphs {
+		texts = append(texts, p.Text())
+	}
+
+	return Response{ID: req.ID, Result: map[string]interface{}{
+		"text":           strings.Join(texts, "\n"),
+		"paragraphs":     texts,
+		"paragraphCount": len(paragraphs),
+	}}
+}
+
+func (s *server) handleTableSetCell(req *Request) Response {
+	const op = "table.setCell"
+
+	var params tableSetCellParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, "invalid params: "+err.Error(), op)
+	}
+
+	doc, ok := s.getDoc(params.DocumentID)
+	if !ok {
+		return errorResponse(req.ID, errors.ErrCodeNotFound,
+			fmt.Sprintf("document %q not found", params.DocumentID), op)
+	}
+
+	if params.Text != "" && len(params.Paragraphs) > 0 {
+		return errorResponse(req.ID, errors.ErrCodeValidation,
+			"provide either text or paragraphs, not both", op)
+	}
+
+	cell, err := resolveCell(doc, params.tableCellRef)
+	if err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
+	}
+
+	items := params.Paragraphs
+	if params.Text != "" {
+		item, err := json.Marshal(paragraphItem{Text: params.Text})
+		if err != nil {
+			return errorResponse(req.ID, errors.ErrCodeInternal, "encoding text item: "+err.Error(), op)
+		}
+		items = []json.RawMessage{item}
+	}
+
+	// Replace the cell's content: clear every existing paragraph, then write
+	// the new items into existing paragraphs (reusing their slots) and append
+	// paragraphs for any overflow. Cells cannot drop paragraphs, so leftover
+	// paragraphs beyond the new content stay as empty paragraphs.
+	existing := cell.Paragraphs()
+	for _, p := range existing {
+		p.ClearRuns()
+	}
+	for i, raw := range items {
+		var pItem paragraphItem
+		if err := json.Unmarshal(raw, &pItem); err != nil {
+			return errorResponse(req.ID, errors.ErrCodeValidation,
+				fmt.Sprintf("invalid paragraph at index %d: %v", i, err), op)
+		}
+		var para domain.Paragraph
+		if i < len(existing) {
+			para = existing[i]
+		} else {
+			para, err = cell.AddParagraph()
+			if err != nil {
+				return errorResponse(req.ID, errors.ErrCodeInternal, "failed to add paragraph: "+err.Error(), op)
+			}
+		}
+		if err := applyParagraph(para, pItem); err != nil {
+			return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
+		}
+	}
+
+	return Response{ID: req.ID, Result: map[string]interface{}{
+		"ok":             true,
+		"paragraphCount": len(cell.Paragraphs()),
 	}}
 }
 

--- a/cmd/docxgo/handlers.go
+++ b/cmd/docxgo/handlers.go
@@ -291,6 +291,10 @@ type tableAddParams struct {
 // tableListParams are the parameters for table.list.
 type tableListParams struct {
 	DocumentID string `json:"documentId"`
+	// IncludeText adds each table's cell texts to the listing, row by row.
+	// Rows report their actual cells, so ragged tables (merged cells) are
+	// represented faithfully rather than padded to columnCount.
+	IncludeText bool `json:"includeText,omitempty"`
 }
 
 // sectionAddParams are the parameters for section.add.
@@ -945,11 +949,30 @@ func (s *server) handleTableList(req *Request) Response {
 	tables := doc.Tables()
 	items := make([]map[string]interface{}, 0, len(tables))
 	for i, t := range tables {
-		items = append(items, map[string]interface{}{
+		item := map[string]interface{}{
 			"index":   i,
 			"rows":    t.RowCount(),
 			"columns": t.ColumnCount(),
-		})
+		}
+		if params.IncludeText {
+			rows := t.Rows()
+			cellRows := make([][]string, 0, len(rows))
+			for _, row := range rows {
+				cells := row.Cells()
+				texts := make([]string, 0, len(cells))
+				for _, cell := range cells {
+					paragraphs := cell.Paragraphs()
+					pTexts := make([]string, 0, len(paragraphs))
+					for _, p := range paragraphs {
+						pTexts = append(pTexts, p.Text())
+					}
+					texts = append(texts, strings.Join(pTexts, "\n"))
+				}
+				cellRows = append(cellRows, texts)
+			}
+			item["cells"] = cellRows
+		}
+		items = append(items, item)
 	}
 
 	return Response{ID: req.ID, Result: map[string]interface{}{

--- a/cmd/docxgo/handlers_test.go
+++ b/cmd/docxgo/handlers_test.go
@@ -883,6 +883,40 @@ func TestHandleTableGetCell(t *testing.T) {
 	}
 }
 
+func TestHandleTableList_IncludeText(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "table.list", map[string]interface{}{
+		"documentId": docID, "includeText": true,
+	}))
+	if resp.Error != nil {
+		t.Fatalf("table.list failed: %+v", resp.Error)
+	}
+	tables := resp.Result.(map[string]interface{})["tables"].([]map[string]interface{})
+	if len(tables) != 1 {
+		t.Fatalf("table count = %d, want 1", len(tables))
+	}
+	cells, ok := tables[0]["cells"].([][]string)
+	if !ok {
+		t.Fatalf("cells missing or wrong type: %T", tables[0]["cells"])
+	}
+	if len(cells) != 2 || len(cells[0]) != 2 {
+		t.Fatalf("cells shape = %v", cells)
+	}
+	if cells[1][0] != "Do you encrypt data at rest?" || cells[1][1] != "TBD" {
+		t.Errorf("row 1 = %v", cells[1])
+	}
+
+	// Without the flag, cells must be absent.
+	resp = s.dispatch(makeRequest(3, "table.list", map[string]interface{}{
+		"documentId": docID,
+	}))
+	tables = resp.Result.(map[string]interface{})["tables"].([]map[string]interface{})
+	if _, present := tables[0]["cells"]; present {
+		t.Error("cells should be absent without includeText")
+	}
+}
+
 func TestHandleTableSetCell_TextShortcut(t *testing.T) {
 	s, docID := newEditTestDoc(t)
 

--- a/cmd/docxgo/handlers_test.go
+++ b/cmd/docxgo/handlers_test.go
@@ -708,6 +708,323 @@ func TestIntegration_CreateOpenInspectSave(t *testing.T) {
 	}
 }
 
+// ─── Edit handler tests ───────────────────────────────────────────────────────
+
+// newEditTestDoc creates an in-memory document with one paragraph and a 2x2
+// question/answer table, returning the server and documentId.
+func newEditTestDoc(t *testing.T) (*server, string) {
+	t.Helper()
+	s := newServer()
+	resp := s.dispatch(makeRequest(1, "document.create", map[string]interface{}{
+		"content": []interface{}{
+			map[string]interface{}{
+				"type": "paragraph",
+				"runs": []interface{}{
+					map[string]interface{}{"text": "Vendor: ACME Corp"},
+				},
+			},
+			map[string]interface{}{
+				"type": "table",
+				"rows": []interface{}{
+					map[string]interface{}{"cells": []interface{}{
+						map[string]interface{}{"paragraphs": []interface{}{
+							map[string]interface{}{"runs": []interface{}{map[string]interface{}{"text": "Question", "bold": true}}},
+						}},
+						map[string]interface{}{"paragraphs": []interface{}{
+							map[string]interface{}{"runs": []interface{}{map[string]interface{}{"text": "Answer", "bold": true}}},
+						}},
+					}},
+					map[string]interface{}{"cells": []interface{}{
+						map[string]interface{}{"paragraphs": []interface{}{
+							map[string]interface{}{"runs": []interface{}{map[string]interface{}{"text": "Do you encrypt data at rest?"}}},
+						}},
+						map[string]interface{}{"paragraphs": []interface{}{
+							map[string]interface{}{"runs": []interface{}{map[string]interface{}{"text": "TBD"}}},
+						}},
+					}},
+				},
+			},
+		},
+		"output": "buffer",
+	}))
+	if resp.Error != nil {
+		t.Fatalf("create failed: %+v", resp.Error)
+	}
+	docID := resp.Result.(map[string]interface{})["documentId"].(string)
+	return s, docID
+}
+
+func TestHandleReplaceText(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "document.replaceText", map[string]interface{}{
+		"documentId": docID,
+		"find":       "ACME Corp",
+		"replace":    "Reindeer AI",
+	}))
+	if resp.Error != nil {
+		t.Fatalf("replaceText failed: %+v", resp.Error)
+	}
+	result := resp.Result.(map[string]interface{})
+	if result["replaced"] != 1 {
+		t.Errorf("replaced = %v, want 1", result["replaced"])
+	}
+
+	listResp := s.dispatch(makeRequest(3, "paragraph.list", map[string]interface{}{
+		"documentId": docID,
+	}))
+	paras := listResp.Result.(map[string]interface{})["paragraphs"].([]map[string]interface{})
+	if paras[0]["text"] != "Vendor: Reindeer AI" {
+		t.Errorf("paragraph text = %q", paras[0]["text"])
+	}
+}
+
+func TestHandleReplaceText_ReachesTableCells(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "document.replaceText", map[string]interface{}{
+		"documentId": docID,
+		"find":       "TBD",
+		"replace":    "Yes, AES-256",
+	}))
+	if resp.Error != nil {
+		t.Fatalf("replaceText failed: %+v", resp.Error)
+	}
+	if got := resp.Result.(map[string]interface{})["replaced"]; got != 1 {
+		t.Errorf("replaced = %v, want 1", got)
+	}
+
+	cellResp := s.dispatch(makeRequest(3, "table.getCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+	}))
+	if cellResp.Error != nil {
+		t.Fatalf("getCell failed: %+v", cellResp.Error)
+	}
+	if got := cellResp.Result.(map[string]interface{})["text"]; got != "Yes, AES-256" {
+		t.Errorf("cell text = %q", got)
+	}
+}
+
+func TestHandleReplaceText_Validation(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "document.replaceText", map[string]interface{}{
+		"documentId": docID, "find": "", "replace": "x",
+	}))
+	if resp.Error == nil {
+		t.Error("expected error for empty find")
+	}
+
+	resp = s.dispatch(makeRequest(3, "document.replaceText", map[string]interface{}{
+		"documentId": "doc-999", "find": "a", "replace": "b",
+	}))
+	if resp.Error == nil || resp.Error.Code != "NOT_FOUND" {
+		t.Errorf("expected NOT_FOUND for unknown doc, got %+v", resp.Error)
+	}
+}
+
+func TestHandleParagraphSetText(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "paragraph.setText", map[string]interface{}{
+		"documentId": docID,
+		"index":      0,
+		"runs": []interface{}{
+			map[string]interface{}{"text": "Completed by ", "italic": true},
+			map[string]interface{}{"text": "Reindeer", "bold": true},
+		},
+	}))
+	if resp.Error != nil {
+		t.Fatalf("setText failed: %+v", resp.Error)
+	}
+
+	listResp := s.dispatch(makeRequest(3, "paragraph.list", map[string]interface{}{
+		"documentId": docID,
+	}))
+	paras := listResp.Result.(map[string]interface{})["paragraphs"].([]map[string]interface{})
+	if paras[0]["text"] != "Completed by Reindeer" {
+		t.Errorf("paragraph text = %q", paras[0]["text"])
+	}
+}
+
+func TestHandleParagraphSetText_IndexOutOfRange(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "paragraph.setText", map[string]interface{}{
+		"documentId": docID, "index": 99, "text": "x",
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Errorf("expected VALIDATION_ERROR, got %+v", resp.Error)
+	}
+}
+
+func TestHandleTableGetCell(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "table.getCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 0,
+	}))
+	if resp.Error != nil {
+		t.Fatalf("getCell failed: %+v", resp.Error)
+	}
+	result := resp.Result.(map[string]interface{})
+	if result["text"] != "Do you encrypt data at rest?" {
+		t.Errorf("cell text = %q", result["text"])
+	}
+	if result["paragraphCount"] != 1 {
+		t.Errorf("paragraphCount = %v, want 1", result["paragraphCount"])
+	}
+
+	resp = s.dispatch(makeRequest(3, "table.getCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 5, "rowIndex": 0, "columnIndex": 0,
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Errorf("expected VALIDATION_ERROR for bad table index, got %+v", resp.Error)
+	}
+}
+
+func TestHandleTableSetCell_TextShortcut(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+		"text": "Yes — AES-256 at rest, TLS 1.3 in transit.",
+	}))
+	if resp.Error != nil {
+		t.Fatalf("setCell failed: %+v", resp.Error)
+	}
+
+	cellResp := s.dispatch(makeRequest(3, "table.getCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+	}))
+	if got := cellResp.Result.(map[string]interface{})["text"]; got != "Yes — AES-256 at rest, TLS 1.3 in transit." {
+		t.Errorf("cell text = %q", got)
+	}
+}
+
+func TestHandleTableSetCell_RichParagraphs(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+		"paragraphs": []interface{}{
+			map[string]interface{}{"runs": []interface{}{map[string]interface{}{"text": "Yes.", "bold": true}}},
+			map[string]interface{}{"runs": []interface{}{map[string]interface{}{"text": "See SOC 2 report, section 4."}}},
+		},
+	}))
+	if resp.Error != nil {
+		t.Fatalf("setCell failed: %+v", resp.Error)
+	}
+	result := resp.Result.(map[string]interface{})
+	if result["paragraphCount"] != 2 {
+		t.Errorf("paragraphCount = %v, want 2", result["paragraphCount"])
+	}
+
+	cellResp := s.dispatch(makeRequest(3, "table.getCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+	}))
+	if got := cellResp.Result.(map[string]interface{})["text"]; got != "Yes.\nSee SOC 2 report, section 4." {
+		t.Errorf("cell text = %q", got)
+	}
+}
+
+func TestHandleTableSetCell_TextAndParagraphsConflict(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 0, "columnIndex": 0,
+		"text":       "x",
+		"paragraphs": []interface{}{map[string]interface{}{"text": "y"}},
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Errorf("expected VALIDATION_ERROR, got %+v", resp.Error)
+	}
+}
+
+// TestIntegration_EditRoundTrip exercises the questionnaire flow: open a saved
+// document, replace text, fill an answer cell, rewrite a paragraph, save, then
+// reopen and verify all edits survived serialization.
+func TestIntegration_EditRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	docPath := dir + "/questionnaire.docx"
+	editedPath := dir + "/questionnaire-filled.docx"
+
+	s, docID := newEditTestDoc(t)
+	saveResp := s.dispatch(makeRequest(2, "document.save", map[string]interface{}{
+		"documentId": docID, "output": "file", "filePath": docPath,
+	}))
+	if saveResp.Error != nil {
+		t.Fatalf("save failed: %+v", saveResp.Error)
+	}
+
+	openResp := s.dispatch(makeRequest(3, "document.open", map[string]interface{}{
+		"filePath": docPath,
+	}))
+	if openResp.Error != nil {
+		t.Fatalf("open failed: %+v", openResp.Error)
+	}
+	openedID := openResp.Result.(map[string]interface{})["documentId"].(string)
+
+	for i, req := range []map[string]interface{}{
+		{"documentId": openedID, "find": "ACME Corp", "replace": "Reindeer AI"},
+	} {
+		resp := s.dispatch(makeRequest(10+i, "document.replaceText", req))
+		if resp.Error != nil {
+			t.Fatalf("replaceText failed: %+v", resp.Error)
+		}
+		if got := resp.Result.(map[string]interface{})["replaced"]; got != 1 {
+			t.Fatalf("replaced = %v, want 1", got)
+		}
+	}
+	setCellResp := s.dispatch(makeRequest(20, "table.setCell", map[string]interface{}{
+		"documentId": openedID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+		"text": "Yes — AES-256.",
+	}))
+	if setCellResp.Error != nil {
+		t.Fatalf("setCell failed: %+v", setCellResp.Error)
+	}
+	setParaResp := s.dispatch(makeRequest(21, "paragraph.setText", map[string]interface{}{
+		"documentId": openedID, "index": 0, "text": "Vendor: Reindeer AI (reviewed)",
+	}))
+	if setParaResp.Error != nil {
+		t.Fatalf("paragraph.setText failed: %+v", setParaResp.Error)
+	}
+
+	saveResp = s.dispatch(makeRequest(22, "document.save", map[string]interface{}{
+		"documentId": openedID, "output": "file", "filePath": editedPath,
+	}))
+	if saveResp.Error != nil {
+		t.Fatalf("save edited failed: %+v", saveResp.Error)
+	}
+
+	// Reopen and verify the edits survived the round trip.
+	reopenResp := s.dispatch(makeRequest(23, "document.open", map[string]interface{}{
+		"filePath": editedPath,
+	}))
+	if reopenResp.Error != nil {
+		t.Fatalf("reopen failed: %+v", reopenResp.Error)
+	}
+	reopenedID := reopenResp.Result.(map[string]interface{})["documentId"].(string)
+
+	listResp := s.dispatch(makeRequest(24, "paragraph.list", map[string]interface{}{
+		"documentId": reopenedID,
+	}))
+	paras := listResp.Result.(map[string]interface{})["paragraphs"].([]map[string]interface{})
+	if paras[0]["text"] != "Vendor: Reindeer AI (reviewed)" {
+		t.Errorf("reopened paragraph text = %q", paras[0]["text"])
+	}
+
+	cellResp := s.dispatch(makeRequest(25, "table.getCell", map[string]interface{}{
+		"documentId": reopenedID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+	}))
+	if cellResp.Error != nil {
+		t.Fatalf("getCell after reopen failed: %+v", cellResp.Error)
+	}
+	if got := cellResp.Result.(map[string]interface{})["text"]; got != "Yes — AES-256." {
+		t.Errorf("reopened cell text = %q", got)
+	}
+}
+
 // ─── runExec tests ────────────────────────────────────────────────────────────
 
 func TestRunExec_WithRequestFlag(t *testing.T) {

--- a/cmd/docxgo/main.go
+++ b/cmd/docxgo/main.go
@@ -87,6 +87,8 @@ func capabilitiesMap() map[string]bool {
 		"batch":         true,
 		"applyPatch":    true,
 		"setLanguage":   true,
+		"replaceText":   true,
+		"cellEdit":      true,
 		"streaming":     false,
 		"partialUpdate": false,
 	}

--- a/pkg/template/replace.go
+++ b/pkg/template/replace.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Misael Monterroca
+//
+// See LICENSE for the full copyright notice, including predecessor authors,
+// and CREDITS.md for the project genealogy.
+
+package template
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mmonterroca/docxgo/v2/domain"
+)
+
+// ReplaceResult reports the outcome of a ReplaceText call.
+type ReplaceResult struct {
+	// Replaced is the number of occurrences that were replaced.
+	Replaced int
+	// Skipped is the number of occurrences that were found but left
+	// untouched because the match spans a run with non-text content
+	// (fields, breaks, or images).
+	Skipped int
+}
+
+// ReplaceText replaces every occurrence of find with replace across the
+// document: body paragraphs, table cells, headers, and footers. The document
+// is modified in place.
+//
+// Matching is literal and case-sensitive. Runs in each paragraph are first
+// consolidated (see ConsolidateRuns), so text fragmented across runs with
+// identical formatting is matched. A match that spans runs with different
+// formatting is replaced too: the replacement takes the formatting of the
+// first spanned run. Matches that span a run containing fields, breaks, or
+// images are skipped and counted in ReplaceResult.Skipped.
+func ReplaceText(doc domain.Document, find, replace string) (ReplaceResult, error) {
+	if find == "" {
+		return ReplaceResult{}, fmt.Errorf("template: find text must not be empty")
+	}
+
+	var result ReplaceResult
+	err := walkParagraphs(doc, func(para domain.Paragraph, _ paragraphContext) error {
+		replaced, skipped, err := replaceInParagraph(para, find, replace)
+		result.Replaced += replaced
+		result.Skipped += skipped
+		return err
+	})
+	return result, err
+}
+
+// runSpan maps a run to its byte-offset range [start, end) within the
+// paragraph's concatenated text.
+type runSpan struct {
+	run        domain.Run
+	start, end int
+}
+
+// replaceInParagraph replaces occurrences of find within a single paragraph.
+// After each successful replacement the paragraph text is rebuilt and the
+// scan resumes just past the inserted replacement, so a replacement that
+// itself contains find is never re-matched.
+func replaceInParagraph(para domain.Paragraph, find, replace string) (replaced, skipped int, err error) {
+	if err := ConsolidateRuns(para); err != nil {
+		return 0, 0, err
+	}
+
+	cursor := 0
+	for {
+		spans, full := paragraphSpans(para)
+		if cursor >= len(full) {
+			break
+		}
+		rel := strings.Index(full[cursor:], find)
+		if rel < 0 {
+			break
+		}
+		start := cursor + rel
+		end := start + len(find)
+
+		ok, err := replaceSpan(spans, start, end, replace)
+		if err != nil {
+			return replaced, skipped, err
+		}
+		if ok {
+			replaced++
+			cursor = start + len(replace)
+		} else {
+			skipped++
+			cursor = end
+		}
+	}
+	return replaced, skipped, nil
+}
+
+// paragraphSpans returns the paragraph's runs with their byte-offset ranges
+// and the concatenated paragraph text.
+func paragraphSpans(para domain.Paragraph) ([]runSpan, string) {
+	runs := para.Runs()
+	spans := make([]runSpan, 0, len(runs))
+	var sb strings.Builder
+	off := 0
+	for _, r := range runs {
+		t := r.Text()
+		spans = append(spans, runSpan{run: r, start: off, end: off + len(t)})
+		sb.WriteString(t)
+		off += len(t)
+	}
+	return spans, sb.String()
+}
+
+// replaceSpan writes replace over the byte range [start, end) of the
+// paragraph text. A match confined to a single run is always replaceable;
+// a match spanning several runs is replaceable only if every spanned run is
+// text-only. Returns false (and no error) when the match must be skipped.
+func replaceSpan(spans []runSpan, start, end int, replace string) (bool, error) {
+	var spanned []runSpan
+	for _, s := range spans {
+		// Zero-width (empty) runs cannot contribute match text.
+		if s.end > s.start && s.start < end && s.end > start {
+			spanned = append(spanned, s)
+		}
+	}
+	if len(spanned) == 0 {
+		return false, nil
+	}
+
+	if len(spanned) > 1 {
+		for _, s := range spanned {
+			if !isTextOnly(s.run) {
+				return false, nil
+			}
+		}
+	}
+
+	first := spanned[0]
+	last := spanned[len(spanned)-1]
+	firstText := first.run.Text()
+	lastText := last.run.Text()
+
+	if len(spanned) == 1 {
+		newText := firstText[:start-first.start] + replace + firstText[end-first.start:]
+		return true, first.run.SetText(newText)
+	}
+
+	if err := first.run.SetText(firstText[:start-first.start] + replace); err != nil {
+		return false, err
+	}
+	for _, s := range spanned[1 : len(spanned)-1] {
+		if err := s.run.SetText(""); err != nil {
+			return false, err
+		}
+	}
+	return true, last.run.SetText(lastText[end-last.start:])
+}

--- a/pkg/template/replace_test.go
+++ b/pkg/template/replace_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Misael Monterroca
+//
+// See LICENSE for the full copyright notice, including predecessor authors,
+// and CREDITS.md for the project genealogy.
+
+package template
+
+import (
+	"testing"
+
+	"github.com/mmonterroca/docxgo/v2/domain"
+	"github.com/mmonterroca/docxgo/v2/internal/core"
+)
+
+func TestReplaceText_SingleRun(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r, _ := para.AddRun()
+	r.SetText("The answer is TODO for now.")
+
+	result, err := ReplaceText(doc, "TODO", "42")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 1 || result.Skipped != 0 {
+		t.Errorf("result = %+v, want 1 replaced / 0 skipped", result)
+	}
+	if got := para.Text(); got != "The answer is 42 for now." {
+		t.Errorf("paragraph text = %q", got)
+	}
+}
+
+func TestReplaceText_SplitAcrossIdenticalRuns(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	// Word-style fragmentation: same formatting, split mid-word.
+	for _, chunk := range []string{"Not ", "Applic", "able"} {
+		r, _ := para.AddRun()
+		r.SetText(chunk)
+	}
+
+	result, err := ReplaceText(doc, "Not Applicable", "Yes")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 1 {
+		t.Errorf("replaced = %d, want 1", result.Replaced)
+	}
+	if got := para.Text(); got != "Yes" {
+		t.Errorf("paragraph text = %q", got)
+	}
+}
+
+func TestReplaceText_SpanningDifferentFormatting(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r1, _ := para.AddRun()
+	r1.SetText("Status: ")
+	r2, _ := para.AddRun()
+	r2.SetText("PENDING")
+	r2.SetBold(true)
+	r3, _ := para.AddRun()
+	r3.SetText(" (review)")
+
+	// Match spans the normal/bold boundary; consolidation cannot merge these.
+	result, err := ReplaceText(doc, ": PENDING (", ": DONE (")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 1 {
+		t.Errorf("replaced = %d, want 1", result.Replaced)
+	}
+	if got := para.Text(); got != "Status: DONE (review)" {
+		t.Errorf("paragraph text = %q", got)
+	}
+}
+
+func TestReplaceText_MultipleOccurrences(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r, _ := para.AddRun()
+	r.SetText("aaa bbb aaa bbb aaa")
+
+	result, err := ReplaceText(doc, "aaa", "X")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 3 {
+		t.Errorf("replaced = %d, want 3", result.Replaced)
+	}
+	if got := para.Text(); got != "X bbb X bbb X" {
+		t.Errorf("paragraph text = %q", got)
+	}
+}
+
+func TestReplaceText_ReplacementContainsFind(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r, _ := para.AddRun()
+	r.SetText("go go")
+
+	result, err := ReplaceText(doc, "go", "go faster")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 2 {
+		t.Errorf("replaced = %d, want 2", result.Replaced)
+	}
+	if got := para.Text(); got != "go faster go faster" {
+		t.Errorf("paragraph text = %q", got)
+	}
+}
+
+func TestReplaceText_InTableCell(t *testing.T) {
+	doc := core.NewDocument()
+	table, _ := doc.AddTable(1, 2)
+	cell, _ := table.Rows()[0].Cell(1)
+	para, _ := cell.AddParagraph()
+	r, _ := para.AddRun()
+	r.SetText("{answer pending}")
+
+	result, err := ReplaceText(doc, "{answer pending}", "SOC 2 Type II")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 1 {
+		t.Errorf("replaced = %d, want 1", result.Replaced)
+	}
+	if got := para.Text(); got != "SOC 2 Type II" {
+		t.Errorf("cell paragraph text = %q", got)
+	}
+}
+
+func TestReplaceText_SkipsSpanOverNonTextRun(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r1, _ := para.AddRun()
+	r1.SetText("before")
+	r1.SetBold(true) // prevent consolidation with r2
+	r2, _ := para.AddRun()
+	r2.SetText("after")
+	r2.AddBreak(domain.BreakTypeLine)
+
+	result, err := ReplaceText(doc, "beforeafter", "X")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 0 || result.Skipped != 1 {
+		t.Errorf("result = %+v, want 0 replaced / 1 skipped", result)
+	}
+	if got := para.Text(); got != "beforeafter" {
+		t.Errorf("paragraph text = %q, want unchanged", got)
+	}
+}
+
+func TestReplaceText_EmptyFindErrors(t *testing.T) {
+	doc := core.NewDocument()
+	if _, err := ReplaceText(doc, "", "x"); err == nil {
+		t.Fatal("expected error for empty find")
+	}
+}
+
+func TestReplaceText_DeleteWithEmptyReplacement(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r, _ := para.AddRun()
+	r.SetText("Remove [DRAFT] marker")
+
+	result, err := ReplaceText(doc, "[DRAFT] ", "")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 1 {
+		t.Errorf("replaced = %d, want 1", result.Replaced)
+	}
+	if got := para.Text(); got != "Remove marker" {
+		t.Errorf("paragraph text = %q", got)
+	}
+}
+
+func TestReplaceText_NoMatch(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r, _ := para.AddRun()
+	r.SetText("nothing to see")
+
+	result, err := ReplaceText(doc, "absent", "x")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 0 || result.Skipped != 0 {
+		t.Errorf("result = %+v, want zero result", result)
+	}
+	if got := para.Text(); got != "nothing to see" {
+		t.Errorf("paragraph text = %q, want unchanged", got)
+	}
+}


### PR DESCRIPTION
## Motivation

The JSON-RPC CLI's content surface is currently append-only (`document.addContent`, `applyPatch` `append*` ops) plus document properties. The Go API supports full read-modify-save round-trips, but none of that is reachable over RPC — so CLI consumers cannot modify existing document content (fill in a form, update a table cell, replace a phrase).

This PR adds an in-place editing RPC surface, built on the existing template machinery.

## New RPC methods

| Method | Purpose |
|---|---|
| `document.replaceText` | Literal find-and-replace across body paragraphs, table cells, headers, and footers → `{replaced, skipped}` |
| `paragraph.setText` | Rewrite a body paragraph by `paragraph.list` index; accepts the same text/runs/style fields as `paragraph.add` |
| `table.getCell` | Read a cell's paragraph texts by table/row/column index |
| `table.setCell` | Replace a cell's content with plain `text` or rich `paragraphs` items |
| `table.list` `includeText` | Optional flag adding per-row cell texts to the listing (rows report their actual cells, so merged/ragged rows are represented faithfully) |

## Design notes

- The replace engine is `pkg/template/ReplaceText`, reusing `walkParagraphs` + `ConsolidateRuns` from mail merge. Runs are consolidated first, so text fragmented across identically-formatted runs is matched; a match spanning *differently*-formatted runs is still replaced (the replacement takes the first spanned run's formatting); matches overlapping runs with fields, breaks, or images are skipped and counted in `skipped`.
- Replacement rescans from just past the inserted text, so a replacement containing the search text never loops.
- `system.capabilities` advertises `replaceText` and `cellEdit`.

## Testing

- 10 unit tests for `ReplaceText` (single-run, fragmented runs, cross-formatting spans, multiple occurrences, replacement-contains-find, table cells, skip-over-field/break, empty-find error, deletion, no-match)
- 11 handler tests, including a full create → save → open → edit → save → reopen round-trip verifying edits survive serialization
- Full existing suite passes; `gofmt`/`go vet` clean

## Note on target branch

CONTRIBUTING.md says to PR against `dev`, but `dev` currently appears to be behind `master` (v2.7.1 vs v2.7.2), so targeting `dev` would include unrelated `master` commits in the diff. Opened against `master` to keep the diff to exactly these changes — happy to retarget or rebase if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)