### PR TITLE
chore: delete the unreachable no-style-manager styles.xml fallback

### DIFF
--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -1219,15 +1219,11 @@ func (s *DocumentSerializer) DebugPrint(doc domain.Document) {
 }
 
 // documentDefaultParagraphProperties returns the w:pPrDefault contents shared
-// by every generated document, regardless of whether it carries a style
-// manager: 0pt before/after spacing and single line spacing (240 twips,
-// auto rule). Without an explicit default, an empty <w:pPr> (or a paragraph
-// that never sets spacing) falls back to Word's own defaults — 8pt after,
-// 1.15 line spacing — instead of the 0/240 the domain model assumes
-// (constants.DefaultParagraphSpacing / DefaultLineSpacing).
-//
-// This must stay in sync with the raw XML in ZipWriter.writeDefaultStyles,
-// which applies the same defaults for documents with no style manager.
+// by every generated document: 0pt before/after spacing and single line
+// spacing (240 twips, auto rule). Without an explicit default, an empty
+// <w:pPr> (or a paragraph that never sets spacing) falls back to Word's own
+// defaults — 8pt after, 1.15 line spacing — instead of the 0/240 the domain
+// model assumes (constants.DefaultParagraphSpacing / DefaultLineSpacing).
 func documentDefaultParagraphProperties() *xml.ParagraphDefaults {
 	return &xml.ParagraphDefaults{
 		Properties: &xml.StyleParagraphProperties{

--- a/internal/writer/writer_test.go
+++ b/internal/writer/writer_test.go
@@ -10,7 +10,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"encoding/xml"
-	"reflect"
 	"testing"
 
 	"github.com/mmonterroca/docxgo/v2/domain"
@@ -46,7 +45,7 @@ func TestZipWriter_WriteDocument(t *testing.T) {
 		Relationships: []*xmlstructs.Relationship{},
 	}
 
-	err := zw.WriteDocument(doc, rels, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	err := zw.WriteDocument(doc, rels, nil, nil, xmlstructs.NewStyles(), nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("WriteDocument failed: %v", err)
 	}
@@ -102,7 +101,7 @@ func TestZipWriter_ContentTypes(t *testing.T) {
 		Relationships: []*xmlstructs.Relationship{},
 	}
 
-	zw.WriteDocument(doc, rels, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	zw.WriteDocument(doc, rels, nil, nil, xmlstructs.NewStyles(), nil, nil, nil, nil, nil, nil)
 	zw.Close()
 
 	// Read and verify [Content_Types].xml
@@ -168,7 +167,7 @@ func TestZipWriter_DocumentXML(t *testing.T) {
 		Relationships: []*xmlstructs.Relationship{},
 	}
 
-	zw.WriteDocument(doc, rels, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	zw.WriteDocument(doc, rels, nil, nil, xmlstructs.NewStyles(), nil, nil, nil, nil, nil, nil)
 	zw.Close()
 
 	// Read and verify word/document.xml exists
@@ -196,131 +195,16 @@ func TestZipWriter_DocumentXML(t *testing.T) {
 	}
 }
 
-// readZipFile returns the bytes of the named entry in a .docx zip buffer.
-func readZipFile(t *testing.T, buf []byte, name string) []byte {
-	t.Helper()
-	zipReader, err := zip.NewReader(bytes.NewReader(buf), int64(len(buf)))
-	if err != nil {
-		t.Fatalf("Failed to read ZIP: %v", err)
-	}
-	for _, f := range zipReader.File {
-		if f.Name != name {
-			continue
-		}
-		rc, err := f.Open()
-		if err != nil {
-			t.Fatalf("open %s: %v", name, err)
-		}
-		defer rc.Close()
-		var out bytes.Buffer
-		if _, err := out.ReadFrom(rc); err != nil {
-			t.Fatalf("read %s: %v", name, err)
-		}
-		return out.Bytes()
-	}
-	t.Fatalf("%s not found in ZIP", name)
-	return nil
-}
+// TestZipWriter_WriteStyles_NilStylesIsError pins that writeStyles requires a
+// non-nil Styles rather than silently falling back to a hand-maintained
+// default (the fallback was unreachable from any production caller and had
+// already drifted from the serializer's own defaults; see #70).
+func TestZipWriter_WriteStyles_NilStylesIsError(t *testing.T) {
+	var buf bytes.Buffer
+	zw := NewZipWriter(&buf)
 
-// pPrDefaultProperties returns every element and attribute inside the
-// <w:pPrDefault> subtree of a word/styles.xml document, keyed as
-// "element/attribute" (e.g. "spacing/before"). Decoding the subtree rather
-// than comparing raw bytes means the two producers are compared on the
-// properties they describe, not on incidental encoding differences
-// (self-closing vs paired tags, attribute order, indentation). Any property
-// present in one producer and absent in the other shows up as a key
-// difference, so this catches drift the test was written to prevent even for
-// defaults nobody thought to enumerate.
-func pPrDefaultProperties(t *testing.T, stylesXML []byte) map[string]string {
-	t.Helper()
-
-	start := bytes.Index(stylesXML, []byte("<w:pPrDefault"))
-	if start < 0 {
-		t.Fatal("no <w:pPrDefault> element found in styles.xml")
-	}
-	end := bytes.Index(stylesXML[start:], []byte("</w:pPrDefault>"))
-	if end < 0 {
-		t.Fatal("no closing </w:pPrDefault> found in styles.xml")
-	}
-	fragment := stylesXML[start : start+end+len("</w:pPrDefault>")]
-
-	props := make(map[string]string)
-	dec := xml.NewDecoder(bytes.NewReader(fragment))
-	for {
-		tok, err := dec.Token()
-		if err != nil {
-			break
-		}
-		se, ok := tok.(xml.StartElement)
-		if !ok {
-			continue
-		}
-		// Skip the wrapper elements themselves; record their contents.
-		if se.Name.Local == "pPrDefault" || se.Name.Local == "pPr" {
-			continue
-		}
-		if len(se.Attr) == 0 {
-			// A valueless element (e.g. <w:keepNext/>) is itself a property.
-			props[se.Name.Local] = ""
-			continue
-		}
-		for _, a := range se.Attr {
-			props[se.Name.Local+"/"+a.Name.Local] = a.Value
-		}
-	}
-
-	if len(props) == 0 {
-		t.Fatalf("no properties decoded from w:pPrDefault subtree: %s", fragment)
-	}
-	return props
-}
-
-// TestWriteDefaultStyles_MatchesSerializedStyleManagerDefaults pins that the
-// w:pPrDefault written by the no-style-manager fallback (writeDefaultStyles'
-// hand-written XML string) and the one written for a document that does carry
-// a style manager (DocumentSerializer.SerializeStyles' marshaled structs)
-// describe the same default paragraph properties. If they drifted, a document
-// would render with different default spacing purely depending on whether a
-// style manager happened to be attached.
-//
-// Both sides go through the real ZipWriter.WriteDocument and are read back out
-// of the resulting archive, so neither is a hand-rolled imitation that could
-// keep passing while the production paths diverge. The whole w:pPrDefault
-// subtree is compared, not a chosen list of attributes, so a default added to
-// one producer and not the other fails here rather than shipping.
-func TestWriteDefaultStyles_MatchesSerializedStyleManagerDefaults(t *testing.T) {
-	writeStylesXML := func(t *testing.T, styles *xmlstructs.Styles) []byte {
-		t.Helper()
-		var buf bytes.Buffer
-		zw := NewZipWriter(&buf)
-		doc := &xmlstructs.Document{
-			XMLnsW: constants.NamespaceMain,
-			XMLnsR: constants.NamespaceRelationships,
-			Body:   &xmlstructs.Body{},
-		}
-		rels := &xmlstructs.Relationships{Xmlns: constants.NamespacePackageRels}
-		if err := zw.WriteDocument(doc, rels, nil, nil, styles, nil, nil, nil, nil, nil, nil); err != nil {
-			t.Fatalf("WriteDocument: %v", err)
-		}
-		if err := zw.Close(); err != nil {
-			t.Fatalf("Close: %v", err)
-		}
-		return readZipFile(t, buf.Bytes(), "word/styles.xml")
-	}
-
-	// Path A: nil styles -> writeDefaultStyles' raw XML fallback.
-	stylesA := writeStylesXML(t, nil)
-
-	// Path B: a real style manager -> SerializeStyles' marshaled structs.
-	sm := manager.NewStyleManager()
-	stylesB := writeStylesXML(t, serializer.NewDocumentSerializer().SerializeStyles(sm, nil))
-
-	defaultsA := pPrDefaultProperties(t, stylesA)
-	defaultsB := pPrDefaultProperties(t, stylesB)
-
-	if !reflect.DeepEqual(defaultsA, defaultsB) {
-		t.Errorf("w:pPrDefault differs between the two styles.xml producers:\n  no-style-manager  = %+v\n  with-style-manager= %+v",
-			defaultsA, defaultsB)
+	if err := zw.writeStyles(nil); err == nil {
+		t.Fatal("expected an error for nil styles, got nil")
 	}
 }
 

--- a/internal/writer/zip.go
+++ b/internal/writer/zip.go
@@ -442,32 +442,13 @@ func (zw *ZipWriter) writeAppProperties(props *xmlstructs.AppProperties) error {
 	return zw.writeXML("docProps/app.xml", props)
 }
 
-// writeDefaultStyles writes minimal word/styles.xml
-func (zw *ZipWriter) writeDefaultStyles() error {
-	styles := `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
-  <w:docDefaults>
-    <w:rPrDefault>
-      <w:rPr>
-        <w:rFonts w:ascii="Calibri" w:hAnsi="Calibri"/>
-        <w:sz w:val="22"/>
-      </w:rPr>
-    </w:rPrDefault>
-    <w:pPrDefault>
-      <w:pPr>
-        <w:spacing w:before="0" w:after="0" w:line="240" w:lineRule="auto"/>
-      </w:pPr>
-    </w:pPrDefault>
-  </w:docDefaults>
-</w:styles>`
-	return zw.writeRaw("word/styles.xml", []byte(styles))
-}
-
-// writeStyles writes word/styles.xml from serialized styles.
+// writeStyles writes word/styles.xml from serialized styles. styles must be
+// non-nil: the only production caller (internal/core/document.go) always
+// passes serializer.SerializeStyles's result, which is never nil, so a nil
+// here indicates a caller bug rather than a case to degrade gracefully for.
 func (zw *ZipWriter) writeStyles(styles *xmlstructs.Styles) error {
-	// If no styles provided, use defaults
 	if styles == nil {
-		return zw.writeDefaultStyles()
+		return fmt.Errorf("writer: writeStyles: styles must not be nil")
 	}
 
 	w, err := zw.zipWriter.Create("word/styles.xml")


### PR DESCRIPTION
## Summary

`ZipWriter.writeDefaultStyles` wrote a hand-maintained raw `word/styles.xml` string, reached only when `writeStyles` got a `nil *Styles`. The only production caller (`internal/core/document.go`) always passes `ser.SerializeStyles(...)`, which never returns nil — so the fallback only ever ran from tests calling `WriteDocument(..., nil, ...)` directly, never from a real generated document.

It was a second, independent source of truth for default paragraph properties that had to be kept in sync by hand with `SerializeStyles`. #67 already had to update both copies for the new `w:pPrDefault` and add a cross-path drift test asserting they agreed — real maintenance cost for a path with no production consumer. That test (`TestWriteDefaultStyles_MatchesSerializedStyleManagerDefaults`) and its `pPrDefaultProperties`/`readZipFile` helpers are removed along with what they were guarding.

`writeStyles` now returns an error on nil `styles` instead of silently falling back, making the invariant explicit (option 1 from the issue).

Fixes #70

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l ./cmd ./pkg ./internal ./domain ./themes`
- [x] `go test ./...` — all packages pass
- [x] `cd examples && ./test_all.sh` — 10/10
- [x] New `TestZipWriter_WriteStyles_NilStylesIsError` confirms the new error path