### PR TITLE
release: prepare v2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## v2.9.1 — 2026-07-27
+
+### Fixed
+
+- **An explicit spacing override no longer clobbers a style's line spacing.** v2.9.0's fix for explicit-zero spacing widened the emit gate to fire whenever `spacingBefore`/`spacingAfter` was explicitly set, but `Line`/`LineRule` were filled into the same `<w:spacing>` element unconditionally — a paragraph that only called `SetSpacingAfter(0)` gained an unintended direct `w:line="240" w:lineRule="auto"`, silently overriding a style's real line spacing (e.g. 1.5 lines rendering as single-spaced). `Line`/`LineRule` are now gated by their own departure-from-default check, independent of before/after.
+- **`FindPlaceholders`'s reported `Location` is now correct for the common, non-split case.** v2.9.0's offset translation used an inclusive comparison for both the start and end of a match; applied to the start, it misattributed a match beginning exactly at a run boundary — the ordinary Word `"Hello "` + `"{{Name}}"` split — to the end of the *previous* run instead of the start of the one actually holding it, so `RunIndex`/`StartOffset` pointed at text that didn't contain the placeholder and slicing it could panic. It also misattributed matches following a leading empty run. `Location`'s doc comment now states the contract explicitly: when `RunIndex == EndRunIndex`, single-run slicing works exactly as it did before v2.9.0.
+
+### Changed
+
+- **CI is now resilient to the npm lock's platform-package gap between releases.** `npm/package-lock.json` is regenerated with `npm install --package-lock-only` during release prep, which necessarily drops the platform-package entries (they don't exist on the registry yet at that point) — but `npm ci` requires every declared `optionalDependency` to have a resolved lock entry, so CI's Node.js Tests job failed on any commit between a release-prep commit and the next lock regeneration. This reproduced identically after both the v2.8.0 and v2.9.0 release commits. CI now uses `npm install`, which reconciles instead of requiring exact pre-sync.
+- **Hardened the release workflows.** `inputs.version` is now bound via `env:` and validated against a semver pattern before use, instead of being interpolated directly into `run:` shell scripts in a job holding `NPM_TOKEN` and `id-token: write`. Dropped the now-redundant `release: types: [published]` trigger from `npm-publish.yml` — `release.yml`'s `publish-npm` job already calls it unconditionally (see v2.9.0), so keeping both would race two `npm publish` calls for the same tag once `RELEASE_PAT` is configured. The `RELEASE_PAT` emptiness check in `release.yml` is also now bound via `env:` rather than expanded directly into a shell condition.
+
+### Compatibility
+
+- No public Go, CLI protocol, or Node.js API changed.
+- Generated output for a paragraph that both carries a style with non-default line spacing *and* explicitly sets only `spacingBefore`/`spacingAfter` (not line spacing) changes back to what v2.9.0 intended: the style's line spacing is inherited again instead of being overridden by an unintended direct `0/240/auto`. Any other paragraph is unaffected.
+- `FindPlaceholders`/`FindPlaceholdersCustom`/`PlaceholderNames`/`ValidateTemplate` report different (corrected) `RunIndex`/`StartOffset` values for matches that sit exactly at a run boundary or follow a leading empty run — a narrow input shape most callers won't have hit, since v2.9.0 shipped hours before this fix.
+
+---
+
 ## v2.9.0 — 2026-07-27
 
 ### Fixed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration Guide: v1 → docxgo v2
 
-**Current target:** v2.9.0
+**Current target:** v2.9.1
 **Minimum Go version:** 1.23
 
 This guide covers migration from the historical `fumiama/go-docx` API to the
@@ -27,7 +27,7 @@ For the complete current API, see the [API guide](docs/V2_API_GUIDE.md) and
 ## 1. Update the module
 
 ```bash
-go get github.com/mmonterroca/docxgo/v2@v2.9.0
+go get github.com/mmonterroca/docxgo/v2@v2.9.1
 go mod tidy
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Since v2.7.0 it also ships a JSON-RPC command-line interface and a Node.js wrapp
 - **Proofing language** — `WithLanguage` / `WithLanguageEx` for spell-check, grammar, hyphenation
 - **Production quality** — clean architecture, explicit errors, thread-safe internals
 
-**Status:** v2.9.0 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
+**Status:** v2.9.1 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
 
 ---
 

--- a/RELEASE_NOTES_v2.9.1.md
+++ b/RELEASE_NOTES_v2.9.1.md
@@ -1,0 +1,118 @@
+# Release Notes - v2.9.1
+
+**Release Date:** July 27, 2026
+
+## Summary
+
+v2.9.1 is a same-day patch on v2.9.0. A multi-agent code review of that
+release's diff caught two real regressions before they reached many users:
+an unintended direct line-spacing override, and an off-by-one in the new
+`FindPlaceholders` location reporting. Both are fixed here, along with three
+CI/workflow hardening issues the same review surfaced.
+
+No public API changed. If you're already on v2.9.0, upgrade — there's no
+reason to stay on it.
+
+## Fixed
+
+### An explicit spacing override no longer clobbers a style's line spacing
+
+v2.9.0 fixed a real bug: `SetSpacingAfter(0)` on a paragraph carrying a style
+with non-zero spacing used to be silently dropped, with the style's value
+winning over the caller's explicit zero. The fix widened the condition for
+emitting a direct `<w:spacing>` element to include "the caller explicitly set
+spacingBefore or spacingAfter" — but the code that builds that element filled
+in `Line` and `LineRule` unconditionally, regardless of *why* the element was
+being emitted.
+
+The consequence: a paragraph that called only `SetSpacingAfter(0)` — never
+touching line spacing at all — gained an unintended direct
+`w:line="240" w:lineRule="auto"`. If that paragraph's style set a real line
+spacing (say, 1.5 lines for body text), the direct formatting silently
+overrode it, rendering the paragraph single-spaced instead.
+
+`Line` and `LineRule` are now gated by their own check — whether line spacing
+itself was explicitly set or departs from the document defaults — independent
+of whether `Before`/`After` triggered the element. Setting only
+`spacingAfter` now emits only `w:after`, exactly as intended.
+
+### FindPlaceholders reports the correct Location for the common case
+
+v2.9.0 made `FindPlaceholders` stop mutating the documents it scans (see the
+v2.9.0 notes). To find placeholders Word split across multiple runs without
+merging them, it translates a match's position in a virtual concatenated text
+back to the run and offset that actually contains it.
+
+That translation used the same rule — "offset at or before this run's length
+belongs to this run" — for both the start and the end of a match. That rule
+is correct for the end (an exclusive offset), but wrong for the start: a
+match beginning exactly where one run ends and the next begins would resolve
+to the end of the *earlier* run instead of the start of the run that actually
+holds it. This isn't an exotic edge case — `"Hello "` + `"{{Name}}"` is an
+ordinary way for Word to split a paragraph, with the placeholder living
+entirely in the second run. The bug also misattributed placeholders following
+a leading empty run.
+
+Concretely, this meant `Location.RunIndex`/`StartOffset` could point at a run
+that doesn't contain the placeholder at all, and the natural way to use them —
+`runs[loc.RunIndex].Text()[loc.StartOffset:loc.EndOffset]` — could panic with
+a slice-bounds error.
+
+The start and end lookups are now distinct: the end uses an inclusive
+comparison (as before), the start uses a strict one, which also correctly
+skips past empty runs to the run that actually starts the match.
+`template.Location`'s doc comment now states the contract precisely: when
+`RunIndex == EndRunIndex`, slicing a single run works exactly as it did in
+every release before v2.9.0. A difference means the match is genuinely split
+across runs — use `FullMatch`, or `MergeTemplate` to replace it.
+
+## Changed
+
+### CI is now resilient to a gap in the release process
+
+`npm/package-lock.json` is regenerated during release prep with
+`npm install --package-lock-only`, which necessarily drops the
+platform-package entries (`@mmonterroca/docxgo-darwin-arm64` and siblings) —
+they don't exist on the npm registry yet at the moment the release commit is
+made. `npm ci`, used by CI's Node.js Tests job, requires every declared
+`optionalDependency` to already have a resolved entry in the lock, so it
+failed on any commit sitting between a release-prep commit and whenever the
+lock next got regenerated. This reproduced identically after both the v2.8.0
+and v2.9.0 release commits landed on `master`.
+
+CI now uses `npm install`, which reconciles the manifest against the lock
+instead of demanding they already agree exactly. This is what CI actually
+needs here — correctness of the Node.js wrapper's own test suite, not
+lockfile reproducibility for a gap the release process itself produces every
+cycle.
+
+### Hardened the release workflows
+
+- `inputs.version` in `npm-publish.yml` — reachable via manual
+  `workflow_dispatch` — is now bound through `env:` and validated against a
+  semantic-version pattern before being used, instead of being interpolated
+  directly into `run:` shell scripts in a job that holds `NPM_TOKEN` and
+  `id-token: write`.
+- Removed the now-redundant `release: types: [published]` trigger from
+  `npm-publish.yml`. v2.9.0 added a `publish-npm` job to `release.yml` that
+  calls `npm-publish.yml` directly and unconditionally; keeping the old event
+  trigger too meant that once `RELEASE_PAT` is configured (see v2.9.0's
+  notes), a single tag would fire the publish workflow twice, racing two
+  `npm publish` calls for the same version.
+- `release.yml`'s `RELEASE_PAT` emptiness check now reads the secret through
+  `env:` rather than expanding it directly into a shell `if` condition.
+
+## Compatibility
+
+- **No public Go, CLI protocol, or Node.js API changed.**
+- **Generated output** for a paragraph that both carries a style with
+  non-default line spacing *and* explicitly sets only `spacingBefore`/
+  `spacingAfter` (never touching line spacing) changes back to what v2.9.0
+  intended: the style's line spacing is inherited again, rather than being
+  overridden by an unintended direct `0/240/auto`. No other paragraph shape
+  is affected.
+- **`FindPlaceholders`/`FindPlaceholdersCustom`/`PlaceholderNames`/
+  `ValidateTemplate`** report corrected `RunIndex`/`StartOffset` for matches
+  sitting exactly at a run boundary or following a leading empty run — a
+  narrow shape unlikely to have been observed in the few hours v2.9.0 shipped
+  before this fix.

--- a/doc.go
+++ b/doc.go
@@ -289,7 +289,7 @@ This library generates Office Open XML (OOXML) documents compatible with:
 
 # Version
 
-Current version: 2.9.0 (see the Version constant for the authoritative value).
+Current version: 2.9.1 (see the Version constant for the authoritative value).
 
 This is a major rewrite of the original go-docx library with breaking changes.
 See the migration guide in MIGRATION.md for details.

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -62,7 +62,7 @@ Verify the installation:
 
 ```bash
 docxgo version
-# 2.9.0
+# 2.9.1
 ```
 
 ---
@@ -194,7 +194,7 @@ Returns version, protocol version, and platform information.
 ```json
 {
   "name": "docxgo",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "protocolVersion": "1.0",
   "goVersion": "go1.23.0",
   "platform": "darwin",
@@ -247,7 +247,7 @@ Executes multiple RPC requests in a single roundtrip. Each sub-request is proces
 {
   "responses": [
     { "result": { "status": "ok" } },
-    { "result": { "name": "docxgo", "version": "2.9.0", ... } },
+    { "result": { "name": "docxgo", "version": "2.9.1", ... } },
     { "error": { "code": "NOT_FOUND", "message": "..." } }
   ]
 }

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,7 +1,7 @@
 # docxgo v2 Implementation Status
 
 **Last Updated**: July 2026
-**Version**: 2.9.0 (Stable)
+**Version**: 2.9.1 (Stable)
 
 This document tracks the implementation status of all v2 features, helping developers understand what's available, what's in progress, and what's planned.
 
@@ -38,6 +38,7 @@ All development phases have been completed. The library has gone through multipl
 | v2.7.1      | Jul 2026 | Tech themes discoverable via public API (7 total), `docxgo` output branding, doc/provenance alignment |
 | v2.8.0      | Jul 2026 | Final MIT provenance determination, corrected notices, license-complete release artifacts |
 | v2.9.0      | Jul 2026 | Fixed npm-publish cascade, read-only `FindPlaceholders`, explicit zero spacing on styled paragraphs |
+| v2.9.1      | Jul 2026 | Code-review fixes: spacing emit gate no longer clobbers style line spacing, placeholder Location offsets corrected |
 
 ---
 
@@ -418,5 +419,5 @@ Want to help implement missing features? See [CONTRIBUTING.md](../CONTRIBUTING.m
 ---
 
 **Last Updated**: July 2026
-**Status**: Production Ready (v2.9.0 Stable)
+**Status**: Production Ready (v2.9.1 Stable)
 **Maintained by**: Misael Monterroca ([@mmonterroca](https://github.com/mmonterroca))

--- a/docs/README.md
+++ b/docs/README.md
@@ -224,4 +224,4 @@ See: IMPLEMENTATION_STATUS.md - Features list
 ---
 
 **Last Updated**: July 2026  
-**Documentation Version**: v2.9.0
+**Documentation Version**: v2.9.1

--- a/docs/V2_API_GUIDE.md
+++ b/docs/V2_API_GUIDE.md
@@ -1,6 +1,6 @@
 # docxgo v2 API Guide
 
-**Version**: 2.9.0
+**Version**: 2.9.1
 **Last Updated**: July 2026
 
 ---
@@ -994,4 +994,4 @@ See [`examples/14_mail_merge/`](../examples/14_mail_merge/) for a complete worki
 ---
 
 **Last Updated**: July 2026
-**Version**: 2.9.0
+**Version**: 2.9.1

--- a/docs/V2_DESIGN.md
+++ b/docs/V2_DESIGN.md
@@ -1,8 +1,8 @@
 # docxgo v2 - Clean Architecture Design
 
-**Status**: ✅ v2.9.0 Stable
+**Status**: ✅ v2.9.1 Stable
 **Progress**: Production Ready (all core features complete)
-**Latest Release**: v2.9.0 (July 2026)
+**Latest Release**: v2.9.1 (July 2026)
 **Breaking Changes**: Yes (major version bump from original fork)
 
 > **Project Note**: This project is a substantially rewritten successor to `fumiama/go-docx`, focused on clean architecture, type safety, and modern Go practices. The Git history includes AGPL-era upstream snapshots; the completed [provenance audit](./PROVENANCE_AUDIT.md) determines that the current MIT release contains no protectable AGPL implementation.
@@ -1344,7 +1344,7 @@ See [CREDITS.md](../CREDITS.md) for complete project history.
 ---
 
 **Last Updated**: July 2026
-**Status**: ✅ v2.9.0 Stable
+**Status**: ✅ v2.9.1 Stable
 **Progress**: Production Ready (all core features complete)
 
 **Current State:**

--- a/docx.go
+++ b/docx.go
@@ -88,7 +88,7 @@ func reconstructFromPackage(pkg *reader.Package, op string) (domain.Document, er
 }
 
 // Version is the library version.
-const Version = "2.9.0"
+const Version = "2.9.1"
 
 // Common color constants exported for convenience.
 var (

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mmonterroca/docxgo",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mmonterroca/docxgo",
-      "version": "2.9.0",
+      "version": "2.9.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.3",
@@ -17,11 +17,11 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "@mmonterroca/docxgo-darwin-arm64": "2.9.0",
-        "@mmonterroca/docxgo-darwin-x64": "2.9.0",
-        "@mmonterroca/docxgo-linux-arm64": "2.9.0",
-        "@mmonterroca/docxgo-linux-x64": "2.9.0",
-        "@mmonterroca/docxgo-win32-x64": "2.9.0"
+        "@mmonterroca/docxgo-darwin-arm64": "2.9.1",
+        "@mmonterroca/docxgo-darwin-x64": "2.9.1",
+        "@mmonterroca/docxgo-linux-arm64": "2.9.1",
+        "@mmonterroca/docxgo-linux-x64": "2.9.1",
+        "@mmonterroca/docxgo-win32-x64": "2.9.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -465,71 +465,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/@mmonterroca/docxgo-darwin-arm64": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-darwin-arm64/-/docxgo-darwin-arm64-2.9.0.tgz",
-      "integrity": "sha512-CjOK4fj6J7OS2+JC93T5PPZw8MvCABJun0xyvrLzcwE+ZBA9cETaxCc2yCe921PwtD9txFyzLshReQMn+kKvZQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@mmonterroca/docxgo-darwin-x64": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-darwin-x64/-/docxgo-darwin-x64-2.9.0.tgz",
-      "integrity": "sha512-YfUutquHpY2pP1J2JOumI6mWVT9r9u3Br/GUjXGKNNudBYGO1K79XnnvcOZUi/NLd2QVXWpo53qSKgpZ+Wh3Bw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@mmonterroca/docxgo-linux-arm64": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-linux-arm64/-/docxgo-linux-arm64-2.9.0.tgz",
-      "integrity": "sha512-1BhrWxMVIkddxT2k9kq4Z7AH9nt+imVC+64o2UvaDzRm6v/6WXJ+4sYWGdYs4GopX6wQyOuHdJiD/ItGzqainw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@mmonterroca/docxgo-linux-x64": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-linux-x64/-/docxgo-linux-x64-2.9.0.tgz",
-      "integrity": "sha512-5c/1QyUx4/LFO4jtkQM50P6SStf8NiBIBPJBXSsQQG4S8lNxOSFAX2LYd3+J50A+FN8wpg/uE0T/fSgoQI18VA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@mmonterroca/docxgo-win32-x64": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@mmonterroca/docxgo-win32-x64/-/docxgo-win32-x64-2.9.0.tgz",
-      "integrity": "sha512-TBZlAn0EHxp9PFdE6n+DzXAXfQ+JF9rSgKWAYiIkGkwIvaldjlCggQyEWXtsugVYQzDoavFfiQJsQXF1wyQYkg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@types/node": {
       "version": "25.3.3",

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmonterroca/docxgo",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "Node.js wrapper for docxgo — create and manipulate Word documents via JSON-RPC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -50,10 +50,10 @@
     "typescript": "^5.4.0"
   },
   "optionalDependencies": {
-    "@mmonterroca/docxgo-darwin-arm64": "2.9.0",
-    "@mmonterroca/docxgo-darwin-x64": "2.9.0",
-    "@mmonterroca/docxgo-linux-arm64": "2.9.0",
-    "@mmonterroca/docxgo-linux-x64": "2.9.0",
-    "@mmonterroca/docxgo-win32-x64": "2.9.0"
+    "@mmonterroca/docxgo-darwin-arm64": "2.9.1",
+    "@mmonterroca/docxgo-darwin-x64": "2.9.1",
+    "@mmonterroca/docxgo-linux-arm64": "2.9.1",
+    "@mmonterroca/docxgo-linux-x64": "2.9.1",
+    "@mmonterroca/docxgo-win32-x64": "2.9.1"
   }
 }


### PR DESCRIPTION
## Summary

Same-day patch release on v2.9.0, shipping the two correctness fixes from #79 (a multi-agent review of the v2.9.0 diff) plus workflow/CI hardening:

- Version constant, npm package metadata/lock, and all doc version strings bumped 2.9.0 → 2.9.1.
- `CHANGELOG.md` and `RELEASE_NOTES_v2.9.1.md` cover both fixes.
- Patch rather than minor: no public API changed, no new intentional behavior — this restores what v2.9.0 already intended to ship (spacing emit gate no longer clobbers style line spacing; `FindPlaceholders` Location offsets corrected at run boundaries).
- `npm/package-lock.json` regenerated with `npm install --package-lock-only` for the version bump — expected to drop the not-yet-published platform-package entries again; restored at publish time as usual.

## Test plan

- [x] `go build ./... && go vet ./...`
- [x] `go test ./... -count=1` — all packages pass
- [x] `cd examples && ./test_all.sh` — 10/10
- [x] `cd npm && npm install` succeeds against the regenerated lock (CI now uses `npm install`, not `npm ci`, per #79)