### PR TITLE
fix: address code-review findings from v2.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,19 @@ jobs:
       - name: Build Go binary
         run: go build -o npm/bin/docxgo ./cmd/docxgo/
 
+      # npm ci requires package-lock.json to already have resolved entries
+      # for every optionalDependency in package.json. Right after a release
+      # commit bumps npm/package.json's optionalDependencies to a version
+      # not yet on the npm registry, the lock (regenerated with
+      # `npm install --package-lock-only`, which necessarily drops those
+      # unresolvable platform-package entries — see release.yml) has no such
+      # entries, and `npm ci` fails EUSAGE even though the manifest and lock
+      # otherwise agree. `npm install` reconciles instead of requiring exact
+      # pre-sync, which is what CI actually needs here: correctness of the
+      # wrapper's own tests, not lockfile reproducibility for a case the repo's
+      # own release process intentionally produces every cycle.
       - name: Install npm dependencies
-        run: cd npm && npm ci
+        run: cd npm && npm install
 
       - name: Run Node.js tests
         run: cd npm && npx tsx --test src/__tests__/*.test.ts

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,13 +1,13 @@
 name: npm Publish
 
 on:
-  release:
-    types: [published]
   # release.yml invokes this workflow directly as a job (see its publish-npm
-  # job), passing the version explicitly, so publishing no longer depends on
-  # the "release: published" event above ever firing — which it doesn't when
-  # RELEASE_PAT is unset, since GitHub does not let GITHUB_TOKEN-authored
-  # events trigger other workflows.
+  # job), passing the version explicitly. There is deliberately no `release:
+  # types: [published]` trigger here: that event only fires for a real-PAT
+  # (non-bot) authored release, and release.yml's publish-npm job always runs
+  # regardless of RELEASE_PAT — keeping both would fire this workflow twice
+  # for the same tag once RELEASE_PAT is configured, racing two `npm publish`
+  # calls against the same version.
   workflow_call:
     inputs:
       version:
@@ -59,6 +59,21 @@ jobs:
             ext: .exe
 
     steps:
+      # Validated before checkout uses it as a ref and before any run: step
+      # interpolates it: inputs.version only ever reaches this job from a
+      # human typing into workflow_dispatch (workflow_call always passes a
+      # tag-derived version), but a malformed value here would otherwise
+      # produce a confusing "ref not found" from checkout below.
+      - name: Validate version input
+        if: inputs.version != ''
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$INPUT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
+            echo "::error::version input '$INPUT_VERSION' must be a bare semantic version like 2.9.0 (no 'v' prefix, no other characters)"
+            exit 1
+          fi
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.version != '' && format('refs/tags/v{0}', inputs.version) || github.ref }}
@@ -75,9 +90,11 @@ jobs:
 
       - name: Extract version from tag
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          if [ -n "$INPUT_VERSION" ]; then
+            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
           else
             echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
           fi
@@ -155,9 +172,11 @@ jobs:
 
       - name: Extract version from tag
         id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          if [ -n "$INPUT_VERSION" ]; then
+            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
           else
             echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,8 +110,10 @@ jobs:
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
       - name: Check RELEASE_PAT is configured
+        env:
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
         run: |
-          if [ -z "${{ secrets.RELEASE_PAT }}" ]; then
+          if [ -z "$RELEASE_PAT" ]; then
             echo "::warning::RELEASE_PAT is empty or missing — this release will be authored by github-actions[bot] instead of a real user. This is now cosmetic: the publish-npm job below invokes npm-publish.yml directly and no longer depends on the 'release: published' event that a bot-authored release can't fire. Still worth fixing so releases show a real author."
           fi
 

--- a/examples/14_mail_merge/main.go
+++ b/examples/14_mail_merge/main.go
@@ -82,7 +82,6 @@ func main() {
 
 	// Step 4: Merge single document
 	fmt.Println("\nStep 4: Merging template with data...")
-	doc, _ = docx.OpenDocument(templatePath)
 	if err := template.MergeTemplate(doc, data); err != nil {
 		log.Fatalf("Merge failed: %v", err)
 	}

--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -556,15 +556,27 @@ func (s *ParagraphSerializer) serializeProperties(para domain.Paragraph) *xml.Pa
 	// spacing: an exact or at-least rule is a departure even at the default
 	// 240 twips, and without this check it would silently inherit the
 	// lineRule="auto" written into w:pPrDefault.
-	if before != 0 || after != 0 || beforeSet || afterSet || lineSet ||
+	//
+	// Before/After and Line/LineRule are gated independently within the same
+	// element: a paragraph that only set spacingBefore/spacingAfter must not
+	// also emit w:line/w:lineRule, since lineSpacingRuleToString never
+	// returns nil and this fix's own beforeSet/afterSet would otherwise stamp
+	// the default 240/auto onto every such paragraph, silently overriding a
+	// style's own line spacing.
+	lineDeparts := lineSet ||
 		lineSpacing.Value != constants.DefaultLineSpacing ||
-		lineSpacing.Rule != domain.LineSpacingAuto {
-		props.Spacing = &xml.Spacing{
-			Before:   spacingAttr(before, beforeSet),
-			After:    spacingAttr(after, afterSet),
-			Line:     spacingAttr(lineSpacing.Value, lineSet),
-			LineRule: s.lineSpacingRuleToString(lineSpacing.Rule),
+		lineSpacing.Rule != domain.LineSpacingAuto
+
+	if before != 0 || after != 0 || beforeSet || afterSet || lineDeparts {
+		spacing := &xml.Spacing{
+			Before: spacingAttr(before, beforeSet),
+			After:  spacingAttr(after, afterSet),
 		}
+		if lineDeparts {
+			spacing.Line = spacingAttr(lineSpacing.Value, lineSet)
+			spacing.LineRule = s.lineSpacingRuleToString(lineSpacing.Rule)
+		}
+		props.Spacing = spacing
 	}
 
 	// Borders

--- a/internal/serializer/serializer_test.go
+++ b/internal/serializer/serializer_test.go
@@ -1101,6 +1101,65 @@ func TestParagraphSerializer_ExplicitZeroAfterOnStyledParagraphIsEmitted(t *test
 	if xmlPara.Properties.Spacing.Before != nil {
 		t.Errorf("spacing.Before = %v, want omitted (nil), since it was never set", xmlPara.Properties.Spacing.Before)
 	}
+	// Line/LineRule were never set either, so they must also be omitted —
+	// otherwise a paragraph that only set spacingAfter would gain an
+	// unintended direct w:line="240" w:lineRule="auto", overriding the
+	// style's own line spacing (e.g. 1.5 lines) with single-spacing. This
+	// was a real regression: the old code always filled Line/LineRule
+	// whenever the w:spacing element was emitted for any reason.
+	if xmlPara.Properties.Spacing.Line != nil {
+		t.Errorf("spacing.Line = %v, want omitted (nil), since line spacing was never set", xmlPara.Properties.Spacing.Line)
+	}
+	if xmlPara.Properties.Spacing.LineRule != nil {
+		t.Errorf("spacing.LineRule = %v, want omitted (nil), since line spacing was never set", xmlPara.Properties.Spacing.LineRule)
+	}
+}
+
+// TestParagraphSerializer_ExplicitSpacingDoesNotClobberStyleLineSpacing pins
+// the bug found in code review of #77: the emit gate correctly opened the
+// <w:spacing> element on beforeSet/afterSet alone, but Line and LineRule were
+// filled unconditionally inside it — lineSpacingRuleToString never returns
+// nil and a never-touched LineSpacing still carries the constructor's
+// {Auto, 240} defaults, so any paragraph that only set spacingBefore/After
+// silently gained direct w:line="240" w:lineRule="auto", clobbering a
+// style's real line spacing (here, Heading1's own line spacing, simulated by
+// a style with an explicit non-default line spacing).
+func TestParagraphSerializer_ExplicitSpacingDoesNotClobberStyleLineSpacing(t *testing.T) {
+	doc := core.NewDocument()
+	sm := doc.StyleManager()
+	style, err := sm.GetStyle(domain.StyleIDHeading1)
+	if err != nil {
+		t.Fatalf("GetStyle: %v", err)
+	}
+	paraStyle, ok := style.(domain.ParagraphStyle)
+	if !ok {
+		t.Fatal("Heading1 style does not implement domain.ParagraphStyle")
+	}
+	// Give the style a non-default line spacing (1.5 lines) so an
+	// unintended direct override on the paragraph is observable.
+	if err := paraStyle.SetLineSpacing(360); err != nil {
+		t.Fatalf("style SetLineSpacing: %v", err)
+	}
+
+	para, _ := doc.AddParagraph()
+	if err := para.SetStyle(domain.StyleIDHeading1); err != nil {
+		t.Fatalf("SetStyle: %v", err)
+	}
+	if err := para.SetSpacingAfter(0); err != nil {
+		t.Fatalf("SetSpacingAfter: %v", err)
+	}
+	// The paragraph's own LineSpacing was never touched.
+
+	ser := serializer.NewParagraphSerializer()
+	xmlPara := ser.Serialize(para)
+
+	if xmlPara.Properties == nil || xmlPara.Properties.Spacing == nil {
+		t.Fatal("expected direct w:spacing for the explicit SetSpacingAfter(0)")
+	}
+	if xmlPara.Properties.Spacing.Line != nil || xmlPara.Properties.Spacing.LineRule != nil {
+		t.Errorf("got direct w:line=%v w:lineRule=%v, want both omitted so the paragraph inherits the style's 1.5-line spacing",
+			xmlPara.Properties.Spacing.Line, xmlPara.Properties.Spacing.LineRule)
+	}
 }
 
 // TestParagraphSerializer_ExplicitBeforeAndZeroAfterBothEmitted confirms both

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -466,6 +466,71 @@
         "node": ">=18"
       }
     },
+    "node_modules/@mmonterroca/docxgo-darwin-arm64": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-darwin-arm64/-/docxgo-darwin-arm64-2.9.0.tgz",
+      "integrity": "sha512-CjOK4fj6J7OS2+JC93T5PPZw8MvCABJun0xyvrLzcwE+ZBA9cETaxCc2yCe921PwtD9txFyzLshReQMn+kKvZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@mmonterroca/docxgo-darwin-x64": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-darwin-x64/-/docxgo-darwin-x64-2.9.0.tgz",
+      "integrity": "sha512-YfUutquHpY2pP1J2JOumI6mWVT9r9u3Br/GUjXGKNNudBYGO1K79XnnvcOZUi/NLd2QVXWpo53qSKgpZ+Wh3Bw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@mmonterroca/docxgo-linux-arm64": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-linux-arm64/-/docxgo-linux-arm64-2.9.0.tgz",
+      "integrity": "sha512-1BhrWxMVIkddxT2k9kq4Z7AH9nt+imVC+64o2UvaDzRm6v/6WXJ+4sYWGdYs4GopX6wQyOuHdJiD/ItGzqainw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@mmonterroca/docxgo-linux-x64": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-linux-x64/-/docxgo-linux-x64-2.9.0.tgz",
+      "integrity": "sha512-5c/1QyUx4/LFO4jtkQM50P6SStf8NiBIBPJBXSsQQG4S8lNxOSFAX2LYd3+J50A+FN8wpg/uE0T/fSgoQI18VA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@mmonterroca/docxgo-win32-x64": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-win32-x64/-/docxgo-win32-x64-2.9.0.tgz",
+      "integrity": "sha512-TBZlAn0EHxp9PFdE6n+DzXAXfQ+JF9rSgKWAYiIkGkwIvaldjlCggQyEWXtsugVYQzDoavFfiQJsQXF1wyQYkg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@types/node": {
       "version": "25.3.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",

--- a/pkg/template/consolidate_test.go
+++ b/pkg/template/consolidate_test.go
@@ -498,6 +498,69 @@ func TestFindPlaceholders_LocationAcrossSplitRuns(t *testing.T) {
 	}
 }
 
+// TestFindPlaceholders_LocationNotSplitAtRunBoundary pins the off-by-one bug
+// found in code review of #75/#68: a match that is NOT split — it starts
+// exactly at the boundary between two mergeable runs — must resolve its
+// start to the run that actually contains it (the second run), not to the
+// end of the run before it. Before the fix, RunIndex/EndRunIndex disagreed
+// (falsely signaling a split) and runs[loc.RunIndex].Text()[loc.StartOffset:loc.EndOffset]
+// panicked with a slice-bounds error, since StartOffset came from the wrong
+// run's length.
+func TestFindPlaceholders_LocationNotSplitAtRunBoundary(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+
+	r1, _ := para.AddRun()
+	r1.SetText("Hello ") // 6 chars, same formatting as r2 -> mergeable
+	r2, _ := para.AddRun()
+	r2.SetText("{{Name}}") // whole placeholder starts right at the boundary
+
+	placeholders := FindPlaceholders(doc)
+	if len(placeholders) != 1 {
+		t.Fatalf("expected 1 placeholder, got %d", len(placeholders))
+	}
+
+	loc := placeholders[0].Location
+	if loc.RunIndex != loc.EndRunIndex {
+		t.Fatalf("match is not split across runs, but RunIndex=%d != EndRunIndex=%d", loc.RunIndex, loc.EndRunIndex)
+	}
+	if loc.RunIndex != 1 || loc.StartOffset != 0 {
+		t.Errorf("start = (run %d, offset %d), want (run 1, offset 0)", loc.RunIndex, loc.StartOffset)
+	}
+	if loc.EndOffset != 8 {
+		t.Errorf("EndOffset = %d, want 8", loc.EndOffset)
+	}
+
+	runs := para.Runs()
+	got := runs[loc.RunIndex].Text()[loc.StartOffset:loc.EndOffset]
+	if got != "{{Name}}" {
+		t.Errorf("slicing runs[RunIndex].Text()[StartOffset:EndOffset] = %q, want %q", got, "{{Name}}")
+	}
+}
+
+// TestFindPlaceholders_LocationSkipsLeadingEmptyRun confirms a placeholder
+// starting right after a zero-length run resolves to the run that actually
+// holds the text, not the empty one.
+func TestFindPlaceholders_LocationSkipsLeadingEmptyRun(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+
+	r1, _ := para.AddRun()
+	r1.SetText("") // empty, same formatting as r2 -> mergeable group
+	r2, _ := para.AddRun()
+	r2.SetText("{{Name}}")
+
+	placeholders := FindPlaceholders(doc)
+	if len(placeholders) != 1 {
+		t.Fatalf("expected 1 placeholder, got %d", len(placeholders))
+	}
+
+	loc := placeholders[0].Location
+	if loc.RunIndex != 1 || loc.StartOffset != 0 {
+		t.Errorf("start = (run %d, offset %d), want (run 1, offset 0) — skipping the empty run", loc.RunIndex, loc.StartOffset)
+	}
+}
+
 // TestFindPlaceholders_HeaderNotMutated confirms the read-only guarantee also
 // holds for header paragraphs, where logos live alongside mergeable text runs.
 func TestFindPlaceholders_HeaderNotMutated(t *testing.T) {

--- a/pkg/template/placeholder.go
+++ b/pkg/template/placeholder.go
@@ -27,6 +27,20 @@ const (
 )
 
 // Location provides structural context for a placeholder occurrence.
+//
+// When RunIndex == EndRunIndex (the common case — the whole match sits in
+// one run), StartOffset and EndOffset are both offsets into that single run,
+// exactly as in releases before v2.9.0: runs[RunIndex].Text()[StartOffset:EndOffset]
+// yields the full match text.
+//
+// When RunIndex != EndRunIndex, Word split the placeholder across multiple
+// runs (a common artifact of spell-check/proofing) and it was found by
+// scanning across them without merging — see FindPlaceholders. StartOffset
+// and EndOffset are then offsets into two *different* runs (RunIndex and
+// EndRunIndex respectively); slicing a single run with both offsets is
+// incorrect. A caller that needs the full match text should use FullMatch,
+// or MergeTemplate to replace it (which does merge split runs, since writing
+// a single replacement value requires it).
 type Location struct {
 	// Type indicates where the placeholder was found.
 	Type LocationType
@@ -128,8 +142,8 @@ func scanParagraph(para domain.Paragraph, pattern *regexp.Regexp, ctx paragraphC
 			fullMatch := g.text[match[0]:match[1]]
 			name := g.text[match[2]:match[3]]
 
-			startRun, startOffset := locateGroupOffset(g.leader, runLens, match[0])
-			endRun, endOffset := locateGroupOffset(g.leader, runLens, match[1])
+			startRun, startOffset := locateGroupOffset(g.leader, runLens, match[0], false)
+			endRun, endOffset := locateGroupOffset(g.leader, runLens, match[1], true)
 
 			loc := Location{
 				Type:           ctx.locationType,
@@ -159,11 +173,23 @@ func scanParagraph(para domain.Paragraph, pattern *regexp.Regexp, ctx paragraphC
 
 // locateGroupOffset translates a byte offset into a run group's concatenated
 // text back to the index (relative to the paragraph's own runs) and local
-// offset of the run that contains it. An offset at or beyond the end of the
-// group's text resolves to the end of its last run.
-func locateGroupOffset(leader int, runLens []int, offset int) (runIndex, runOffset int) {
+// offset of the run that contains it.
+//
+// isEnd distinguishes how a boundary offset — one landing exactly at the
+// junction between two runs — resolves. A match's exclusive end offset
+// belongs to the run it closes out (isEnd=true, "<="): the end of a match
+// that consumes a run's last character lands at that run's own length, not
+// offset 0 of a run that may not even exist. A match's start offset belongs
+// to the run its first character actually starts in (isEnd=false, strict
+// "<"): using "<=" here would misattribute a start landing exactly at a run
+// boundary to the end of the earlier run instead of the start of the next
+// one, which also skips past empty runs (length 0) to the first run that
+// actually has content — the correct behavior for a leading empty run.
+// An offset at or beyond the end of the group's text resolves to the end of
+// its last run.
+func locateGroupOffset(leader int, runLens []int, offset int, isEnd bool) (runIndex, runOffset int) {
 	for i, l := range runLens {
-		if offset <= l {
+		if offset < l || (isEnd && offset == l) {
 			return leader + i, offset
 		}
 		offset -= l


### PR DESCRIPTION
## Summary

A multi-agent code review of the v2.9.0 diff (`15f2a95..c3e2388`) surfaced two real regressions and three workflow hardening issues. All fixed here.

### Confirmed regressions

- **`internal/serializer/serializer.go`** — the widened spacing emit gate from #77 opened the whole `<w:spacing>` element on `beforeSet`/`afterSet` alone, but `Line`/`LineRule` were filled unconditionally inside it. `lineSpacingRuleToString` never returns nil, and an untouched `LineSpacing` still carries the constructor's `{Auto, 240}` defaults — so a paragraph that only called `SetSpacingAfter(0)` gained an unintended direct `w:line="240" w:lineRule="auto"`, silently overriding a style's real line spacing (e.g. 1.5 lines becomes single-spaced). `Line`/`LineRule` are now gated by their own departure-from-default check, independent of before/after.
- **`pkg/template/placeholder.go`** — `locateGroupOffset`'s `offset <= l` is correct only for a match's exclusive end offset. Applied to the start offset too, it resolved a match beginning exactly at a run boundary to the end of the *previous* run instead of the start of the next one — the ordinary Word `"Hello "` + `"{{Name}}"` split reported a `RunIndex` that doesn't contain the placeholder, and the obvious `runs[loc.RunIndex].Text()[loc.StartOffset:loc.EndOffset]` panics. It also misattributed matches following a leading empty run. The function now takes an `isEnd` flag: strict `<` for the start lookup (which also correctly skips empty runs), inclusive `<=` only for the end lookup. `Location`'s doc comment now states the contract explicitly: when `RunIndex == EndRunIndex`, single-run slicing works exactly as it did before v2.9.0; a difference means the match is genuinely split and callers should use `FullMatch` or `MergeTemplate` instead.

### Workflow hardening

- **`npm-publish.yml`** — `inputs.version` was interpolated directly into `run:` shell scripts in a job holding `NPM_TOKEN` and `id-token: write`. Now bound via `env:` and validated against a semver pattern before checkout uses it as a tag ref. Also dropped the now-redundant `release: types: [published]` trigger — `release.yml`'s `publish-npm` job already calls this workflow unconditionally, so once `RELEASE_PAT` is configured both paths would fire for the same tag and race two `npm publish` calls, with the loser's `403` misdiagnosed by `notify-on-failure` as an expired `NPM_TOKEN`.
- **`release.yml`** — the `RELEASE_PAT` emptiness check expanded the secret directly into a shell `if [ -z "..." ]` condition; bound via `env:` instead.

### Cleanup

- **`examples/14_mail_merge/main.go`** — removed a second, now-dead "re-open because FindPlaceholders mutates" workaround at step 4 that #75 already made unnecessary (a sibling copy was removed in that PR, this one was missed). It discarded any reopen error, risking a nil-pointer panic on `MergeTemplate` if the reopen ever failed.

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l ...`
- [x] `go test ./... -count=1` — all packages pass
- [x] `cd examples && ./test_all.sh` — 10/10, plus manually ran `14_mail_merge` end to end
- [x] `actionlint .github/workflows/release.yml .github/workflows/npm-publish.yml` — clean
- [x] Both Go regression tests confirmed to fail against the pre-fix code (temporarily reverted, reran, restored) before being included here