### PR TITLE
fix: RELEASE_PAT was configured but never actually used

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,15 +125,22 @@ jobs:
           prerelease: ${{ contains(steps.version.outputs.version, 'beta') || contains(steps.version.outputs.version, 'alpha') || contains(steps.version.outputs.version, 'rc') }}
           generate_release_notes: true
           files: release-assets/*
-        env:
-          # Ideally a real PAT (repo-scoped "Contents: Read and write" is
-          # enough) so the release shows a real author instead of
-          # github-actions[bot] — see the RELEASE_PAT check above. No longer
-          # load-bearing for npm publishing: the publish-npm job below calls
-          # npm-publish.yml directly instead of relying on the "release:
-          # published" event, which a GITHUB_TOKEN-authored release can't
-          # fire (GitHub's anti-recursion protection).
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+          # softprops/action-gh-release's `token` input defaults to
+          # `${{ github.token }}` in its own action.yml, and that default is
+          # resolved by the Actions runtime before the action ever runs — so
+          # the action always sees a non-empty token input regardless of any
+          # env var we set on this step. Passing RELEASE_PAT via `env:
+          # GITHUB_TOKEN` (the previous approach) was silently ignored; it
+          # must be passed as this `with: token:` input to actually override
+          # the default. An empty RELEASE_PAT is treated by the action as
+          # unset and falls back to `github.token` — same degrade-to-bot-
+          # author behavior as before, just via the mechanism that actually
+          # works. No longer load-bearing for npm publishing either way: the
+          # publish-npm job below calls npm-publish.yml directly instead of
+          # relying on the "release: published" event, which a
+          # GITHUB_TOKEN-authored release can't fire (GitHub's anti-recursion
+          # protection).
+          token: ${{ secrets.RELEASE_PAT }}
 
   publish-npm:
     name: Publish to npm


### PR DESCRIPTION
## Summary

- `RELEASE_PAT` has been configured as a repo secret since before v2.9.0, but every release (v2.9.0, v2.9.1) still shows `github-actions[bot]` as the author. Confirmed via the run logs for v2.9.1: the "Check RELEASE_PAT is configured" step's warning never fires (the secret is non-empty), yet the release is still bot-authored.
- Root cause: `softprops/action-gh-release`'s `token` input defaults to `${{ github.token }}` in its own `action.yml`. That default expression is resolved by the Actions runtime at step-input-resolution time, before the action's code ever runs — so the action always observes a non-empty `token` input, regardless of what we set via `env: GITHUB_TOKEN` on the step. Our previous fix (in v2.9.1, for #72) set `RELEASE_PAT` that way and it was silently ineffective.
- Fix: pass `RELEASE_PAT` as the `token` **input** instead of an env var, which is the mechanism the action actually reads. An empty `RELEASE_PAT` is documented to be treated as unset by the action, so the existing degrade-to-bot-author warning path is unchanged.

## Test plan

- [x] `actionlint .github/workflows/release.yml` passes
- [ ] Next tag push shows the release authored by a real user (assuming `RELEASE_PAT` holds a valid PAT with `Contents: Read and write`)