### PR TITLE
chore: retire the dev integration branch, contribute against master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ permissions:
 
 on:
   push:
-    branches: [ master, dev ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, dev ]
+    branches: [ master ]
 
 jobs:
   lint-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,12 @@ permissions:
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, 'integration/**' ]
   pull_request:
-    branches: [ master ]
+    # Filters on the BASE branch, so integration/** is listed to keep PRs that
+    # co-stage work on a short-lived integration branch under CI (see the
+    # branching section of CONTRIBUTING.md).
+    branches: [ master, 'integration/**' ]
 
 jobs:
   lint-and-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Changed
+
+- **The `dev` integration branch has been retired; contributions now branch from and target `master`.** `dev` was introduced as a Git Flow integration branch, but since ~v2.4 its only traffic had been `master → dev` sync merges — it had stopped being a real integration point while still being the branch `CONTRIBUTING.md` told contributors to use. That cost real contributions: [#35](https://github.com/mmonterroca/docxgo/pull/35) targeted `dev`, went stale there, and had to be re-shipped through `master` as [#39](https://github.com/mmonterroca/docxgo/pull/39); [#57](https://github.com/mmonterroca/docxgo/pull/57) was closed; and the author of [#64](https://github.com/mmonterroca/docxgo/pull/64) declined to target `dev` at all because it was behind `master` and doing so would have pulled unrelated history into the diff. Releases are cut by tagging `master`, so the branch was never the release gate either. Short-lived `integration/<topic>` branches remain available for the rare case where two in-flight changes must be co-staged before either lands.
+
+---
+
 ## v2.7.2 — 2026-07-18
 
 ### Compliance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,21 +8,21 @@ Thank you for your interest in contributing to docxgo! This document provides gu
 
 1. **Read the docs**: [README.md](README.md), [V2_DESIGN.md](docs/V2_DESIGN.md)
 2. **Check issues**: Look for `good-first-issue` or `help-wanted` labels
-3. **Follow Git Flow**: Branch from `dev`, PR back to `dev`
+3. **Branch from `master`, PR back to `master`**
 4. **Write tests**: Aim for 95%+ coverage
 5. **Update docs**: Keep README and examples in sync
 
 ---
 
-## Git Flow Workflow
+## Branching Workflow
 
-We use a simplified Git Flow branching strategy to maintain code quality and stability:
+We use trunk-based development: contributions branch directly from `master` and PR back to `master`.
 
 ### Branch Structure
 
-- **`master`**: Production-ready code only. This branch contains stable releases and is tagged with semantic versions (e.g., `v2.5.0`).
-- **`dev`**: Integration branch where features are tested before release. All development work merges here first.
-- **Feature branches**: Short-lived branches for specific features, bug fixes, or improvements. Named with prefixes like `feature/`, `fix/`, `docs/`, etc.
+- **`master`**: Production-ready code. This branch contains stable releases and is tagged with semantic versions (e.g., `v2.5.0`). Protected — all changes land via reviewed pull request.
+- **Feature branches**: Short-lived branches for specific features, bug fixes, or improvements. Named with prefixes like `feature/`, `fix/`, `docs/`, etc. Deleted once merged.
+- **Integration branches** (rare): if two in-flight changes genuinely need to be co-staged before either lands on `master`, cut a short-lived `integration/<topic>` branch for that purpose and delete it once both land. This is the exception, not a standing branch — we do not keep a permanent second long-lived branch, since a branch that isn't part of every contributor's default path drifts stale and misdirects contributions (see [CHANGELOG](CHANGELOG.md) for why we retired the old `dev` integration branch).
 
 ### Contributing Process
 
@@ -48,11 +48,11 @@ git remote -v  # Verify remotes
 
 #### 3. Create Feature Branch
 
-Always branch from `dev`:
+Always branch from `master`:
 
 ```bash
-git checkout dev
-git pull upstream dev  # Get latest changes
+git checkout master
+git pull upstream master  # Get latest changes
 git checkout -b feature/your-feature-name
 ```
 
@@ -116,7 +116,7 @@ git push origin feature/your-feature-name
 
 1. Go to the [original repository](https://github.com/mmonterroca/docxgo)
 2. Click "New Pull Request"
-3. **Important**: Set base branch to `dev` (NOT `master`)
+3. Set base branch to `master`
 4. Set compare branch to your feature branch
 5. Fill in the PR template:
    - Clear description of changes
@@ -129,14 +129,13 @@ git push origin feature/your-feature-name
 - Wait for maintainer review
 - Address feedback by pushing additional commits
 - Engage in discussion if needed
-- Once approved, maintainers will merge to `dev`
+- Once approved, maintainers will merge to `master`
 
 #### 9. Release Process
 
 Periodically, maintainers will:
-1. Merge `dev` → `master`
-2. Tag the release with semantic version
-3. Create GitHub release with changelog
+1. Tag `master` with the next semantic version
+2. Create GitHub release with changelog (this triggers automated binary builds and npm publishing)
 
 ## What We're Looking For
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Go library for creating and editing Microsoft Word (`.docx` / OOXML) documents, with a JSON-RPC CLI and Node.js wrapper for use from other languages.
 
+**🌐 Official Website:** [docxgo.dev](https://docxgo.dev/)
+
 [![Go Reference](https://pkg.go.dev/badge/github.com/mmonterroca/docxgo/v2.svg)](https://pkg.go.dev/github.com/mmonterroca/docxgo/v2)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Go Report Card](https://goreportcard.com/badge/github.com/mmonterroca/docxgo)](https://goreportcard.com/report/github.com/mmonterroca/docxgo)

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Coverage varies by package — `domain` and `pkg/errors` are at 100%, `internal/
 
 ## Contributing
 
-Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow (feature branches → `dev` → `master`), testing requirements, and PR process. In short: fork, branch, add tests, run `go test ./...`, and open a PR against `dev`.
+Contributions are welcome — see [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow (feature branches → `master`), testing requirements, and PR process. In short: fork, branch from `master`, add tests, run `go test ./...`, and open a PR against `master`.
 
 ---
 


### PR DESCRIPTION
## Motivation

`dev` was introduced as a Git Flow integration branch, but since ~v2.4 its only traffic has been `master → dev` sync merges — it stopped being a real integration point.

Meanwhile every recent external contribution that targeted it was harmed:

- PR #35 targeted `dev`, went stale there, and the same feature was re-shipped through `master` as #39
- PR #57 (also against `dev`) was closed
- PR #64's author explicitly declined to target `dev` because it was 7 commits behind `master` and 0 ahead — targeting it would have pulled unrelated history into the diff

`CONTRIBUTING.md` still instructed contributors to branch from `dev` and set it as the PR base (line 119: *"Set base branch to `dev` (NOT `master`)"*), which is exactly what tripped up #64.

## Changes

- `CONTRIBUTING.md`: switch to trunk-based development — branch from `master`, PR to `master`. Adds a short-lived `integration/<topic>` branch as the escape hatch for the rare case where two in-flight changes need to be co-staged before either lands.
- `.github/workflows/ci.yml`: drop `dev` from the `push`/`pull_request` triggers.

## Follow-up (not in this PR)

Once this merges and CI is confirmed green on `master`, the `dev` ref itself will be deleted (remote + local). Grepped the repo: outside of docs, the only remaining "dev" matches are `/dev/null` and `pkg.go.dev` — nothing depends on the branch. Historical references in `RELEASE_NOTES_v2.5.0.md` / `RELEASE_NOTES_v2.7.0.md` are left untouched as historical record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)