### PR TITLE
release: prepare v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## v2.9.0 — 2026-07-27
+
+### Fixed
+
+- **npm publish no longer depends on the GitHub release event.** `release.yml` authors the GitHub Release with a `RELEASE_PAT` so the `release: published` event fires `npm-publish.yml` automatically — but when that secret is empty or expired, the release silently falls back to being authored by `github-actions[bot]`, and GitHub's anti-recursion rule means a `GITHUB_TOKEN`-authored event can never trigger another workflow. Every release since at least v2.7.2 had to be published to npm by hand via `workflow_dispatch`, with `release.yml` reporting success regardless. `release.yml` now invokes `npm-publish.yml` directly as a `workflow_call` job, passing the version it already computed, so publishing no longer depends on that event firing at all. The `RELEASE_PAT` check is now a build warning instead of the only thing standing between "released" and "published to npm".
+- **`FindPlaceholders`, `FindPlaceholdersCustom`, `PlaceholderNames`, and `ValidateTemplate` no longer mutate the document they scan.** All four read as pure queries but called `ConsolidateRuns` internally to heal placeholders Word split across runs — v2.8.0 removed the worst consequence of that (silently dropped images), but the mutation itself remained: a caller who scanned a template to preview its placeholders got their in-memory document restructured as a side effect. The run-grouping logic `ConsolidateRuns` uses to decide what's mergeable is now shared with a new scan path that matches against each group's concatenated text and reports offsets back against the paragraph's real, unmodified runs — nothing merges unless `MergeTemplate` actually needs to write replacement text. `Location` gains `EndRunIndex` so a match spanning multiple runs can report where it ends, not just where it starts.
+- **An explicit zero spacing (or line spacing) is now honored on a paragraph carrying a style.** v2.8.0 fixed the *unstyled* case: a paragraph with no style and no explicit spacing correctly inherits `0` from the new `w:pPrDefault`. It did not fix the styled case, because `Paragraph.SpacingBefore()`/`SpacingAfter() int` can't distinguish "never set" from "explicitly set to 0" — so `SetSpacingAfter(0)` on a paragraph with a style supplying non-zero spacing was silently dropped, and the style's value won instead of the caller's explicit zero. The same gap applied to line spacing: an explicit `SetLineSpacing(Auto, 240)` meant to override a style's non-auto rule back to single-spacing was indistinguishable from never calling it, since `Auto`/`240` are also the defaults. The concrete paragraph type now tracks whether each setter was ever called and the serializer honors an explicit value even at zero. **Indentation has the identical gap** but needs a different fix shape — tracked in [#76](https://github.com/mmonterroca/docxgo/issues/76).
+
+### Changed
+
+- **Removed the unreachable no-style-manager `styles.xml` fallback.** `ZipWriter.writeDefaultStyles` wrote a hand-maintained raw XML string, reachable only when `writeStyles` received a `nil` `*Styles` — which never happens from the one production caller. It was a second, independent source of truth for default paragraph properties that had to be kept in sync by hand with the serializer; `writeStyles` now returns an error on `nil` instead of degrading to it.
+- **CLI:** `paragraph.add`'s `spacingBefore`/`spacingAfter` fields become nullable (`*int` server-side) so a JSON `"spacingAfter": 0` can be told apart from omitting the field — otherwise the spacing fix above would only reach the Go API, not the CLI or Node.js wrapper.
+- Refreshed `npm/package-lock.json` for the version bump; this incidentally restores `npm ci` in CI, which had been broken since the v2.8.0 release commit landed with an unrelated lockfile desync (unrelated to any fix in this release).
+
+### Compatibility
+
+- **No public Go interface changed.** `domain.Paragraph` is unchanged; the new `SpacingBeforeSet()`/`SpacingAfterSet()`/`LineSpacingSet()` methods are exposed only on the concrete internal type, read by the serializer via a type assertion that degrades gracefully for any other `domain.Paragraph` implementation (third-party, wrapped) — see `TestParagraphSerializer_WrappedParagraphDegradesGracefully`.
+- **`template.Location`** gains a new field, `EndRunIndex` (additive). `RunIndex`/`StartOffset` now point at the paragraph's own run and offset rather than a post-consolidation run that no longer exists for scans — no non-test consumer of these fields exists in this repo, and no `RunIndex`/`StartOffset`/`EndOffset` semantics changed for the common case of a match inside a single run.
+- **CLI JSON-RPC:** `spacingBefore`/`spacingAfter` remain optional integer fields; omitting them is unchanged, but `0` now behaves differently (honored, rather than ignored) when the paragraph carries a style.
+- Generated output changes as described under **Fixed** for paragraphs that explicitly set spacing to 0 on a styled paragraph.
+
+---
+
 ## v2.8.0 — 2026-07-27
 
 ### Fixed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration Guide: v1 → docxgo v2
 
-**Current target:** v2.8.0
+**Current target:** v2.9.0
 **Minimum Go version:** 1.23
 
 This guide covers migration from the historical `fumiama/go-docx` API to the
@@ -27,7 +27,7 @@ For the complete current API, see the [API guide](docs/V2_API_GUIDE.md) and
 ## 1. Update the module
 
 ```bash
-go get github.com/mmonterroca/docxgo/v2@v2.8.0
+go get github.com/mmonterroca/docxgo/v2@v2.9.0
 go mod tidy
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Since v2.7.0 it also ships a JSON-RPC command-line interface and a Node.js wrapp
 - **Proofing language** — `WithLanguage` / `WithLanguageEx` for spell-check, grammar, hyphenation
 - **Production quality** — clean architecture, explicit errors, thread-safe internals
 
-**Status:** v2.8.0 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
+**Status:** v2.9.0 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
 
 ---
 

--- a/RELEASE_NOTES_v2.9.0.md
+++ b/RELEASE_NOTES_v2.9.0.md
@@ -1,0 +1,156 @@
+# Release Notes - v2.9.0
+
+**Release Date:** July 27, 2026
+
+## Summary
+
+v2.9.0 closes out the follow-ups filed during v2.8.0's release: the release
+pipeline's npm publish step no longer depends on an event that a bot-authored
+release can never fire, `FindPlaceholders` and its siblings stop mutating the
+document they scan, an explicit zero spacing is now honored on a styled
+paragraph, and a dead code path in the styles writer is removed.
+
+The spacing fix **changes rendering for paragraphs that explicitly zero their
+spacing on top of a style** — see "Rendering change" below before upgrading.
+Nothing else in this release changes generated output.
+
+## Fixed
+
+### npm publish no longer depends on the GitHub release event
+
+`release.yml` authors the GitHub Release using a `RELEASE_PAT` repository
+secret specifically so the `release: published` event fires and
+`npm-publish.yml` picks it up automatically. When that secret is empty or
+expired, `softprops/action-gh-release` silently falls back to the default
+`GITHUB_TOKEN`, and the release ships anyway — authored by
+`github-actions[bot]` instead of a real user. GitHub does not let events
+created by `GITHUB_TOKEN` trigger other workflows (anti-recursion protection),
+so `npm-publish.yml`'s trigger never fires. `release.yml` still reports
+success, because creating the release worked fine; nothing surfaces that the
+cascade it exists to start did not happen.
+
+This was not hypothetical: every release since at least v2.7.2, including
+v2.8.0, needed a manual `workflow_dispatch` to actually reach npm.
+
+`release.yml` now invokes `npm-publish.yml` directly as a `workflow_call` job,
+passing the version it already computed as a job output. Publishing is now an
+edge in the release job graph rather than a listener on an event that can go
+silently dead. The `RELEASE_PAT` emptiness check remains, but as a warning: a
+bot-authored release is no longer a publish blocker, only a cosmetic wrong
+author on the GitHub Release page.
+
+### FindPlaceholders, PlaceholderNames, and ValidateTemplate no longer mutate the document they scan
+
+All three read as pure queries — none return an error, none hint at taking a
+mutable argument. Internally, though, they called `template.ConsolidateRuns`
+on every paragraph to heal placeholders Word split across `<w:r>` elements.
+v2.8.0 removed the worst consequence of that mutation (it used to silently
+drop images); this removes the mutation itself.
+
+The run-grouping logic `ConsolidateRuns` already computed — which adjacent
+runs share formatting and can be treated as one span of text — is now a
+shared helper. The scanner matches placeholders against each group's
+concatenated *virtual* text without touching the paragraph, then translates
+the match's offsets back to the real, unmodified run and offset where it
+starts and ends.
+
+`template.Location` gains a new field, `EndRunIndex`, since a match spanning
+multiple runs now needs to report where it ends as well as where it starts.
+`RunIndex`/`StartOffset` point at the run the paragraph actually has, not a
+post-consolidation run that no longer exists once the scan is done.
+
+`MergeTemplate` is unaffected and keeps consolidating — there, merging split
+runs is necessary to write the replacement text into one place.
+
+### An explicit zero spacing (or line spacing) is now honored on a styled paragraph
+
+v2.8.0 fixed this for the *unstyled* case: a paragraph with no style and no
+explicit spacing now correctly inherits `0` from the document's
+`w:pPrDefault`. It did not fix the *styled* case, because
+`Paragraph.SpacingBefore()`/`SpacingAfter() int` can't tell "the caller never
+called this" from "the caller explicitly set it to 0" — so
+`SetSpacingAfter(0)` on a paragraph carrying a style with non-zero spacing was
+silently dropped, and the style's own value won instead of the caller's
+explicit zero.
+
+The same gap applied to line spacing: an explicit
+`SetLineSpacing({Rule: Auto, Value: 240})` meant to override a style's
+non-auto rule back to single-spacing was indistinguishable from never calling
+`SetLineSpacing` at all, since `Auto`/`240` are also the defaults.
+
+The concrete paragraph type now tracks whether `SetSpacingBefore`,
+`SetSpacingAfter`, and `SetLineSpacing` were ever called, and the serializer
+honors an explicit value even when it happens to be zero (or a default).
+`domain.Paragraph` itself is unchanged — the tracking is read via a type
+assertion that degrades to the old behavior for any implementation that
+doesn't expose it, so third-party or wrapped paragraphs keep working exactly
+as before.
+
+**Indentation has the identical gap** — `SetIndent` can't currently express
+"I set Left but left Right untouched" either — but fixing it needs a
+different shape of change (`SetIndent` takes one struct covering all four
+sides, unlike spacing's four independent setters). Tracked separately in
+[#76](https://github.com/mmonterroca/docxgo/issues/76).
+
+## Rendering change
+
+**A paragraph that carries a style and explicitly sets its own spacing to 0
+will now render at that 0, instead of silently keeping the style's spacing.**
+
+This only affects paragraphs that both (a) have a style with non-zero
+spacing, and (b) explicitly call `SetSpacingBefore(0)`, `SetSpacingAfter(0)`,
+or `SetLineSpacing` with default-looking values, expecting it to stick. Before
+this release, such a call was silently ignored. If your code relied on that
+silent ignoring — i.e., you called `SetSpacingAfter(0)` on a styled paragraph
+but expected the style's spacing to still show through — remove the call;
+that intent can no longer be expressed as "set to 0", since 0 is now always
+honored. Paragraphs that never call these setters are unaffected.
+
+## Changed
+
+### Removed the unreachable no-style-manager styles.xml fallback
+
+`ZipWriter.writeDefaultStyles` wrote a hand-maintained raw `word/styles.xml`
+string, reached only when `writeStyles` received a `nil` `*Styles`. The only
+production caller (`internal/core/document.go`) always passes a real
+serialized style manager, so the fallback only ever ran from tests calling
+`WriteDocument` directly — never from a generated document. It was a second,
+independent source of truth for default paragraph properties that had to be
+kept in sync by hand with the serializer; v2.8.0's spacing fix had to update
+both copies and add a test pinning that they agreed. `writeStyles` now
+returns an error on `nil` instead of degrading to the fallback, making the
+invariant explicit. That cross-path drift test is removed along with what it
+was guarding.
+
+### CLI: spacingBefore/spacingAfter accept an explicit zero
+
+`paragraph.add`'s `spacingBefore`/`spacingAfter` JSON fields become nullable
+integers server-side, so a request body with `"spacingAfter": 0` can be told
+apart from omitting the field entirely. Without this, the spacing fix above
+would only reach the Go API — the CLI and Node.js wrapper would still have no
+way to ask for an explicit zero. Omitting the field is unchanged; passing a
+number, including `0`, now always sets it.
+
+## Known limitations
+
+- **Indentation has the same unset-tracking gap the spacing fix closed.** An
+  explicit `SetIndent(domain.Indentation{Left: 720, Right: 0})` intended to
+  zero out a style's right indent is indistinguishable from never touching
+  `Right`, and is silently dropped in favor of the style's value. Tracked in
+  [#76](https://github.com/mmonterroca/docxgo/issues/76).
+
+## Compatibility
+
+- **No public Go interface changed.** `domain.Paragraph` is exactly as it was;
+  the new `SpacingBeforeSet()`/`SpacingAfterSet()`/`LineSpacingSet()` methods
+  live only on the internal concrete type.
+- **`template.Location`** gains `EndRunIndex` (additive). No non-test consumer
+  of `RunIndex`/`StartOffset`/`EndOffset` exists in this repo (`cmd/docxgo`,
+  `npm/`), and their values are unchanged for the common case of a match
+  contained in a single run.
+- **CLI JSON-RPC:** `spacingBefore`/`spacingAfter` remain optional; omitting
+  them behaves as before. Passing an explicit `0` on a styled paragraph now
+  behaves differently — see "Rendering change".
+- `template.ConsolidateRuns`, `MergeTemplate`, and `FindPlaceholders` keep
+  their existing signatures for every `domain.Paragraph` implementation,
+  including third-party and wrapped ones.

--- a/doc.go
+++ b/doc.go
@@ -289,7 +289,7 @@ This library generates Office Open XML (OOXML) documents compatible with:
 
 # Version
 
-Current version: 2.8.0 (see the Version constant for the authoritative value).
+Current version: 2.9.0 (see the Version constant for the authoritative value).
 
 This is a major rewrite of the original go-docx library with breaking changes.
 See the migration guide in MIGRATION.md for details.

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -62,7 +62,7 @@ Verify the installation:
 
 ```bash
 docxgo version
-# 2.8.0
+# 2.9.0
 ```
 
 ---
@@ -194,7 +194,7 @@ Returns version, protocol version, and platform information.
 ```json
 {
   "name": "docxgo",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "protocolVersion": "1.0",
   "goVersion": "go1.23.0",
   "platform": "darwin",
@@ -247,7 +247,7 @@ Executes multiple RPC requests in a single roundtrip. Each sub-request is proces
 {
   "responses": [
     { "result": { "status": "ok" } },
-    { "result": { "name": "docxgo", "version": "2.8.0", ... } },
+    { "result": { "name": "docxgo", "version": "2.9.0", ... } },
     { "error": { "code": "NOT_FOUND", "message": "..." } }
   ]
 }

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,7 +1,7 @@
 # docxgo v2 Implementation Status
 
 **Last Updated**: July 2026
-**Version**: 2.8.0 (Stable)
+**Version**: 2.9.0 (Stable)
 
 This document tracks the implementation status of all v2 features, helping developers understand what's available, what's in progress, and what's planned.
 
@@ -37,6 +37,7 @@ All development phases have been completed. The library has gone through multipl
 | v2.7.0      | Jul 2026 | JSON-RPC CLI (`cmd/docxgo`) + Node.js wrapper (`@mmonterroca/docxgo`), `document.setLanguage` |
 | v2.7.1      | Jul 2026 | Tech themes discoverable via public API (7 total), `docxgo` output branding, doc/provenance alignment |
 | v2.8.0      | Jul 2026 | Final MIT provenance determination, corrected notices, license-complete release artifacts |
+| v2.9.0      | Jul 2026 | Fixed npm-publish cascade, read-only `FindPlaceholders`, explicit zero spacing on styled paragraphs |
 
 ---
 
@@ -417,5 +418,5 @@ Want to help implement missing features? See [CONTRIBUTING.md](../CONTRIBUTING.m
 ---
 
 **Last Updated**: July 2026
-**Status**: Production Ready (v2.8.0 Stable)
+**Status**: Production Ready (v2.9.0 Stable)
 **Maintained by**: Misael Monterroca ([@mmonterroca](https://github.com/mmonterroca))

--- a/docs/README.md
+++ b/docs/README.md
@@ -224,4 +224,4 @@ See: IMPLEMENTATION_STATUS.md - Features list
 ---
 
 **Last Updated**: July 2026  
-**Documentation Version**: v2.8.0
+**Documentation Version**: v2.9.0

--- a/docs/V2_API_GUIDE.md
+++ b/docs/V2_API_GUIDE.md
@@ -1,6 +1,6 @@
 # docxgo v2 API Guide
 
-**Version**: 2.8.0
+**Version**: 2.9.0
 **Last Updated**: July 2026
 
 ---
@@ -994,4 +994,4 @@ See [`examples/14_mail_merge/`](../examples/14_mail_merge/) for a complete worki
 ---
 
 **Last Updated**: July 2026
-**Version**: 2.8.0
+**Version**: 2.9.0

--- a/docs/V2_DESIGN.md
+++ b/docs/V2_DESIGN.md
@@ -1,8 +1,8 @@
 # docxgo v2 - Clean Architecture Design
 
-**Status**: ✅ v2.8.0 Stable
+**Status**: ✅ v2.9.0 Stable
 **Progress**: Production Ready (all core features complete)
-**Latest Release**: v2.8.0 (July 2026)
+**Latest Release**: v2.9.0 (July 2026)
 **Breaking Changes**: Yes (major version bump from original fork)
 
 > **Project Note**: This project is a substantially rewritten successor to `fumiama/go-docx`, focused on clean architecture, type safety, and modern Go practices. The Git history includes AGPL-era upstream snapshots; the completed [provenance audit](./PROVENANCE_AUDIT.md) determines that the current MIT release contains no protectable AGPL implementation.
@@ -1344,7 +1344,7 @@ See [CREDITS.md](../CREDITS.md) for complete project history.
 ---
 
 **Last Updated**: July 2026
-**Status**: ✅ v2.8.0 Stable
+**Status**: ✅ v2.9.0 Stable
 **Progress**: Production Ready (all core features complete)
 
 **Current State:**

--- a/docx.go
+++ b/docx.go
@@ -88,7 +88,7 @@ func reconstructFromPackage(pkg *reader.Package, op string) (domain.Document, er
 }
 
 // Version is the library version.
-const Version = "2.8.0"
+const Version = "2.9.0"
 
 // Common color constants exported for convenience.
 var (

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mmonterroca/docxgo",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mmonterroca/docxgo",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.3",
@@ -17,11 +17,11 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "@mmonterroca/docxgo-darwin-arm64": "2.8.0",
-        "@mmonterroca/docxgo-darwin-x64": "2.8.0",
-        "@mmonterroca/docxgo-linux-arm64": "2.8.0",
-        "@mmonterroca/docxgo-linux-x64": "2.8.0",
-        "@mmonterroca/docxgo-win32-x64": "2.8.0"
+        "@mmonterroca/docxgo-darwin-arm64": "2.9.0",
+        "@mmonterroca/docxgo-darwin-x64": "2.9.0",
+        "@mmonterroca/docxgo-linux-arm64": "2.9.0",
+        "@mmonterroca/docxgo-linux-x64": "2.9.0",
+        "@mmonterroca/docxgo-win32-x64": "2.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmonterroca/docxgo",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Node.js wrapper for docxgo — create and manipulate Word documents via JSON-RPC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -50,10 +50,10 @@
     "typescript": "^5.4.0"
   },
   "optionalDependencies": {
-    "@mmonterroca/docxgo-darwin-arm64": "2.8.0",
-    "@mmonterroca/docxgo-darwin-x64": "2.8.0",
-    "@mmonterroca/docxgo-linux-arm64": "2.8.0",
-    "@mmonterroca/docxgo-linux-x64": "2.8.0",
-    "@mmonterroca/docxgo-win32-x64": "2.8.0"
+    "@mmonterroca/docxgo-darwin-arm64": "2.9.0",
+    "@mmonterroca/docxgo-darwin-x64": "2.9.0",
+    "@mmonterroca/docxgo-linux-arm64": "2.9.0",
+    "@mmonterroca/docxgo-linux-x64": "2.9.0",
+    "@mmonterroca/docxgo-win32-x64": "2.9.0"
   }
 }


### PR DESCRIPTION
## Summary

Prepares the v2.9.0 release: version bump, CHANGELOG + release notes, and an npm lock refresh.

- Version constant, npm package metadata/lock, and all doc version strings bumped 2.8.0 → 2.9.0.
- `CHANGELOG.md` and `RELEASE_NOTES_v2.9.0.md` cover the four fixes from this cycle (#72, #70, #68, #69).
- Minor rather than patch: an explicit `SetSpacingAfter(0)` (or `SetLineSpacing` at default-looking values) on a paragraph carrying a style now overrides the style's own spacing instead of being silently dropped — a visible rendering change for anyone relying on the old, incorrect silent-ignore behavior. No public Go interface changed.
- `npm/package-lock.json` regenerated with `npm install --package-lock-only` (drops platform-package entries, since 2.9.0 isn't on the registry yet — `npm-publish.yml` restores them at publish time, same as every prior release). This incidentally fixes CI's "Node.js Tests" job, which has been failing on `master` since the v2.8.0 release commit landed with the same lock desync — unrelated to anything in this release, discovered while regenerating the lock for this bump.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./...` — all packages pass
- [x] `cd examples && ./test_all.sh` — 10/10
- [x] `cd npm && npm ci && npx tsx --test src/__tests__/*.test.ts` — 35/35, confirms the lock regeneration actually works