### PR TITLE
fix: reject double quotes in generated field-code arguments

### DIFF
--- a/cmd/docxgo/handlers_test.go
+++ b/cmd/docxgo/handlers_test.go
@@ -891,6 +891,37 @@ func TestHandleCreate_UnknownTheme(t *testing.T) {
 	}
 }
 
+// TestHandleCreate_FieldStyleWithQuoteRejected covers the RPC-reachable path
+// for the field-code injection CodeQL flagged (go/unsafe-quoting): a quote in
+// a styleRef field's style name used to break out of the quoted STYLEREF
+// argument in the generated field code.
+func TestHandleCreate_FieldStyleWithQuoteRejected(t *testing.T) {
+	s := newServer()
+	params := map[string]interface{}{
+		"content": []interface{}{
+			map[string]interface{}{
+				"type": "paragraph",
+				"runs": []interface{}{
+					map[string]interface{}{
+						"field": map[string]interface{}{
+							"type":  "styleRef",
+							"style": `Heading 1" \* MERGEFORMAT "x`,
+						},
+					},
+				},
+			},
+		},
+		"output": "buffer",
+	}
+	resp := s.dispatch(makeRequest("t1", "document.create", params))
+	if resp.Error == nil {
+		t.Fatal("expected error for a style name containing a double quote")
+	}
+	if resp.Error.Code != "VALIDATION_ERROR" {
+		t.Errorf("expected VALIDATION_ERROR, got %s", resp.Error.Code)
+	}
+}
+
 // ─── Nil params tests ────────────────────────────────────────────────────────
 
 func TestHandleCreate_NilParams(t *testing.T) {

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -1052,6 +1052,12 @@ Style reference field (for running headers):
 }
 ```
 
+`url`, `style`, and `options.levels` (the TOC field's heading-range switch) are
+rejected if they contain a double quote — they are embedded inside a quoted
+argument of the generated field code, and a literal `"` would otherwise break
+out of it. The request fails with a validation error rather than producing a
+corrupted or exploitable field.
+
 **Image object:**
 
 ```json

--- a/docs/V2_API_GUIDE.md
+++ b/docs/V2_API_GUIDE.md
@@ -509,6 +509,13 @@ current image decoding pipeline.
 
 Fields are dynamic elements that Word updates automatically.
 
+`NewHyperlinkField`'s `url`, `NewStyleRefField`'s `styleName`, and
+`NewTOCField`'s `"levels"` switch are embedded inside a quoted argument of the
+generated field code. None of these constructors return an error, so a value
+containing a double quote does not panic — it is rejected silently at
+construction (the field keeps its safe default code) and the rejection
+surfaces as an error from `run.AddField`, which callers should check.
+
 #### Available Field Types
 
 ```go

--- a/internal/core/field.go
+++ b/internal/core/field.go
@@ -24,6 +24,12 @@ type docxField struct {
 	result     string
 	isDirty    bool // Indicates if field needs recalculation
 	properties map[string]string
+	// err records a rejection from one of the New*Field constructors — a
+	// caller-supplied value that would have broken out of the field code's
+	// quoted argument (e.g. a `"` in a hyperlink URL or a STYLEREF style
+	// name). The field is left with its safe default code; run.AddField
+	// checks this via ValidationError and refuses to attach the field.
+	err error
 }
 
 // NewField creates a new field with the specified type.
@@ -62,28 +68,63 @@ func NewTOCField(switches map[string]string) domain.Field {
 	}
 
 	// Rebuild code with switches
-	field.code = field.buildTOCCode()
+	code, err := field.buildTOCCode()
+	if err != nil {
+		field.err = err
+		return field
+	}
+	field.code = code
 
 	return field
 }
 
 // NewHyperlinkField creates a hyperlink field.
+//
+// url must not contain a double quote: it is interpolated inside a quoted
+// field-code argument, and Word's field-code syntax has no escape the
+// docxgo reader can round-trip (see extractQuotedStrings in
+// internal/reader/reconstruct.go). A url containing one is rejected — the
+// field is left with a safe default code and no url/display property, and
+// run.AddField refuses to attach it — rather than producing a corrupted or
+// injectable field code.
 func NewHyperlinkField(url, displayText string) domain.Field {
 	field := NewField(domain.FieldTypeHyperlink).(*docxField)
+	safe := strings.ReplaceAll(url, `"`, "")
+	if safe != url {
+		field.err = errors.NewValidationError("NewHyperlinkField", "url", url,
+			`url must not contain a double quote`)
+		return field
+	}
 	field.properties["url"] = url
 	field.properties["display"] = displayText
-	field.code = fmt.Sprintf(`HYPERLINK "%s"`, url)
+	field.code = fmt.Sprintf(`HYPERLINK "%s"`, safe)
 	field.result = displayText
 	field.isDirty = false
 	return field
 }
 
-// NewStyleRefField creates a STYLEREF field.
+// NewStyleRefField creates a STYLEREF field. styleName is subject to the
+// same quoting constraint as NewHyperlinkField's url.
 func NewStyleRefField(styleName string) domain.Field {
 	field := NewField(domain.FieldTypeStyleRef).(*docxField)
+	safe := strings.ReplaceAll(styleName, `"`, "")
+	if safe != styleName {
+		field.err = errors.NewValidationError("NewStyleRefField", "styleName", styleName,
+			`styleName must not contain a double quote`)
+		return field
+	}
 	field.properties["style"] = styleName
-	field.code = fmt.Sprintf(`STYLEREF "%s"`, styleName)
+	field.code = fmt.Sprintf(`STYLEREF "%s"`, safe)
 	return field
+}
+
+// ValidationError reports a rejection recorded by NewHyperlinkField,
+// NewStyleRefField, or NewTOCField. run.AddField checks this via a type
+// assertion and refuses to attach a field that failed construction.
+func (f *docxField) ValidationError() error {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.err
 }
 
 // Type returns the field type.
@@ -212,13 +253,19 @@ func (f *docxField) getDefaultCode() string {
 	}
 }
 
-// buildTOCCode builds a TOC field code with switches.
-func (f *docxField) buildTOCCode() string {
+// buildTOCCode builds a TOC field code with switches. levels is subject to
+// the same quoting constraint as NewHyperlinkField's url.
+func (f *docxField) buildTOCCode() (string, error) {
 	code := constants.FieldCodeTOC
 
 	// Heading levels (default 1-3)
 	if levels, ok := f.properties["levels"]; ok {
-		code += fmt.Sprintf(` \\o "%s"`, levels)
+		safe := strings.ReplaceAll(levels, `"`, "")
+		if safe != levels {
+			return "", errors.NewValidationError("NewTOCField", "levels", levels,
+				`levels must not contain a double quote`)
+		}
+		code += fmt.Sprintf(` \\o "%s"`, safe)
 	} else {
 		code += ` \\o "1-3"`
 	}
@@ -242,7 +289,7 @@ func (f *docxField) buildTOCCode() string {
 	// Use styles
 	code += ` \\u`
 
-	return code
+	return code, nil
 }
 
 // SetProperty sets a field property (for advanced customization).

--- a/internal/core/field_test.go
+++ b/internal/core/field_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/mmonterroca/docxgo/v2/domain"
+	"github.com/mmonterroca/docxgo/v2/pkg/constants"
 )
 
 func TestNewField(t *testing.T) {
@@ -168,6 +169,102 @@ func TestNewStyleRefField(t *testing.T) {
 	code := field.Code()
 	if !strings.Contains(code, "STYLEREF") || !strings.Contains(code, styleName) {
 		t.Errorf("Code() = %q, want to contain STYLEREF and %q", code, styleName)
+	}
+}
+
+// newTestRun returns a fresh run inside a scratch document, for tests that
+// need to exercise run.AddField's validation.
+func newTestRun(t *testing.T) domain.Run {
+	t.Helper()
+	doc := NewDocument()
+	para, err := doc.AddParagraph()
+	if err != nil {
+		t.Fatalf("AddParagraph() error = %v", err)
+	}
+	run, err := para.AddRun()
+	if err != nil {
+		t.Fatalf("AddRun() error = %v", err)
+	}
+	return run
+}
+
+// TestNewHyperlinkFieldRejectsQuote pins the fix for the field-code
+// injection CodeQL flagged (go/unsafe-quoting): a url containing a double
+// quote used to break out of the quoted HYPERLINK argument. The
+// strings.Contains style used elsewhere in this file would pass on an
+// injected payload, so this asserts Code() by exact equality.
+func TestNewHyperlinkFieldRejectsQuote(t *testing.T) {
+	url := `https://example.com/" INCLUDETEXT "C:\x`
+
+	field := NewHyperlinkField(url, "display")
+
+	if got, want := field.Code(), "HYPERLINK"; got != want {
+		t.Errorf("Code() = %q, want %q (safe default, not the injected value)", got, want)
+	}
+
+	df := field.(*docxField)
+	if _, ok := df.GetProperty("url"); ok {
+		t.Error("GetProperty(url) = ok, want the property to be unset on rejection")
+	}
+
+	run := newTestRun(t)
+	if err := run.AddField(field); err == nil {
+		t.Error("AddField() error = nil, want a validation error for the rejected field")
+	}
+}
+
+// TestNewStyleRefFieldRejectsQuote is the STYLEREF counterpart. Unlike
+// HYPERLINK, STYLEREF always reaches word/document.xml unconditionally
+// (there's no relationship-branch shadowing), so this is the more directly
+// exploitable of the two.
+func TestNewStyleRefFieldRejectsQuote(t *testing.T) {
+	styleName := `Heading 1" \* MERGEFORMAT "x`
+
+	field := NewStyleRefField(styleName)
+
+	if got, want := field.Code(), `STYLEREF "Heading 1"`; got != want {
+		t.Errorf("Code() = %q, want %q (safe default, not the injected value)", got, want)
+	}
+
+	run := newTestRun(t)
+	if err := run.AddField(field); err == nil {
+		t.Error("AddField() error = nil, want a validation error for the rejected field")
+	}
+}
+
+// TestNewTOCFieldRejectsInvalidLevels covers the third CodeQL-flagged sink:
+// the \o switch built from the caller-supplied "levels" property.
+func TestNewTOCFieldRejectsInvalidLevels(t *testing.T) {
+	field := NewTOCField(map[string]string{"levels": `1-3" \c "Figure`})
+
+	// field.go builds \\o (double backslash) as a raw string literal today —
+	// that's a separate, pre-existing quirk (tracked separately), not part
+	// of this fix. The default-else branch in buildTOCCode is the exact
+	// bytes this must match.
+	want := constants.FieldCodeTOC + ` \\o "1-3" \\h \\z \\u`
+	if got := field.Code(); got != want {
+		t.Errorf("Code() = %q, want %q (safe default, not the injected value)", got, want)
+	}
+
+	run := newTestRun(t)
+	if err := run.AddField(field); err == nil {
+		t.Error("AddField() error = nil, want a validation error for the rejected field")
+	}
+}
+
+// TestNewTOCFieldAcceptsValidLevels guards against the quote guard being too
+// aggressive: a legitimate levels value must still work.
+func TestNewTOCFieldAcceptsValidLevels(t *testing.T) {
+	field := NewTOCField(map[string]string{"levels": "1-5"})
+
+	want := constants.FieldCodeTOC + ` \\o "1-5" \\h \\z \\u`
+	if got := field.Code(); got != want {
+		t.Errorf("Code() = %q, want %q", got, want)
+	}
+
+	run := newTestRun(t)
+	if err := run.AddField(field); err != nil {
+		t.Errorf("AddField() error = %v, want nil for a valid field", err)
 	}
 }
 

--- a/internal/core/run.go
+++ b/internal/core/run.go
@@ -209,6 +209,12 @@ func (r *run) AddField(field domain.Field) error {
 		return errors.InvalidArgument("Run.AddField", "field", nil, "field cannot be nil")
 	}
 
+	if validator, ok := field.(interface{ ValidationError() error }); ok {
+		if err := validator.ValidationError(); err != nil {
+			return errors.Wrap(err, "Run.AddField")
+		}
+	}
+
 	if field.Type() == domain.FieldTypeHyperlink {
 		accessor, ok := field.(interface {
 			GetProperty(string) (string, bool)


### PR DESCRIPTION
## Summary

- `NewHyperlinkField`'s `url`, `NewStyleRefField`'s `styleName`, and `NewTOCField`'s `"levels"` switch were interpolated unescaped inside a quoted argument of the generated Word field code (`HYPERLINK "%s"`, `STYLEREF "%s"`, `\o "%s"`). A value containing a double quote broke out of the quoted argument. Flagged by CodeQL (`go/unsafe-quoting`, critical) — see #85.
- `STYLEREF` and the TOC `\o` switch reach `word/document.xml` unconditionally on every save; `HYPERLINK` is currently shadowed by the relationship-based serialization path but `Code()` is public and the same construction is repeated in the reader on untrusted input, so it's fixed too.
- Escaping was ruled out: the reader's field-code parser (`extractQuotedStrings`, `reconstruct.go`) splits on bare quotes with no escape awareness, so any `\"` scheme would corrupt docxgo's own open→save round-trip. Values containing a quote are rejected instead.
- None of the three constructors return an error today, so rejection is recorded on the field and surfaces from `run.AddField` — the one chokepoint every field must pass through to reach a run's XML.
- Guarded with `strings.ReplaceAll` rather than an early-return `strings.Contains` check: CodeQL's `go/unsafe-quoting` models a `ReplaceAll`-shaped sanitizer as a barrier but does not model guard-and-return, so an early-return form would have left the alerts open despite being semantically correct.

Closes #85.

## Test plan

- [x] New regression tests in `internal/core/field_test.go` (`TestNewHyperlinkFieldRejectsQuote`, `TestNewStyleRefFieldRejectsQuote`, `TestNewTOCFieldRejectsInvalidLevels`, `TestNewTOCFieldAcceptsValidLevels`) — each confirmed failing against pre-fix code via `git stash`, with exact-equality assertions on `Code()` (the existing `strings.Contains` style would pass on an injected payload).
- [x] `TestHandleCreate_FieldStyleWithQuoteRejected` in `cmd/docxgo/handlers_test.go` covers the RPC-reachable path.
- [x] `go build ./... && go vet ./... && gofmt -l` clean.
- [x] `go test ./...` — all packages pass.
- [x] `examples/test_all.sh` — 10/10 pass, including `04_fields` (balanced-quote `SetCode` calls, untouched by this fix) and `07_advanced` (`NewHyperlinkField`).
- [ ] Pre-flight CodeQL verification on a throwaway branch carrying this fix on top of `feat/in-place-edit-rpc` (the alerts only reproduce there — `master` has no source CodeQL traces to these sinks yet).