### PR TITLE
fix: FindPlaceholders no longer mutates the document it scans

### DIFF
--- a/examples/14_mail_merge/main.go
+++ b/examples/14_mail_merge/main.go
@@ -71,8 +71,6 @@ func main() {
 		"grand_total":     "$9,072.00",
 	}
 
-	// Re-open for validation (FindPlaceholders modifies runs via consolidation)
-	doc, _ = docx.OpenDocument(templatePath)
 	validationErrors := template.ValidateTemplate(doc, data)
 	if len(validationErrors) == 0 {
 		fmt.Println("  All placeholders have matching data keys!")

--- a/pkg/template/consolidate.go
+++ b/pkg/template/consolidate.go
@@ -17,6 +17,47 @@ func consolidateErr(err error) error {
 	return fmt.Errorf("template: consolidate runs: %w", err)
 }
 
+// runGroup is a maximal sequence of adjacent text-only runs with identical
+// formatting, over the original run indices of a paragraph. leader is the
+// index of the first run in the group; count is how many runs, starting at
+// leader, belong to it. text is their concatenated content.
+type runGroup struct {
+	text   string
+	leader int
+	count  int
+}
+
+// runGroups partitions a paragraph's runs into runGroups. It is the single
+// definition of "which adjacent runs represent one logical span of text",
+// shared by ConsolidateRuns (which merges each group in place) and the
+// placeholder scanner (which reads across a group without merging it) so the
+// two can never drift on what counts as mergeable.
+func runGroups(runs []domain.Run) []runGroup {
+	if len(runs) == 0 {
+		return nil
+	}
+
+	groups := make([]runGroup, 0, len(runs))
+	groups = append(groups, runGroup{text: runs[0].Text(), leader: 0, count: 1})
+
+	for i := 1; i < len(runs); i++ {
+		prev := runs[i-1]
+		curr := runs[i]
+
+		// Merge if both are text-only and have identical formatting
+		if isTextOnly(prev) && isTextOnly(curr) && formatsEqual(prev, curr) {
+			// Absorb this run's text into the current group
+			groups[len(groups)-1].text += curr.Text()
+			groups[len(groups)-1].count++
+		} else {
+			// Start a new group
+			groups = append(groups, runGroup{text: curr.Text(), leader: i, count: 1})
+		}
+	}
+
+	return groups
+}
+
 // ConsolidateRuns merges adjacent runs with identical formatting in a paragraph.
 // This heals the "split placeholder" problem where Word fragments tokens like
 // {{name}} across multiple <w:r> elements due to spell-check, proofing, or
@@ -34,39 +75,16 @@ func consolidateErr(err error) error {
 // mutation fails partway through, it stops immediately and returns that error
 // rather than silently continuing with a partially consolidated paragraph.
 //
-// It is called automatically by MergeTemplate and FindPlaceholders.
+// It is called automatically by MergeTemplate, where merging split
+// placeholders across runs is necessary to replace them. FindPlaceholders
+// scans for split placeholders without calling this — see runGroups.
 func ConsolidateRuns(para domain.Paragraph) error {
 	runs := para.Runs()
 	if len(runs) <= 1 {
 		return nil
 	}
 
-	// Build merge groups over the original run indices. Each group is a
-	// sequence of adjacent text-only runs with identical formatting; leader is
-	// the index of the run that survives and receives the combined text.
-	type mergeGroup struct {
-		text   string
-		leader int
-		count  int
-	}
-
-	groups := make([]mergeGroup, 0, len(runs))
-	groups = append(groups, mergeGroup{text: runs[0].Text(), leader: 0, count: 1})
-
-	for i := 1; i < len(runs); i++ {
-		prev := runs[i-1]
-		curr := runs[i]
-
-		// Merge if both are text-only and have identical formatting
-		if isTextOnly(prev) && isTextOnly(curr) && formatsEqual(prev, curr) {
-			// Absorb this run's text into the current group
-			groups[len(groups)-1].text += curr.Text()
-			groups[len(groups)-1].count++
-		} else {
-			// Start a new group
-			groups = append(groups, mergeGroup{text: curr.Text(), leader: i, count: 1})
-		}
-	}
+	groups := runGroups(runs)
 
 	// If nothing was merged, there is nothing to rewrite.
 	if len(groups) == len(runs) {

--- a/pkg/template/consolidate_test.go
+++ b/pkg/template/consolidate_test.go
@@ -403,9 +403,9 @@ func TestMergeTemplate_PreservesImage(t *testing.T) {
 }
 
 func TestFindPlaceholders_PreservesImage(t *testing.T) {
-	// FindPlaceholders is read-only from the caller's perspective, but it
-	// consolidates runs internally to find placeholders split across them.
-	// That consolidation must not mutate away an unrelated image.
+	// FindPlaceholders is read-only: it must not mutate the paragraph at all
+	// (see #68), so an unrelated image is untouched by construction, not by
+	// surviving a consolidation the read-only path used to perform.
 	doc := core.NewDocument()
 	para, _ := doc.AddParagraph()
 
@@ -417,6 +417,7 @@ func TestFindPlaceholders_PreservesImage(t *testing.T) {
 	if _, err := para.AddImage(createTestPNG(t)); err != nil {
 		t.Fatalf("AddImage: %v", err)
 	}
+	runsBefore := len(para.Runs())
 
 	placeholders := FindPlaceholders(doc)
 	if len(placeholders) != 1 {
@@ -425,6 +426,121 @@ func TestFindPlaceholders_PreservesImage(t *testing.T) {
 
 	if got := countImageRuns(para); got != 1 {
 		t.Errorf("image run lost via FindPlaceholders: got %d image runs, want 1", got)
+	}
+	if got := len(para.Runs()); got != runsBefore {
+		t.Errorf("FindPlaceholders mutated run count: got %d runs, want %d (unchanged)", got, runsBefore)
+	}
+}
+
+// TestFindPlaceholders_DoesNotMergeRuns pins that scanning for placeholders
+// never rewrites the paragraph's runs, even when it finds one split across
+// several of them — the mutation ConsolidateRuns performs is reserved for
+// MergeTemplate, which actually needs the merge to write replacement text.
+func TestFindPlaceholders_DoesNotMergeRuns(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+
+	r1, _ := para.AddRun()
+	r1.SetText("Hello {{")
+	r2, _ := para.AddRun()
+	r2.SetText("Name")
+	r3, _ := para.AddRun()
+	r3.SetText("}}!")
+
+	placeholders := FindPlaceholders(doc)
+	if len(placeholders) != 1 {
+		t.Fatalf("expected 1 placeholder, got %d", len(placeholders))
+	}
+	if placeholders[0].Name != "Name" {
+		t.Errorf("expected 'Name', got %q", placeholders[0].Name)
+	}
+
+	if got := len(para.Runs()); got != 3 {
+		t.Fatalf("FindPlaceholders merged runs: got %d runs, want 3 (unchanged)", got)
+	}
+	if got := para.Runs()[0].Text(); got != "Hello {{" {
+		t.Errorf("run 0 text changed: got %q, want %q", got, "Hello {{")
+	}
+	if got := para.Runs()[1].Text(); got != "Name" {
+		t.Errorf("run 1 text changed: got %q, want %q", got, "Name")
+	}
+	if got := para.Runs()[2].Text(); got != "}}!" {
+		t.Errorf("run 2 text changed: got %q, want %q", got, "}}!")
+	}
+}
+
+// TestFindPlaceholders_LocationAcrossSplitRuns pins the Location reported for
+// a placeholder split across runs: RunIndex/StartOffset point at the run and
+// offset where the match starts, EndRunIndex/EndOffset at where it ends, both
+// relative to the paragraph's own unmodified runs.
+func TestFindPlaceholders_LocationAcrossSplitRuns(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+
+	r1, _ := para.AddRun()
+	r1.SetText("Hello {{") // 8 chars, "{{" at offset 6-8
+	r2, _ := para.AddRun()
+	r2.SetText("Name") // 4 chars
+	r3, _ := para.AddRun()
+	r3.SetText("}}!") // "}}" at offset 0-2
+
+	placeholders := FindPlaceholders(doc)
+	if len(placeholders) != 1 {
+		t.Fatalf("expected 1 placeholder, got %d", len(placeholders))
+	}
+
+	loc := placeholders[0].Location
+	if loc.RunIndex != 0 || loc.StartOffset != 6 {
+		t.Errorf("start = (run %d, offset %d), want (run 0, offset 6)", loc.RunIndex, loc.StartOffset)
+	}
+	if loc.EndRunIndex != 2 || loc.EndOffset != 2 {
+		t.Errorf("end = (run %d, offset %d), want (run 2, offset 2)", loc.EndRunIndex, loc.EndOffset)
+	}
+}
+
+// TestFindPlaceholders_HeaderNotMutated confirms the read-only guarantee also
+// holds for header paragraphs, where logos live alongside mergeable text runs.
+func TestFindPlaceholders_HeaderNotMutated(t *testing.T) {
+	doc := core.NewDocument()
+	if _, err := doc.AddSection(); err != nil {
+		t.Fatalf("AddSection: %v", err)
+	}
+	section := doc.Sections()[0]
+	header, err := section.Header(domain.HeaderDefault)
+	if err != nil {
+		t.Fatalf("Header: %v", err)
+	}
+	para, _ := header.AddParagraph()
+
+	r1, _ := para.AddRun()
+	r1.SetText("Hello {{")
+	r2, _ := para.AddRun()
+	r2.SetText("Name}}")
+
+	placeholders := FindPlaceholders(doc)
+	if len(placeholders) != 1 {
+		t.Fatalf("expected 1 placeholder, got %d", len(placeholders))
+	}
+	if got := len(para.Runs()); got != 2 {
+		t.Errorf("FindPlaceholders merged header runs: got %d runs, want 2 (unchanged)", got)
+	}
+}
+
+// TestValidateTemplate_DoesNotMutate confirms ValidateTemplate, which scans
+// via FindPlaceholders internally, does not merge runs either.
+func TestValidateTemplate_DoesNotMutate(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+
+	r1, _ := para.AddRun()
+	r1.SetText("Hello {{")
+	r2, _ := para.AddRun()
+	r2.SetText("Name}}")
+
+	_ = ValidateTemplate(doc, MergeData{"Name": "World"})
+
+	if got := len(para.Runs()); got != 2 {
+		t.Errorf("ValidateTemplate merged runs: got %d runs, want 2 (unchanged)", got)
 	}
 }
 

--- a/pkg/template/placeholder.go
+++ b/pkg/template/placeholder.go
@@ -32,11 +32,18 @@ type Location struct {
 	Type LocationType
 	// ParagraphIndex is the paragraph index within its container.
 	ParagraphIndex int
-	// RunIndex is the run index within the paragraph.
+	// RunIndex is the index of the run containing the start of the
+	// placeholder, in the paragraph's own (unmodified) run list.
 	RunIndex int
-	// StartOffset is the byte offset of the placeholder start within the run text.
+	// EndRunIndex is the index of the run containing the end of the
+	// placeholder. Equal to RunIndex unless Word split the placeholder across
+	// multiple runs, in which case it is the last run the match spans.
+	EndRunIndex int
+	// StartOffset is the byte offset of the placeholder start within the run
+	// at RunIndex.
 	StartOffset int
-	// EndOffset is the byte offset after the placeholder end within the run text.
+	// EndOffset is the byte offset after the placeholder end within the run
+	// at EndRunIndex.
 	EndOffset int
 	// TableIndex, RowIndex, CellIndex are set when Type == LocationTableCell.
 	TableIndex int
@@ -63,8 +70,12 @@ type Placeholder struct {
 // defaultPattern matches {{key}} where key is one or more word characters or dots.
 var defaultPattern = regexp.MustCompile(`\{\{\.?(\w+(?:\.\w+)*)\}\}`)
 
-// FindPlaceholders scans the entire document and returns all placeholder occurrences.
-// It consolidates runs in each paragraph before scanning to heal split placeholders.
+// FindPlaceholders scans the entire document and returns all placeholder
+// occurrences. It does not modify the document: placeholders that Word split
+// across multiple runs are found by scanning across the run group they would
+// merge into (see runGroups), without actually merging it. Use MergeTemplate
+// to replace placeholders, which does merge split runs since that is
+// necessary to write the replacement text.
 func FindPlaceholders(doc domain.Document) []Placeholder {
 	return findPlaceholdersWithPattern(doc, defaultPattern)
 }
@@ -79,15 +90,6 @@ func findPlaceholdersWithPattern(doc domain.Document, pattern *regexp.Regexp) []
 	var results []Placeholder
 
 	_ = walkParagraphs(doc, func(para domain.Paragraph, ctx paragraphContext) error {
-		// Consolidate runs to heal split placeholders. FindPlaceholders /
-		// FindPlaceholdersCustom don't return an error, and this is a
-		// read-only scan, so consolidation is best-effort: a rare failure just
-		// means this paragraph is scanned without healing (possibly missing a
-		// split placeholder) rather than aborting the whole scan and returning
-		// a truncated list. The mutating path (MergeTemplate) propagates the
-		// error instead.
-		_ = ConsolidateRuns(para)
-
 		found := scanParagraph(para, pattern, ctx)
 		results = append(results, found...)
 		return nil
@@ -96,14 +98,25 @@ func findPlaceholdersWithPattern(doc domain.Document, pattern *regexp.Regexp) []
 	return results
 }
 
-// scanParagraph searches all runs in a paragraph for placeholders.
+// scanParagraph searches a paragraph for placeholders without mutating it.
+// It groups runs the same way ConsolidateRuns would (see runGroups) so a
+// placeholder split across several runs by Word is still found, then matches
+// against each group's concatenated text and translates offsets back to the
+// paragraph's actual, unmodified runs.
 func scanParagraph(para domain.Paragraph, pattern *regexp.Regexp, ctx paragraphContext) []Placeholder {
 	var results []Placeholder
 	runs := para.Runs()
 
-	for ri, run := range runs {
-		text := run.Text()
-		matches := pattern.FindAllStringSubmatchIndex(text, -1)
+	for _, g := range runGroups(runs) {
+		matches := pattern.FindAllStringSubmatchIndex(g.text, -1)
+		if len(matches) == 0 {
+			continue
+		}
+
+		runLens := make([]int, g.count)
+		for i := 0; i < g.count; i++ {
+			runLens[i] = len(runs[g.leader+i].Text())
+		}
 
 		for _, match := range matches {
 			// Ensure there is at least one capturing group before indexing.
@@ -112,15 +125,19 @@ func scanParagraph(para domain.Paragraph, pattern *regexp.Regexp, ctx paragraphC
 				continue
 			}
 			// match[0:2] is full match, match[2:4] is first capture group
-			fullMatch := text[match[0]:match[1]]
-			name := text[match[2]:match[3]]
+			fullMatch := g.text[match[0]:match[1]]
+			name := g.text[match[2]:match[3]]
+
+			startRun, startOffset := locateGroupOffset(g.leader, runLens, match[0])
+			endRun, endOffset := locateGroupOffset(g.leader, runLens, match[1])
 
 			loc := Location{
 				Type:           ctx.locationType,
 				ParagraphIndex: ctx.paraIdx,
-				RunIndex:       ri,
-				StartOffset:    match[0],
-				EndOffset:      match[1],
+				RunIndex:       startRun,
+				EndRunIndex:    endRun,
+				StartOffset:    startOffset,
+				EndOffset:      endOffset,
 				TableIndex:     ctx.tableIdx,
 				RowIndex:       ctx.rowIdx,
 				CellIndex:      ctx.cellIdx,
@@ -138,6 +155,21 @@ func scanParagraph(para domain.Paragraph, pattern *regexp.Regexp, ctx paragraphC
 	}
 
 	return results
+}
+
+// locateGroupOffset translates a byte offset into a run group's concatenated
+// text back to the index (relative to the paragraph's own runs) and local
+// offset of the run that contains it. An offset at or beyond the end of the
+// group's text resolves to the end of its last run.
+func locateGroupOffset(leader int, runLens []int, offset int) (runIndex, runOffset int) {
+	for i, l := range runLens {
+		if offset <= l {
+			return leader + i, offset
+		}
+		offset -= l
+	}
+	last := len(runLens) - 1
+	return leader + last, runLens[last]
 }
 
 // PlaceholderNames returns the deduplicated set of placeholder names found in the document.


### PR DESCRIPTION
## Summary

`FindPlaceholders` / `FindPlaceholdersCustom` / `PlaceholderNames` / `ValidateTemplate` all read as pure queries — none return an error, none hint at taking a mutable-thing. But internally, every one of them called `ConsolidateRuns` on each paragraph to heal placeholders Word split across `<w:r>` elements. #66 removed the worst consequence of that mutation (it used to silently drop images); this removes the mutation itself.

- `pkg/template/consolidate.go`: extracted the run-grouping logic `ConsolidateRuns` already computed into a shared `runGroups` helper. `ConsolidateRuns` now consumes it without behavior change; the placeholder scanner consumes the same one, so the two definitions of "which adjacent runs form one logical span of text" can't drift apart.
- `pkg/template/placeholder.go`: `findPlaceholdersWithPattern` no longer calls `ConsolidateRuns`. `scanParagraph` matches the regex against each group's concatenated *virtual* text (still healing split placeholders) and translates match offsets back to the paragraph's real, unmodified runs via `locateGroupOffset`.
- `Location` gains `EndRunIndex` — a match spanning multiple runs now reports where it ends, not just where it starts. `RunIndex`/`StartOffset` point at the run and offset the paragraph actually has, not a post-consolidation run that no longer exists in the document. No non-test caller of these fields exists in this repo (`cmd/docxgo`, `npm/`), so this is a compatible addition.
- `MergeTemplate` is unaffected and keeps consolidating — there the merge is necessary to write replacement text into one run.
- Removed our own workaround at `examples/14_mail_merge/main.go` (`// Re-open for validation (FindPlaceholders modifies runs via consolidation)`) — the re-open is no longer needed, which is itself a proof the fix landed.

Fixes #68

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l ...`
- [x] `go test ./...` — all packages pass
- [x] `cd examples && ./test_all.sh` — 10/10, plus manually ran `examples/14_mail_merge` end to end
- [x] New regression tests confirmed to fail without the fix (temporarily reintroduced the `ConsolidateRuns` call and watched `TestFindPlaceholders_DoesNotMergeRuns` etc. fail) before reverting:
  - `TestFindPlaceholders_DoesNotMergeRuns` — run count/text unchanged after a scan that finds a split placeholder
  - `TestFindPlaceholders_LocationAcrossSplitRuns` — `RunIndex`/`StartOffset`/`EndRunIndex`/`EndOffset` point at the real runs
  - `TestFindPlaceholders_HeaderNotMutated` — same guarantee in headers, where logos live
  - `TestValidateTemplate_DoesNotMutate`
  - `TestFindPlaceholders_PreservesImage` strengthened to also assert run count is unchanged