### PR TITLE
fix: honor an explicit zero spacing on a styled paragraph

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -10,6 +10,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"io"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -1591,4 +1592,146 @@ func removeZipEntry(t *testing.T, data []byte, name string) []byte {
 		t.Fatalf("failed to finalize ZIP: %v", err)
 	}
 	return out.Bytes()
+}
+
+// headingParagraphXML returns the <w:p>...</w:p> fragment of the first
+// paragraph in document.xml carrying the Heading1 style, for tests that need
+// to inspect a specific paragraph's direct formatting rather than the whole
+// document.
+func headingParagraphXML(t *testing.T, doc domain.Document) string {
+	t.Helper()
+	docXML := readZipPart(t, doc, "word/document.xml")
+
+	paraPattern := regexp.MustCompile(`(?s)<w:p[ >].*?</w:p>`)
+	for _, p := range paraPattern.FindAllString(docXML, -1) {
+		if strings.Contains(p, `w:val="Heading1"`) {
+			return p
+		}
+	}
+	t.Fatal("no Heading1 paragraph found in word/document.xml")
+	return ""
+}
+
+// TestBuilder_HeadingParagraphNoDirectSpacing guards against the #63
+// regression class through the full public pipeline (NewDocumentBuilder ->
+// Build -> WriteTo -> real ZIP), not just the internal serializer unit test:
+// a Heading1 paragraph that never sets its own spacing must not carry direct
+// <w:spacing>, so it inherits the style's own value instead of docDefaults'
+// 0/0.
+func TestBuilder_HeadingParagraphNoDirectSpacing(t *testing.T) {
+	builder := NewDocumentBuilder()
+	builder.AddParagraph().Text("Intro").End()
+
+	doc, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	heading, err := doc.AddParagraph()
+	if err != nil {
+		t.Fatalf("AddParagraph: %v", err)
+	}
+	if err := heading.SetStyle(domain.StyleIDHeading1); err != nil {
+		t.Fatalf("SetStyle: %v", err)
+	}
+	if _, err := heading.AddRun(); err != nil {
+		t.Fatalf("AddRun: %v", err)
+	}
+
+	fragment := headingParagraphXML(t, doc)
+	if strings.Contains(fragment, "<w:spacing") {
+		t.Errorf("expected no direct w:spacing on a Heading1 paragraph that didn't set its own, got: %s", fragment)
+	}
+}
+
+// TestBuilder_ExplicitZeroSpacingOnHeadingIsHonored is the positive
+// counterpart: once the paragraph explicitly asks for SetSpacingAfter(0), it
+// must appear in the generated document.xml, overriding the Heading1 style.
+func TestBuilder_ExplicitZeroSpacingOnHeadingIsHonored(t *testing.T) {
+	builder := NewDocumentBuilder()
+	builder.AddParagraph().Text("Intro").End()
+
+	doc, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	heading, err := doc.AddParagraph()
+	if err != nil {
+		t.Fatalf("AddParagraph: %v", err)
+	}
+	if err := heading.SetStyle(domain.StyleIDHeading1); err != nil {
+		t.Fatalf("SetStyle: %v", err)
+	}
+	if err := heading.SetSpacingAfter(0); err != nil {
+		t.Fatalf("SetSpacingAfter: %v", err)
+	}
+	if _, err := heading.AddRun(); err != nil {
+		t.Fatalf("AddRun: %v", err)
+	}
+
+	fragment := headingParagraphXML(t, doc)
+	if !strings.Contains(fragment, `w:after="0"`) {
+		t.Errorf(`expected w:after="0" on a Heading1 paragraph with an explicit SetSpacingAfter(0), got: %s`, fragment)
+	}
+}
+
+// TestOpenDocument_RoundTripsExplicitZeroSpacing confirms an explicit
+// SetSpacingAfter(0) on a styled paragraph survives a full open+resave round
+// trip: the reader (internal/reader/reconstruct.go) only calls SetSpacingAfter
+// when the source XML actually carries a w:after attribute, so re-opening and
+// re-saving must set the tracking flag again rather than losing it.
+func TestOpenDocument_RoundTripsExplicitZeroSpacing(t *testing.T) {
+	builder := NewDocumentBuilder()
+	builder.AddParagraph().Text("Intro").End()
+
+	doc, err := builder.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	heading, err := doc.AddParagraph()
+	if err != nil {
+		t.Fatalf("AddParagraph: %v", err)
+	}
+	if err := heading.SetStyle(domain.StyleIDHeading1); err != nil {
+		t.Fatalf("SetStyle: %v", err)
+	}
+	if err := heading.SetSpacingAfter(0); err != nil {
+		t.Fatalf("SetSpacingAfter: %v", err)
+	}
+	if _, err := heading.AddRun(); err != nil {
+		t.Fatalf("AddRun: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo failed: %v", err)
+	}
+
+	reopened, err := OpenDocumentFromBytes(buf.Bytes())
+	if err != nil {
+		t.Fatalf("OpenDocumentFromBytes failed: %v", err)
+	}
+
+	var resaved bytes.Buffer
+	if _, err := reopened.WriteTo(&resaved); err != nil {
+		t.Fatalf("WriteTo (resave) failed: %v", err)
+	}
+
+	docXML := string(zipPart(t, resaved.Bytes(), "word/document.xml"))
+	paraPattern := regexp.MustCompile(`(?s)<w:p[ >].*?</w:p>`)
+	var fragment string
+	for _, p := range paraPattern.FindAllString(docXML, -1) {
+		if strings.Contains(p, `w:val="Heading1"`) {
+			fragment = p
+			break
+		}
+	}
+	if fragment == "" {
+		t.Fatal("no Heading1 paragraph found after round trip")
+	}
+	if !strings.Contains(fragment, `w:after="0"`) {
+		t.Errorf(`expected w:after="0" to survive an open+resave round trip, got: %s`, fragment)
+	}
 }

--- a/cmd/docxgo/handlers.go
+++ b/cmd/docxgo/handlers.go
@@ -343,8 +343,8 @@ type paragraphItem struct {
 	Runs          []runItem       `json:"runs,omitempty"`
 	Style         string          `json:"style,omitempty"`
 	Alignment     string          `json:"alignment,omitempty"`
-	SpacingBefore int             `json:"spacingBefore,omitempty"`
-	SpacingAfter  int             `json:"spacingAfter,omitempty"`
+	SpacingBefore *int            `json:"spacingBefore,omitempty"`
+	SpacingAfter  *int            `json:"spacingAfter,omitempty"`
 	LineSpacing   *lineSpacingDef `json:"lineSpacing,omitempty"`
 	Indent        *indentDef      `json:"indent,omitempty"`
 	Numbering     *numberingDef   `json:"numbering,omitempty"`
@@ -1446,11 +1446,11 @@ func applyParagraph(para domain.Paragraph, item paragraphItem) error {
 			_ = para.SetAlignment(align)
 		}
 	}
-	if item.SpacingBefore > 0 {
-		_ = para.SetSpacingBefore(item.SpacingBefore)
+	if item.SpacingBefore != nil {
+		_ = para.SetSpacingBefore(*item.SpacingBefore)
 	}
-	if item.SpacingAfter > 0 {
-		_ = para.SetSpacingAfter(item.SpacingAfter)
+	if item.SpacingAfter != nil {
+		_ = para.SetSpacingAfter(*item.SpacingAfter)
 	}
 	if item.LineSpacing != nil {
 		_ = para.SetLineSpacing(parseLineSpacing(item.LineSpacing))

--- a/cmd/docxgo/handlers_test.go
+++ b/cmd/docxgo/handlers_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"archive/zip"
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
@@ -1104,6 +1105,76 @@ func TestHandleParagraphAdd_WithFormatting(t *testing.T) {
 	}))
 	if resp.Error != nil {
 		t.Fatalf("paragraph.add with formatting failed: %+v", resp.Error)
+	}
+}
+
+// TestHandleParagraphAdd_ExplicitZeroSpacingOnStyledParagraph guards #69
+// through the actual RPC surface: spacingAfter/spacingBefore became *int so a
+// JSON "spacingAfter": 0 can be told apart from omitting the field entirely.
+// Before that change, applyParagraph's `> 0` guard treated an explicit 0
+// exactly like "not provided" and the paragraph silently kept its Heading1
+// style's own spacing instead.
+func TestHandleParagraphAdd_ExplicitZeroSpacingOnStyledParagraph(t *testing.T) {
+	s := newServer()
+
+	createResp := s.dispatch(makeRequest(1, "document.create", map[string]interface{}{
+		"output": "buffer",
+	}))
+	docID := createResp.Result.(map[string]interface{})["documentId"].(string)
+
+	addResp := s.dispatch(makeRequest(2, "paragraph.add", map[string]interface{}{
+		"documentId":   docID,
+		"style":        "Heading1",
+		"spacingAfter": 0,
+		"runs": []interface{}{
+			map[string]interface{}{"text": "Heading"},
+		},
+	}))
+	if addResp.Error != nil {
+		t.Fatalf("paragraph.add failed: %+v", addResp.Error)
+	}
+
+	saveResp := s.dispatch(makeRequest(3, "document.save", map[string]interface{}{
+		"documentId": docID,
+		"output":     "buffer",
+	}))
+	if saveResp.Error != nil {
+		t.Fatalf("document.save failed: %+v", saveResp.Error)
+	}
+
+	result := saveResp.Result.(map[string]interface{})
+	dataStr, _ := result["data"].(string)
+	docxBytes, err := base64.StdEncoding.DecodeString(dataStr)
+	if err != nil {
+		t.Fatalf("failed to decode base64: %v", err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(docxBytes), int64(len(docxBytes)))
+	if err != nil {
+		t.Fatalf("failed to read docx as zip: %v", err)
+	}
+	var docXML []byte
+	for _, f := range zr.File {
+		if f.Name != "word/document.xml" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("failed to open document.xml: %v", err)
+		}
+		defer rc.Close()
+		var buf bytes.Buffer
+		if _, err := buf.ReadFrom(rc); err != nil {
+			t.Fatalf("failed to read document.xml: %v", err)
+		}
+		docXML = buf.Bytes()
+	}
+	if docXML == nil {
+		t.Fatal("word/document.xml not found in saved docx")
+	}
+
+	if !strings.Contains(string(docXML), `w:after="0"`) {
+		t.Errorf(`expected w:after="0" for an explicit spacingAfter:0 on a Heading1 paragraph, got: %s`, docXML)
 	}
 }
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -650,8 +650,8 @@ Adds a single paragraph to an existing document. Supports the same paragraph pro
 | `documentId` | String | Yes | Session document ID |
 | `style` | String | No | Paragraph style name |
 | `alignment` | String | No | `left`, `center`, `right`, `justify`, `distribute` |
-| `spacingBefore` | Number | No | Spacing before (twips) |
-| `spacingAfter` | Number | No | Spacing after (twips) |
+| `spacingBefore` | Number | No | Spacing before (twips). Omit to leave unset; `0` is honored as an explicit override, including over a style's own spacing |
+| `spacingAfter` | Number | No | Spacing after (twips). Omit to leave unset; `0` is honored as an explicit override, including over a style's own spacing |
 | `lineSpacing` | Object | No | `{ "rule": "auto", "value": 360 }` |
 | `indent` | Object | No | `{ "left", "right", "firstLine", "hanging" }` |
 | `numbering` | Object | No | `{ "id": 1, "level": 0 }` |

--- a/internal/core/paragraph.go
+++ b/internal/core/paragraph.go
@@ -37,13 +37,24 @@ type paragraph struct {
 	spacingBefore int
 	spacingAfter  int
 	lineSpacing   domain.LineSpacing
-	numbering     *domain.NumberingReference
-	borders       domain.ParagraphBorders
-	idGen         IDGenerator
-	relManager    *manager.RelationshipManager
-	bookmarkID    string // ID for bookmark (if this paragraph needs one for TOC)
-	bookmarkName  string // Name for bookmark (e.g., "_Toc123456")
-	mediaManager  *manager.MediaManager
+	// *Set track whether the caller ever called the corresponding setter, so
+	// the serializer can tell "never set" from "explicitly set to a value
+	// that happens to equal the default" — most importantly, an explicit 0
+	// on a paragraph whose style supplies a non-zero spacing. The domain
+	// getters (SpacingBefore, SpacingAfter, LineSpacing) can't express this
+	// distinction themselves without changing their public return types, so
+	// it's exposed on the concrete type only, the same pattern StyleName()
+	// uses for the serializer's style-name access.
+	spacingBeforeSet bool
+	spacingAfterSet  bool
+	lineSpacingSet   bool
+	numbering        *domain.NumberingReference
+	borders          domain.ParagraphBorders
+	idGen            IDGenerator
+	relManager       *manager.RelationshipManager
+	bookmarkID       string // ID for bookmark (if this paragraph needs one for TOC)
+	bookmarkName     string // Name for bookmark (e.g., "_Toc123456")
+	mediaManager     *manager.MediaManager
 }
 
 // NewParagraph creates a new Paragraph.
@@ -428,7 +439,14 @@ func (p *paragraph) SetSpacingBefore(twips int) error {
 			"spacing must be between 0 and 31680 twips (0 to 22 inches)")
 	}
 	p.spacingBefore = twips
+	p.spacingBeforeSet = true
 	return nil
+}
+
+// SpacingBeforeSet reports whether SetSpacingBefore was ever called, so the
+// serializer can distinguish an explicit 0 from a value that was never set.
+func (p *paragraph) SpacingBeforeSet() bool {
+	return p.spacingBeforeSet
 }
 
 // SpacingAfter returns spacing after the paragraph (in twips).
@@ -443,7 +461,14 @@ func (p *paragraph) SetSpacingAfter(twips int) error {
 			"spacing must be between 0 and 31680 twips (0 to 22 inches)")
 	}
 	p.spacingAfter = twips
+	p.spacingAfterSet = true
 	return nil
+}
+
+// SpacingAfterSet reports whether SetSpacingAfter was ever called, so the
+// serializer can distinguish an explicit 0 from a value that was never set.
+func (p *paragraph) SpacingAfterSet() bool {
+	return p.spacingAfterSet
 }
 
 // LineSpacing returns the line spacing setting.
@@ -462,7 +487,15 @@ func (p *paragraph) SetLineSpacing(spacing domain.LineSpacing) error {
 			"line spacing value must be between 0 and 31680 twips")
 	}
 	p.lineSpacing = spacing
+	p.lineSpacingSet = true
 	return nil
+}
+
+// LineSpacingSet reports whether SetLineSpacing was ever called, so the
+// serializer can distinguish an explicit auto/240 (the default values) from
+// line spacing that was never set at all.
+func (p *paragraph) LineSpacingSet() bool {
+	return p.lineSpacingSet
 }
 
 // Numbering returns the numbering reference applied to the paragraph, if any.

--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -542,20 +542,27 @@ func (s *ParagraphSerializer) serializeProperties(para domain.Paragraph) *xml.Pa
 	before := para.SpacingBefore()
 	after := para.SpacingAfter()
 	lineSpacing := para.LineSpacing()
+	beforeSet, afterSet, lineSet := spacingSetFlags(para)
 
-	// Emit direct spacing only when the paragraph actually departs from the
-	// document defaults, so that a paragraph at those defaults inherits from
-	// its style rather than overriding it. The rule matters as much as the
-	// value here: an exact or at-least rule is a departure even at the
-	// default 240 twips, and without this check it would silently inherit the
+	// Emit direct spacing when the paragraph departs from the document
+	// defaults, OR when the caller explicitly set a value — even one that
+	// happens to equal a default, like SetSpacingAfter(0) on a paragraph
+	// whose style supplies non-zero spacing. Paragraph.SpacingBefore() int
+	// can't distinguish "never set" from "explicitly set to 0" on its own;
+	// beforeSet/afterSet/lineSet come from the concrete type's *Set() methods
+	// (see spacingSetFlags) and degrade to false for any domain.Paragraph
+	// implementation that doesn't expose them, falling back to the
+	// zero-value gate below. The rule matters as much as the value for line
+	// spacing: an exact or at-least rule is a departure even at the default
+	// 240 twips, and without this check it would silently inherit the
 	// lineRule="auto" written into w:pPrDefault.
-	if before != 0 || after != 0 ||
+	if before != 0 || after != 0 || beforeSet || afterSet || lineSet ||
 		lineSpacing.Value != constants.DefaultLineSpacing ||
 		lineSpacing.Rule != domain.LineSpacingAuto {
 		props.Spacing = &xml.Spacing{
-			Before:   intPtrIfNotZero(before),
-			After:    intPtrIfNotZero(after),
-			Line:     intPtrIfNotZero(lineSpacing.Value),
+			Before:   spacingAttr(before, beforeSet),
+			After:    spacingAttr(after, afterSet),
+			Line:     spacingAttr(lineSpacing.Value, lineSet),
 			LineRule: s.lineSpacingRuleToString(lineSpacing.Rule),
 		}
 	}
@@ -985,6 +992,38 @@ func boolPtr(b bool) *bool {
 
 func intPtr(i int) *int {
 	return &i
+}
+
+// spacingSetter exposes whether a paragraph's spacing setters were ever
+// called, letting the serializer emit an explicit 0 instead of treating it as
+// "unset". Implemented by the concrete paragraph type in internal/core; see
+// serializeProperties.
+type spacingSetter interface {
+	SpacingBeforeSet() bool
+	SpacingAfterSet() bool
+	LineSpacingSet() bool
+}
+
+// spacingSetFlags returns whether para's spacing-before, spacing-after, and
+// line-spacing were explicitly set, degrading to all-false for any
+// domain.Paragraph implementation that doesn't expose spacingSetter.
+func spacingSetFlags(para domain.Paragraph) (beforeSet, afterSet, lineSet bool) {
+	if p, ok := para.(spacingSetter); ok {
+		return p.SpacingBeforeSet(), p.SpacingAfterSet(), p.LineSpacingSet()
+	}
+	return false, false, false
+}
+
+// spacingAttr returns a pointer to value for XML serialization: present
+// whenever the caller explicitly set the property, even at zero, so it
+// overrides a style's own spacing instead of being mistaken for "unset".
+// Otherwise it falls back to omitting zero, letting docDefaults or the
+// paragraph's style supply the value.
+func spacingAttr(value int, explicitlySet bool) *int {
+	if explicitlySet {
+		return intPtr(value)
+	}
+	return intPtrIfNotZero(value)
 }
 
 func intPtrIfNotZero(i int) *int {

--- a/internal/serializer/serializer_test.go
+++ b/internal/serializer/serializer_test.go
@@ -1002,22 +1002,40 @@ func TestParagraphSerializer_ExactLineSpacingAtDefaultValueIsEmitted(t *testing.
 		})
 	}
 
-	// The auto rule at the default value is genuinely "no departure" and must
-	// still stay out of the way of the style.
-	doc := core.NewDocument()
-	para, _ := doc.AddParagraph()
-	if err := para.SetLineSpacing(domain.LineSpacing{
-		Rule:  domain.LineSpacingAuto,
-		Value: 240,
-	}); err != nil {
-		t.Fatalf("SetLineSpacing: %v", err)
-	}
+	// An explicit SetLineSpacing(Auto, 240) is a real call the caller made,
+	// even though it names the default values — since it's distinguishable
+	// from "never called" (see LineSpacingSet, #69), it must still emit, so
+	// it can override a style's own non-auto line spacing rather than being
+	// mistaken for "unset" and silently losing to the style.
+	t.Run("ExplicitAutoAtDefaultIsEmitted", func(t *testing.T) {
+		doc := core.NewDocument()
+		para, _ := doc.AddParagraph()
+		if err := para.SetLineSpacing(domain.LineSpacing{
+			Rule:  domain.LineSpacingAuto,
+			Value: 240,
+		}); err != nil {
+			t.Fatalf("SetLineSpacing: %v", err)
+		}
 
-	ser := serializer.NewParagraphSerializer()
-	xmlPara := ser.Serialize(para)
-	if xmlPara.Properties != nil && xmlPara.Properties.Spacing != nil {
-		t.Errorf("expected no direct w:spacing for auto rule at the default value, got %+v", xmlPara.Properties.Spacing)
-	}
+		ser := serializer.NewParagraphSerializer()
+		xmlPara := ser.Serialize(para)
+		if xmlPara.Properties == nil || xmlPara.Properties.Spacing == nil {
+			t.Fatal("expected direct w:spacing for an explicit SetLineSpacing call, even at default values")
+		}
+	})
+
+	// A paragraph that never calls SetLineSpacing at all is the genuine
+	// "no departure" case and must stay out of the way of the style.
+	t.Run("NeverSetStaysSilent", func(t *testing.T) {
+		doc := core.NewDocument()
+		para, _ := doc.AddParagraph()
+
+		ser := serializer.NewParagraphSerializer()
+		xmlPara := ser.Serialize(para)
+		if xmlPara.Properties != nil && xmlPara.Properties.Spacing != nil {
+			t.Errorf("expected no direct w:spacing when SetLineSpacing was never called, got %+v", xmlPara.Properties.Spacing)
+		}
+	})
 }
 
 func TestParagraphSerializer_PartialIndentOmitsOtherSides(t *testing.T) {
@@ -1048,5 +1066,97 @@ func TestParagraphSerializer_PartialIndentOmitsOtherSides(t *testing.T) {
 	}
 	if ind.Hanging != nil {
 		t.Errorf("ind.Hanging = %v, want omitted (nil)", ind.Hanging)
+	}
+}
+
+// TestParagraphSerializer_ExplicitZeroAfterOnStyledParagraphIsEmitted guards
+// against the #69 bug: SpacingAfter() int can't distinguish "never called"
+// from "explicitly set to 0", so an explicit SetSpacingAfter(0) on a
+// paragraph whose style supplies non-zero spacing used to be silently
+// dropped, and the paragraph inherited the style's value instead of the
+// caller's explicit 0.
+func TestParagraphSerializer_ExplicitZeroAfterOnStyledParagraphIsEmitted(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	if err := para.SetStyle(domain.StyleIDHeading1); err != nil {
+		t.Fatalf("SetStyle: %v", err)
+	}
+	if err := para.SetSpacingAfter(0); err != nil {
+		t.Fatalf("SetSpacingAfter: %v", err)
+	}
+
+	ser := serializer.NewParagraphSerializer()
+	xmlPara := ser.Serialize(para)
+
+	if xmlPara.Properties == nil || xmlPara.Properties.Spacing == nil {
+		t.Fatal("expected direct w:spacing for an explicit SetSpacingAfter(0) on a styled paragraph")
+	}
+	after := xmlPara.Properties.Spacing.After
+	if after == nil || *after != 0 {
+		t.Errorf("spacing.After = %v, want a pointer to 0", after)
+	}
+	// Before was never set, so it must still be omitted — otherwise the
+	// caller's explicit After:0 would carry an unintended Before:0 with it,
+	// clobbering the style's own before-spacing too.
+	if xmlPara.Properties.Spacing.Before != nil {
+		t.Errorf("spacing.Before = %v, want omitted (nil), since it was never set", xmlPara.Properties.Spacing.Before)
+	}
+}
+
+// TestParagraphSerializer_ExplicitBeforeAndZeroAfterBothEmitted confirms both
+// an explicit non-zero Before and an explicit zero After are emitted
+// together, rather than the zero-value gate hiding one of them.
+func TestParagraphSerializer_ExplicitBeforeAndZeroAfterBothEmitted(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	if err := para.SetStyle(domain.StyleIDHeading1); err != nil {
+		t.Fatalf("SetStyle: %v", err)
+	}
+	if err := para.SetSpacingBefore(240); err != nil {
+		t.Fatalf("SetSpacingBefore: %v", err)
+	}
+	if err := para.SetSpacingAfter(0); err != nil {
+		t.Fatalf("SetSpacingAfter: %v", err)
+	}
+
+	ser := serializer.NewParagraphSerializer()
+	xmlPara := ser.Serialize(para)
+
+	if xmlPara.Properties == nil || xmlPara.Properties.Spacing == nil {
+		t.Fatal("expected direct w:spacing")
+	}
+	spacing := xmlPara.Properties.Spacing
+	if spacing.Before == nil || *spacing.Before != 240 {
+		t.Errorf("spacing.Before = %v, want a pointer to 240", spacing.Before)
+	}
+	if spacing.After == nil || *spacing.After != 0 {
+		t.Errorf("spacing.After = %v, want a pointer to 0", spacing.After)
+	}
+}
+
+// wrappedParagraph is the plain embedding decorator a third-party consumer
+// would write to add behavior around a domain.Paragraph.
+type wrappedParagraph struct{ domain.Paragraph }
+
+// TestParagraphSerializer_WrappedParagraphDegradesGracefully confirms that a
+// domain.Paragraph implementation which doesn't expose the concrete type's
+// *Set() methods (any third-party or wrapped implementation) neither panics
+// nor gets an explicit zero it never asked for — it falls back to the
+// zero-value gate, exactly like before #69.
+func TestParagraphSerializer_WrappedParagraphDegradesGracefully(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	if err := para.SetStyle(domain.StyleIDHeading1); err != nil {
+		t.Fatalf("SetStyle: %v", err)
+	}
+	if err := para.SetSpacingAfter(0); err != nil {
+		t.Fatalf("SetSpacingAfter: %v", err)
+	}
+
+	ser := serializer.NewParagraphSerializer()
+	xmlPara := ser.Serialize(wrappedParagraph{para})
+
+	if xmlPara.Properties != nil && xmlPara.Properties.Spacing != nil {
+		t.Errorf("expected no direct w:spacing through a wrapped domain.Paragraph (degraded behavior), got %+v", xmlPara.Properties.Spacing)
 	}
 }


### PR DESCRIPTION
## Summary

`Paragraph.SpacingBefore()`/`SpacingAfter() int` can't tell "never set" from "explicitly set to 0", so `SetSpacingAfter(0)` on a paragraph carrying a style with non-zero spacing was silently dropped: the serializer's zero-value gate treated the explicit `0` exactly like the paragraph never touching spacing at all, and the style's own value won instead. #67 fixed the *unstyled* half of this (a paragraph with no style and no explicit spacing now correctly inherits `0` from `docDefaults`); this fixes the *styled* half.

- `internal/core/paragraph.go`: `spacingBefore`/`spacingAfter`/`lineSpacing` each gain a `*Set bool` flag set by their setter, exposed on the concrete type as `SpacingBeforeSet()`/`SpacingAfterSet()`/`LineSpacingSet()` — the public `domain.Paragraph` interface is unchanged.
- `internal/serializer/serializer.go`: reads those flags via a type assertion (`spacingSetFlags`), the same pattern already used for style-name access at the top of `serializeProperties`. Degrades to the old zero-value gate for any `domain.Paragraph` implementation that doesn't expose them (third-party, wrapped) — see `TestParagraphSerializer_WrappedParagraphDegradesGracefully`.
- Extended the same tracking to line spacing, which has the identical bug: an explicit `SetLineSpacing(Auto, 240)` meant to override a style's non-auto rule back to single-spacing used to be indistinguishable from never calling it, since Auto/240 are also the defaults. Updated the one existing test (`TestParagraphSerializer_ExactLineSpacingAtDefaultValueIsEmitted`) that encoded the old, incorrect expectation.
- CLI: `paragraphItem.SpacingBefore`/`SpacingAfter` become `*int` (from `int`) so a JSON `"spacingAfter": 0` can be told apart from omitting the field — otherwise the fix would only reach the Go API, not the CLI/Node.js wrapper. Documented in `docs/CLI_GUIDE.md`.
- Indentation has the identical gap (`SetIndent` takes one struct covering four sides, so a single set-flag isn't enough and the reader's merged-indent construction would need rework) — filed separately as #76 rather than folded in here.

Fixes #69

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l ...`
- [x] `go test ./...` — all packages pass
- [x] `cd examples && ./test_all.sh` — 10/10
- [x] New regression tests confirmed to fail without the fix (temporarily stashed the `internal/core/paragraph.go` and `internal/serializer/serializer.go` changes and watched them fail) before reverting:
  - `TestParagraphSerializer_ExplicitZeroAfterOnStyledParagraphIsEmitted` / `..._ExplicitBeforeAndZeroAfterBothEmitted`
  - `TestParagraphSerializer_WrappedParagraphDegradesGracefully` (passes both ways, confirming the degrade path)
  - `TestBuilder_HeadingParagraphNoDirectSpacing` (the #63 non-regression, through the full public `NewDocumentBuilder` → `Build` → `WriteTo` pipeline, not just the internal serializer)
  - `TestBuilder_ExplicitZeroSpacingOnHeadingIsHonored`
  - `TestOpenDocument_RoundTripsExplicitZeroSpacing` (explicit zero survives a full open+resave round trip)
  - `TestHandleParagraphAdd_ExplicitZeroSpacingOnStyledParagraph` (through the actual JSON-RPC surface)