### PR TITLE
fix: publish to npm as a direct workflow call, not the release event

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,9 +3,19 @@ name: npm Publish
 on:
   release:
     types: [published]
-  # GitHub does not let GITHUB_TOKEN-authored events trigger other workflows.
-  # release.yml creates the release with RELEASE_PAT so the event above fires
-  # automatically; this dispatch remains an idempotent fallback.
+  # release.yml invokes this workflow directly as a job (see its publish-npm
+  # job), passing the version explicitly, so publishing no longer depends on
+  # the "release: published" event above ever firing — which it doesn't when
+  # RELEASE_PAT is unset, since GitHub does not let GITHUB_TOKEN-authored
+  # events trigger other workflows.
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 2.7.2, no "v" prefix)'
+        required: true
+        type: string
+  # Idempotent manual fallback, usable from the default branch if a release
+  # ever needs to be re-published by hand.
   #
   # workflow_dispatch is only usable against a ref where the workflow file
   # itself already declares this trigger, so the release tag (created before
@@ -51,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/v{0}', inputs.version) || github.ref }}
+          ref: ${{ inputs.version != '' && format('refs/tags/v{0}', inputs.version) || github.ref }}
 
       - uses: actions/setup-go@v7
         with:
@@ -66,8 +76,8 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
           else
             echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
           fi
@@ -136,7 +146,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/v{0}', inputs.version) || github.ref }}
+          ref: ${{ inputs.version != '' && format('refs/tags/v{0}', inputs.version) || github.ref }}
 
       - uses: actions/setup-node@v4
         with:
@@ -146,8 +156,8 @@ jobs:
       - name: Extract version from tag
         id: version
         run: |
-          if [ -n "${{ github.event.inputs.version }}" ]; then
-            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
           else
             echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,8 @@ jobs:
     name: Create GitHub Release
     needs: [build, test]
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -107,6 +109,12 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
+      - name: Check RELEASE_PAT is configured
+        run: |
+          if [ -z "${{ secrets.RELEASE_PAT }}" ]; then
+            echo "::warning::RELEASE_PAT is empty or missing — this release will be authored by github-actions[bot] instead of a real user. This is now cosmetic: the publish-npm job below invokes npm-publish.yml directly and no longer depends on the 'release: published' event that a bot-authored release can't fire. Still worth fixing so releases show a real author."
+          fi
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
@@ -116,11 +124,23 @@ jobs:
           generate_release_notes: true
           files: release-assets/*
         env:
-          # Must be a real PAT (repo-scoped "Contents: Read and write" is
-          # enough), not the default GITHUB_TOKEN: GitHub does not let events
-          # created by GITHUB_TOKEN trigger other workflows (anti-recursion
-          # protection), so npm-publish.yml's "release: published" trigger
-          # would never fire if this stayed as GITHUB_TOKEN. See
-          # npm-publish.yml's workflow_dispatch fallback for the manual path
-          # this replaces.
+          # Ideally a real PAT (repo-scoped "Contents: Read and write" is
+          # enough) so the release shows a real author instead of
+          # github-actions[bot] — see the RELEASE_PAT check above. No longer
+          # load-bearing for npm publishing: the publish-npm job below calls
+          # npm-publish.yml directly instead of relying on the "release:
+          # published" event, which a GITHUB_TOKEN-authored release can't
+          # fire (GitHub's anti-recursion protection).
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+
+  publish-npm:
+    name: Publish to npm
+    needs: release
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+    uses: ./.github/workflows/npm-publish.yml
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Every release since at least v2.7.2 has had to be pushed to npm by hand via `workflow_dispatch`. `release.yml` authors the GitHub Release with `RELEASE_PAT`, but when that secret is empty or expired the release falls back to being authored by `github-actions[bot]`, and GitHub's anti-recursion rule means a `GITHUB_TOKEN`-authored event can never trigger `npm-publish.yml`'s `release: published` listener. The failure is silent — `release.yml` still reports success even though the cascade it exists to start never happens.

This removes the dependency on that event entirely:

- `npm-publish.yml` gains a `workflow_call` trigger (`version` input), alongside the existing `release:` and `workflow_dispatch:` triggers.
- The checkout `ref` and version-extraction steps now key off the `inputs.version` context (works for both `workflow_call` and `workflow_dispatch`) instead of `github.event.inputs.version`, which is only populated for `workflow_dispatch`.
- `release.yml`'s `release` job now exposes its computed version as a job output.
- New `publish-npm` job in `release.yml`, `needs: release`, invokes `npm-publish.yml` directly via `uses:` + `secrets: inherit`, passing the version explicitly. `id-token: write` and `issues: write` are granted on this calling job since reusable-workflow jobs can't exceed what the caller grants.
- The `RELEASE_PAT` emptiness check is now a `::warning::` instead of silently doing nothing — a bot-authored release is no longer a publish blocker, just cosmetic (wrong author on the Release page).

## Why not just add the guard from #72

The issue's suggested fix (fail loudly if `RELEASE_PAT` is empty) would still leave every release requiring a real, unexpired PAT to publish at all. This makes the npm publish step a first-class part of the release job graph instead of an event listener that can silently go dead.

Fixes #72

## Test plan

- [x] `actionlint .github/workflows/release.yml .github/workflows/npm-publish.yml` — clean
- [x] `go build ./... && go vet ./...` — unaffected (no Go changes)
- [ ] Real validation happens on the next tag push (v2.9.0) — `gh run list --workflow=npm-publish.yml` should show a run triggered by `release.yml`, not a manual `workflow_dispatch`
- [x] `workflow_dispatch` fallback preserved unchanged for manual re-publish