### PR TITLE
[throwaway] CodeQL preflight for field-code fix

### DIFF
--- a/cmd/docxgo/handlers.go
+++ b/cmd/docxgo/handlers.go
@@ -314,19 +314,28 @@ type replaceTextParams struct {
 // the body-paragraph index as reported by paragraph.list; the embedded
 // paragraphItem carries the new content (text or runs) and any style fields
 // to apply.
+//
+// Index is a pointer so an omitted field is distinguishable from an
+// explicit 0: this method replaces the paragraph's content, so a client
+// that forgets index must not have its request silently resolve to the
+// first paragraph.
 type paragraphSetTextParams struct {
 	DocumentID string `json:"documentId"`
-	Index      int    `json:"index"`
+	Index      *int   `json:"index"`
 	paragraphItem
 }
 
 // tableCellRef addresses a single cell, shared by table.getCell and
 // table.setCell. Indices follow table.list ordering.
+//
+// The indices are pointers for the same reason as paragraphSetTextParams.Index:
+// an omitted coordinate must be rejected rather than defaulting to 0 and
+// silently addressing the first table/row/column.
 type tableCellRef struct {
 	DocumentID  string `json:"documentId"`
-	TableIndex  int    `json:"tableIndex"`
-	RowIndex    int    `json:"rowIndex"`
-	ColumnIndex int    `json:"columnIndex"`
+	TableIndex  *int   `json:"tableIndex"`
+	RowIndex    *int   `json:"rowIndex"`
+	ColumnIndex *int   `json:"columnIndex"`
 }
 
 // tableSetCellParams are the parameters for table.setCell. Text is a shortcut
@@ -1020,8 +1029,11 @@ func (s *server) handleParagraphSetText(req *Request) Response {
 	const op = "paragraph.setText"
 
 	var params paragraphSetTextParams
-	if err := json.Unmarshal(req.Params, &params); err != nil {
+	if err := decodeStrict(req.Params, &params); err != nil {
 		return errorResponse(req.ID, errors.ErrCodeValidation, "invalid params: "+err.Error(), op)
+	}
+	if params.Index == nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, "index is required", op)
 	}
 
 	doc, ok := s.getDoc(params.DocumentID)
@@ -1031,10 +1043,11 @@ func (s *server) handleParagraphSetText(req *Request) Response {
 	}
 
 	paragraphs := doc.Paragraphs()
-	if params.Index < 0 || params.Index >= len(paragraphs) {
+	index := *params.Index
+	if index < 0 || index >= len(paragraphs) {
 		return errorResponse(req.ID, errors.ErrCodeValidation,
 			fmt.Sprintf("paragraph index %d out of range (document has %d paragraphs)",
-				params.Index, len(paragraphs)), op)
+				index, len(paragraphs)), op)
 	}
 
 	// Validate before clearing: this method replaces the paragraph's content,
@@ -1044,7 +1057,7 @@ func (s *server) handleParagraphSetText(req *Request) Response {
 		return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
 	}
 
-	para := paragraphs[params.Index]
+	para := paragraphs[index]
 	para.ClearRuns()
 	if err := applyParagraph(para, params.paragraphItem); err != nil {
 		return errorResponse(req.ID, errors.ErrCodeInternal,
@@ -1053,8 +1066,23 @@ func (s *server) handleParagraphSetText(req *Request) Response {
 
 	return Response{ID: req.ID, Result: map[string]interface{}{
 		"ok":    true,
-		"index": params.Index,
+		"index": index,
 	}}
+}
+
+// decodeStrict decodes data into v, rejecting a literal null and any field v
+// does not declare. Plain json.Unmarshal accepts both silently: a misspelled
+// field name or a null array element would otherwise decode to a zero value
+// indistinguishable from a deliberately minimal request, which for
+// paragraph.setText and table.setCell means content gets silently cleared
+// instead of the request being rejected.
+func decodeStrict(data []byte, v interface{}) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		return fmt.Errorf("must not be null")
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	return dec.Decode(v)
 }
 
 // validateParagraphItem reports whether applyParagraph would accept item,
@@ -1079,18 +1107,23 @@ func validateParagraphItem(item paragraphItem) error {
 
 // resolveCell resolves a tableCellRef to a cell, with range-checked indices.
 func resolveCell(doc domain.Document, ref tableCellRef) (domain.TableCell, error) {
+	if ref.TableIndex == nil || ref.RowIndex == nil || ref.ColumnIndex == nil {
+		return nil, fmt.Errorf("tableIndex, rowIndex, and columnIndex are all required")
+	}
+	tableIndex, rowIndex, columnIndex := *ref.TableIndex, *ref.RowIndex, *ref.ColumnIndex
+
 	tables := doc.Tables()
-	if ref.TableIndex < 0 || ref.TableIndex >= len(tables) {
+	if tableIndex < 0 || tableIndex >= len(tables) {
 		return nil, fmt.Errorf("table index %d out of range (document has %d tables)",
-			ref.TableIndex, len(tables))
+			tableIndex, len(tables))
 	}
-	row, err := tables[ref.TableIndex].Row(ref.RowIndex)
+	row, err := tables[tableIndex].Row(rowIndex)
 	if err != nil {
-		return nil, fmt.Errorf("row %d: %w", ref.RowIndex, err)
+		return nil, fmt.Errorf("row %d: %w", rowIndex, err)
 	}
-	cell, err := row.Cell(ref.ColumnIndex)
+	cell, err := row.Cell(columnIndex)
 	if err != nil {
-		return nil, fmt.Errorf("column %d: %w", ref.ColumnIndex, err)
+		return nil, fmt.Errorf("column %d: %w", columnIndex, err)
 	}
 	return cell, nil
 }
@@ -1162,7 +1195,17 @@ func (s *server) handleTableSetCell(req *Request) Response {
 		return errorResponse(req.ID, errors.ErrCodeValidation,
 			fmt.Sprintf("cell (%d,%d) is covered by a horizontal merge and is not written to the document; "+
 				"target the leading cell of the merged region instead",
-				params.RowIndex, params.ColumnIndex), op)
+				*params.RowIndex, *params.ColumnIndex), op)
+	}
+
+	// A vertical-merge continuation cell is serialized, but Word ignores its
+	// content and renders the vMerge-restart cell above it instead — writing
+	// here would report success while remaining invisible.
+	if cell.VMerge() == domain.VMergeContinue {
+		return errorResponse(req.ID, errors.ErrCodeValidation,
+			fmt.Sprintf("cell (%d,%d) is a continuation of a vertical merge and its content is not displayed; "+
+				"target the topmost cell of the merged region instead",
+				*params.RowIndex, *params.ColumnIndex), op)
 	}
 
 	rawItems := params.Paragraphs
@@ -1181,7 +1224,7 @@ func (s *server) handleTableSetCell(req *Request) Response {
 	items := make([]paragraphItem, 0, len(rawItems))
 	for i, raw := range rawItems {
 		var pItem paragraphItem
-		if err := json.Unmarshal(raw, &pItem); err != nil {
+		if err := decodeStrict(raw, &pItem); err != nil {
 			return errorResponse(req.ID, errors.ErrCodeValidation,
 				fmt.Sprintf("invalid paragraph at index %d: %v", i, err), op)
 		}

--- a/cmd/docxgo/handlers.go
+++ b/cmd/docxgo/handlers.go
@@ -109,6 +109,8 @@ func (s *server) dispatch(req *Request) Response {
 		return s.handleAddPageBreak(req)
 	case "document.applyPatch":
 		return s.handleApplyPatch(req)
+	case "document.replaceText":
+		return s.handleReplaceText(req)
 	case "document.close":
 		return s.handleClose(req)
 	// paragraph.*
@@ -116,11 +118,17 @@ func (s *server) dispatch(req *Request) Response {
 		return s.handleParagraphAdd(req)
 	case "paragraph.list":
 		return s.handleParagraphList(req)
+	case "paragraph.setText":
+		return s.handleParagraphSetText(req)
 	// table.*
 	case "table.add":
 		return s.handleTableAdd(req)
 	case "table.list":
 		return s.handleTableList(req)
+	case "table.getCell":
+		return s.handleTableGetCell(req)
+	case "table.setCell":
+		return s.handleTableSetCell(req)
 	// section.*
 	case "section.add":
 		return s.handleSectionAdd(req)
@@ -289,6 +297,40 @@ type tableListParams struct {
 type sectionAddParams struct {
 	DocumentID string `json:"documentId"`
 	sectionItem
+}
+
+// replaceTextParams are the parameters for document.replaceText.
+type replaceTextParams struct {
+	DocumentID string `json:"documentId"`
+	Find       string `json:"find"`
+	Replace    string `json:"replace"`
+}
+
+// paragraphSetTextParams are the parameters for paragraph.setText. Index is
+// the body-paragraph index as reported by paragraph.list; the embedded
+// paragraphItem carries the new content (text or runs) and any style fields
+// to apply.
+type paragraphSetTextParams struct {
+	DocumentID string `json:"documentId"`
+	Index      int    `json:"index"`
+	paragraphItem
+}
+
+// tableCellRef addresses a single cell, shared by table.getCell and
+// table.setCell. Indices follow table.list ordering.
+type tableCellRef struct {
+	DocumentID  string `json:"documentId"`
+	TableIndex  int    `json:"tableIndex"`
+	RowIndex    int    `json:"rowIndex"`
+	ColumnIndex int    `json:"columnIndex"`
+}
+
+// tableSetCellParams are the parameters for table.setCell. Text is a shortcut
+// for a single plain paragraph; Paragraphs carries rich content items.
+type tableSetCellParams struct {
+	tableCellRef
+	Text       string            `json:"text,omitempty"`
+	Paragraphs []json.RawMessage `json:"paragraphs,omitempty"`
 }
 
 // applyPatchParams are the parameters for document.applyPatch.
@@ -913,6 +955,185 @@ func (s *server) handleTableList(req *Request) Response {
 	return Response{ID: req.ID, Result: map[string]interface{}{
 		"tables": items,
 		"count":  len(items),
+	}}
+}
+
+func (s *server) handleReplaceText(req *Request) Response {
+	const op = "document.replaceText"
+
+	var params replaceTextParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, "invalid params: "+err.Error(), op)
+	}
+
+	doc, ok := s.getDoc(params.DocumentID)
+	if !ok {
+		return errorResponse(req.ID, errors.ErrCodeNotFound,
+			fmt.Sprintf("document %q not found", params.DocumentID), op)
+	}
+
+	if params.Find == "" {
+		return errorResponse(req.ID, errors.ErrCodeValidation, "find is required and must not be empty", op)
+	}
+
+	result, err := template.ReplaceText(doc, params.Find, params.Replace)
+	if err != nil {
+		return errorResponse(req.ID, errors.ErrCodeInternal, "replace failed: "+err.Error(), op)
+	}
+
+	return Response{ID: req.ID, Result: map[string]interface{}{
+		"replaced": result.Replaced,
+		"skipped":  result.Skipped,
+	}}
+}
+
+func (s *server) handleParagraphSetText(req *Request) Response {
+	const op = "paragraph.setText"
+
+	var params paragraphSetTextParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, "invalid params: "+err.Error(), op)
+	}
+
+	doc, ok := s.getDoc(params.DocumentID)
+	if !ok {
+		return errorResponse(req.ID, errors.ErrCodeNotFound,
+			fmt.Sprintf("document %q not found", params.DocumentID), op)
+	}
+
+	paragraphs := doc.Paragraphs()
+	if params.Index < 0 || params.Index >= len(paragraphs) {
+		return errorResponse(req.ID, errors.ErrCodeValidation,
+			fmt.Sprintf("paragraph index %d out of range (document has %d paragraphs)",
+				params.Index, len(paragraphs)), op)
+	}
+
+	para := paragraphs[params.Index]
+	para.ClearRuns()
+	if err := applyParagraph(para, params.paragraphItem); err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
+	}
+
+	return Response{ID: req.ID, Result: map[string]interface{}{
+		"ok":    true,
+		"index": params.Index,
+	}}
+}
+
+// resolveCell resolves a tableCellRef to a cell, with range-checked indices.
+func resolveCell(doc domain.Document, ref tableCellRef) (domain.TableCell, error) {
+	tables := doc.Tables()
+	if ref.TableIndex < 0 || ref.TableIndex >= len(tables) {
+		return nil, fmt.Errorf("table index %d out of range (document has %d tables)",
+			ref.TableIndex, len(tables))
+	}
+	row, err := tables[ref.TableIndex].Row(ref.RowIndex)
+	if err != nil {
+		return nil, fmt.Errorf("row %d: %w", ref.RowIndex, err)
+	}
+	cell, err := row.Cell(ref.ColumnIndex)
+	if err != nil {
+		return nil, fmt.Errorf("column %d: %w", ref.ColumnIndex, err)
+	}
+	return cell, nil
+}
+
+func (s *server) handleTableGetCell(req *Request) Response {
+	const op = "table.getCell"
+
+	var params tableCellRef
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, "invalid params: "+err.Error(), op)
+	}
+
+	doc, ok := s.getDoc(params.DocumentID)
+	if !ok {
+		return errorResponse(req.ID, errors.ErrCodeNotFound,
+			fmt.Sprintf("document %q not found", params.DocumentID), op)
+	}
+
+	cell, err := resolveCell(doc, params)
+	if err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
+	}
+
+	paragraphs := cell.Paragraphs()
+	texts := make([]string, 0, len(paragraphs))
+	for _, p := range paragraphs {
+		texts = append(texts, p.Text())
+	}
+
+	return Response{ID: req.ID, Result: map[string]interface{}{
+		"text":           strings.Join(texts, "\n"),
+		"paragraphs":     texts,
+		"paragraphCount": len(paragraphs),
+	}}
+}
+
+func (s *server) handleTableSetCell(req *Request) Response {
+	const op = "table.setCell"
+
+	var params tableSetCellParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, "invalid params: "+err.Error(), op)
+	}
+
+	doc, ok := s.getDoc(params.DocumentID)
+	if !ok {
+		return errorResponse(req.ID, errors.ErrCodeNotFound,
+			fmt.Sprintf("document %q not found", params.DocumentID), op)
+	}
+
+	if params.Text != "" && len(params.Paragraphs) > 0 {
+		return errorResponse(req.ID, errors.ErrCodeValidation,
+			"provide either text or paragraphs, not both", op)
+	}
+
+	cell, err := resolveCell(doc, params.tableCellRef)
+	if err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
+	}
+
+	items := params.Paragraphs
+	if params.Text != "" {
+		item, err := json.Marshal(paragraphItem{Text: params.Text})
+		if err != nil {
+			return errorResponse(req.ID, errors.ErrCodeInternal, "encoding text item: "+err.Error(), op)
+		}
+		items = []json.RawMessage{item}
+	}
+
+	// Replace the cell's content: clear every existing paragraph, then write
+	// the new items into existing paragraphs (reusing their slots) and append
+	// paragraphs for any overflow. Cells cannot drop paragraphs, so leftover
+	// paragraphs beyond the new content stay as empty paragraphs.
+	existing := cell.Paragraphs()
+	for _, p := range existing {
+		p.ClearRuns()
+	}
+	for i, raw := range items {
+		var pItem paragraphItem
+		if err := json.Unmarshal(raw, &pItem); err != nil {
+			return errorResponse(req.ID, errors.ErrCodeValidation,
+				fmt.Sprintf("invalid paragraph at index %d: %v", i, err), op)
+		}
+		var para domain.Paragraph
+		if i < len(existing) {
+			para = existing[i]
+		} else {
+			para, err = cell.AddParagraph()
+			if err != nil {
+				return errorResponse(req.ID, errors.ErrCodeInternal, "failed to add paragraph: "+err.Error(), op)
+			}
+		}
+		if err := applyParagraph(para, pItem); err != nil {
+			return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
+		}
+	}
+
+	return Response{ID: req.ID, Result: map[string]interface{}{
+		"ok":             true,
+		"paragraphCount": len(cell.Paragraphs()),
 	}}
 }
 

--- a/cmd/docxgo/handlers.go
+++ b/cmd/docxgo/handlers.go
@@ -331,9 +331,15 @@ type tableCellRef struct {
 
 // tableSetCellParams are the parameters for table.setCell. Text is a shortcut
 // for a single plain paragraph; Paragraphs carries rich content items.
+//
+// Both are pointers/slices rather than plain values so that "provided but
+// empty" stays distinguishable from "omitted": setCell replaces the cell's
+// content, so `"text": ""` and `"paragraphs": []` are meaningful requests to
+// empty it, while omitting both is a request with no content at all and is
+// rejected rather than silently wiping the cell.
 type tableSetCellParams struct {
 	tableCellRef
-	Text       string            `json:"text,omitempty"`
+	Text       *string           `json:"text,omitempty"`
 	Paragraphs []json.RawMessage `json:"paragraphs,omitempty"`
 }
 
@@ -1031,16 +1037,44 @@ func (s *server) handleParagraphSetText(req *Request) Response {
 				params.Index, len(paragraphs)), op)
 	}
 
+	// Validate before clearing: this method replaces the paragraph's content,
+	// so rejecting the request after ClearRuns would leave the caller with an
+	// error response and an emptied paragraph.
+	if err := validateParagraphItem(params.paragraphItem); err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
+	}
+
 	para := paragraphs[params.Index]
 	para.ClearRuns()
 	if err := applyParagraph(para, params.paragraphItem); err != nil {
-		return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
+		return errorResponse(req.ID, errors.ErrCodeInternal,
+			"applying validated paragraph: "+err.Error(), op)
 	}
 
 	return Response{ID: req.ID, Result: map[string]interface{}{
 		"ok":    true,
 		"index": params.Index,
 	}}
+}
+
+// validateParagraphItem reports whether applyParagraph would accept item,
+// without touching the caller's document: it applies the item to a scratch
+// paragraph in a throwaway document and reports the outcome.
+//
+// paragraph.setText and table.setCell both clear existing content before
+// writing, so an item that turns out to be invalid has to be caught before
+// anything is destroyed. applyParagraph ignores failures from styling setters
+// (SetStyle, SetAlignment and friends are all discarded with _), so the only
+// errors this can surface come from AddRun/SetText and from hyperlink, field,
+// and image items — none of which depend on the target document's own styles,
+// so a scratch document gives the same verdict as the real one.
+func validateParagraphItem(item paragraphItem) error {
+	scratch := docx.NewDocument()
+	para, err := scratch.AddParagraph()
+	if err != nil {
+		return err
+	}
+	return applyParagraph(para, item)
 }
 
 // resolveCell resolves a tableCellRef to a cell, with range-checked indices.
@@ -1107,9 +1141,13 @@ func (s *server) handleTableSetCell(req *Request) Response {
 			fmt.Sprintf("document %q not found", params.DocumentID), op)
 	}
 
-	if params.Text != "" && len(params.Paragraphs) > 0 {
+	if params.Text != nil && params.Paragraphs != nil {
 		return errorResponse(req.ID, errors.ErrCodeValidation,
 			"provide either text or paragraphs, not both", op)
+	}
+	if params.Text == nil && params.Paragraphs == nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation,
+			"provide either text or paragraphs; to empty the cell pass an empty paragraphs array", op)
 	}
 
 	cell, err := resolveCell(doc, params.tableCellRef)
@@ -1117,13 +1155,41 @@ func (s *server) handleTableSetCell(req *Request) Response {
 		return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
 	}
 
-	items := params.Paragraphs
-	if params.Text != "" {
-		item, err := json.Marshal(paragraphItem{Text: params.Text})
+	// A cell swallowed by a horizontal merge is never serialized, so writing
+	// to it would report success and then silently drop the content on save.
+	// Point the caller at the leading cell of the merged region instead.
+	if cell.IsHorizontallyMergedContinuation() {
+		return errorResponse(req.ID, errors.ErrCodeValidation,
+			fmt.Sprintf("cell (%d,%d) is covered by a horizontal merge and is not written to the document; "+
+				"target the leading cell of the merged region instead",
+				params.RowIndex, params.ColumnIndex), op)
+	}
+
+	rawItems := params.Paragraphs
+	if params.Text != nil {
+		item, err := json.Marshal(paragraphItem{Text: *params.Text})
 		if err != nil {
 			return errorResponse(req.ID, errors.ErrCodeInternal, "encoding text item: "+err.Error(), op)
 		}
-		items = []json.RawMessage{item}
+		rawItems = []json.RawMessage{item}
+	}
+
+	// Decode and validate every item before touching the cell. Writing the
+	// content clears what is already there, so a request that turns out to
+	// be invalid halfway through would otherwise destroy the cell's original
+	// content and still return an error.
+	items := make([]paragraphItem, 0, len(rawItems))
+	for i, raw := range rawItems {
+		var pItem paragraphItem
+		if err := json.Unmarshal(raw, &pItem); err != nil {
+			return errorResponse(req.ID, errors.ErrCodeValidation,
+				fmt.Sprintf("invalid paragraph at index %d: %v", i, err), op)
+		}
+		if err := validateParagraphItem(pItem); err != nil {
+			return errorResponse(req.ID, errors.ErrCodeValidation,
+				fmt.Sprintf("invalid paragraph at index %d: %v", i, err), op)
+		}
+		items = append(items, pItem)
 	}
 
 	// Replace the cell's content: clear every existing paragraph, then write
@@ -1134,12 +1200,7 @@ func (s *server) handleTableSetCell(req *Request) Response {
 	for _, p := range existing {
 		p.ClearRuns()
 	}
-	for i, raw := range items {
-		var pItem paragraphItem
-		if err := json.Unmarshal(raw, &pItem); err != nil {
-			return errorResponse(req.ID, errors.ErrCodeValidation,
-				fmt.Sprintf("invalid paragraph at index %d: %v", i, err), op)
-		}
+	for i, pItem := range items {
 		var para domain.Paragraph
 		if i < len(existing) {
 			para = existing[i]
@@ -1150,7 +1211,8 @@ func (s *server) handleTableSetCell(req *Request) Response {
 			}
 		}
 		if err := applyParagraph(para, pItem); err != nil {
-			return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
+			return errorResponse(req.ID, errors.ErrCodeInternal,
+				fmt.Sprintf("applying validated paragraph %d: %v", i, err), op)
 		}
 	}
 

--- a/cmd/docxgo/handlers.go
+++ b/cmd/docxgo/handlers.go
@@ -291,6 +291,10 @@ type tableAddParams struct {
 // tableListParams are the parameters for table.list.
 type tableListParams struct {
 	DocumentID string `json:"documentId"`
+	// IncludeText adds each table's cell texts to the listing, row by row.
+	// Rows report their actual cells, so ragged tables (merged cells) are
+	// represented faithfully rather than padded to columnCount.
+	IncludeText bool `json:"includeText,omitempty"`
 }
 
 // sectionAddParams are the parameters for section.add.
@@ -945,11 +949,30 @@ func (s *server) handleTableList(req *Request) Response {
 	tables := doc.Tables()
 	items := make([]map[string]interface{}, 0, len(tables))
 	for i, t := range tables {
-		items = append(items, map[string]interface{}{
+		item := map[string]interface{}{
 			"index":   i,
 			"rows":    t.RowCount(),
 			"columns": t.ColumnCount(),
-		})
+		}
+		if params.IncludeText {
+			rows := t.Rows()
+			cellRows := make([][]string, 0, len(rows))
+			for _, row := range rows {
+				cells := row.Cells()
+				texts := make([]string, 0, len(cells))
+				for _, cell := range cells {
+					paragraphs := cell.Paragraphs()
+					pTexts := make([]string, 0, len(paragraphs))
+					for _, p := range paragraphs {
+						pTexts = append(pTexts, p.Text())
+					}
+					texts = append(texts, strings.Join(pTexts, "\n"))
+				}
+				cellRows = append(cellRows, texts)
+			}
+			item["cells"] = cellRows
+		}
+		items = append(items, item)
 	}
 
 	return Response{ID: req.ID, Result: map[string]interface{}{

--- a/cmd/docxgo/handlers_test.go
+++ b/cmd/docxgo/handlers_test.go
@@ -976,6 +976,114 @@ func TestHandleTableSetCell_TextAndParagraphsConflict(t *testing.T) {
 	}
 }
 
+// cellText reads a cell's text back through table.getCell.
+func cellText(t *testing.T, s *server, docID string, table, row, col int) string {
+	t.Helper()
+	resp := s.dispatch(makeRequest(99, "table.getCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": table, "rowIndex": row, "columnIndex": col,
+	}))
+	if resp.Error != nil {
+		t.Fatalf("getCell: %+v", resp.Error)
+	}
+	return resp.Result.(map[string]interface{})["text"].(string)
+}
+
+// paragraphText reads a body paragraph's text back through paragraph.list.
+func paragraphText(t *testing.T, s *server, docID string, index int) string {
+	t.Helper()
+	resp := s.dispatch(makeRequest(98, "paragraph.list", map[string]interface{}{
+		"documentId": docID,
+	}))
+	if resp.Error != nil {
+		t.Fatalf("paragraph.list: %+v", resp.Error)
+	}
+	paras := resp.Result.(map[string]interface{})["paragraphs"].([]map[string]interface{})
+	return paras[index]["text"].(string)
+}
+
+// TestHandleTableSetCell_NoContentIsRejected covers a request carrying neither
+// text nor paragraphs — a misspelled content field, say. It used to clear the
+// cell and answer ok:true, destroying content the caller never asked to touch
+// and giving no signal that anything had happened.
+func TestHandleTableSetCell_NoContentIsRejected(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+	before := cellText(t, s, docID, 0, 1, 1)
+
+	resp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+		"value": "Yes", // not a field the handler knows
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Fatalf("expected VALIDATION_ERROR, got %+v", resp.Error)
+	}
+	if got := cellText(t, s, docID, 0, 1, 1); got != before {
+		t.Errorf("cell text = %q, want %q (unchanged)", got, before)
+	}
+}
+
+// TestHandleTableSetCell_EmptyParagraphsClears keeps the documented way to
+// empty a cell working now that "no content at all" is rejected.
+func TestHandleTableSetCell_EmptyParagraphsClears(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+		"paragraphs": []interface{}{},
+	}))
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	if got := cellText(t, s, docID, 0, 1, 1); got != "" {
+		t.Errorf("cell text = %q, want empty", got)
+	}
+}
+
+// TestHandleTableSetCell_InvalidItemLeavesCellIntact covers a request whose
+// second paragraph is rejected. The handler clears the cell before writing, so
+// validating only as it went left the caller with an error response and a
+// destroyed cell that could not be recovered from the session.
+func TestHandleTableSetCell_InvalidItemLeavesCellIntact(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+	before := cellText(t, s, docID, 0, 1, 1)
+
+	resp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+		"paragraphs": []interface{}{
+			map[string]interface{}{"text": "Yes"},
+			map[string]interface{}{"runs": []interface{}{
+				map[string]interface{}{"hyperlink": map[string]interface{}{"url": ""}},
+			}},
+		},
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Fatalf("expected VALIDATION_ERROR, got %+v", resp.Error)
+	}
+	if got := cellText(t, s, docID, 0, 1, 1); got != before {
+		t.Errorf("cell text = %q, want %q (unchanged)", got, before)
+	}
+}
+
+// TestHandleParagraphSetText_InvalidContentLeavesParagraphIntact is the
+// paragraph-level counterpart: a rejected request must not empty the
+// paragraph it declined to rewrite.
+func TestHandleParagraphSetText_InvalidContentLeavesParagraphIntact(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+	before := paragraphText(t, s, docID, 0)
+
+	resp := s.dispatch(makeRequest(2, "paragraph.setText", map[string]interface{}{
+		"documentId": docID, "index": 0,
+		"runs": []interface{}{
+			map[string]interface{}{"hyperlink": map[string]interface{}{"url": ""}},
+		},
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Fatalf("expected VALIDATION_ERROR, got %+v", resp.Error)
+	}
+	if got := paragraphText(t, s, docID, 0); got != before {
+		t.Errorf("paragraph text = %q, want %q (unchanged)", got, before)
+	}
+}
+
 // TestIntegration_EditRoundTrip exercises the questionnaire flow: open a saved
 // document, replace text, fill an answer cell, rewrite a paragraph, save, then
 // reopen and verify all edits survived serialization.

--- a/cmd/docxgo/handlers_test.go
+++ b/cmd/docxgo/handlers_test.go
@@ -883,6 +883,40 @@ func TestHandleTableGetCell(t *testing.T) {
 	}
 }
 
+func TestHandleTableList_IncludeText(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "table.list", map[string]interface{}{
+		"documentId": docID, "includeText": true,
+	}))
+	if resp.Error != nil {
+		t.Fatalf("table.list failed: %+v", resp.Error)
+	}
+	tables := resp.Result.(map[string]interface{})["tables"].([]map[string]interface{})
+	if len(tables) != 1 {
+		t.Fatalf("table count = %d, want 1", len(tables))
+	}
+	cells, ok := tables[0]["cells"].([][]string)
+	if !ok {
+		t.Fatalf("cells missing or wrong type: %T", tables[0]["cells"])
+	}
+	if len(cells) != 2 || len(cells[0]) != 2 {
+		t.Fatalf("cells shape = %v", cells)
+	}
+	if cells[1][0] != "Do you encrypt data at rest?" || cells[1][1] != "TBD" {
+		t.Errorf("row 1 = %v", cells[1])
+	}
+
+	// Without the flag, cells must be absent.
+	resp = s.dispatch(makeRequest(3, "table.list", map[string]interface{}{
+		"documentId": docID,
+	}))
+	tables = resp.Result.(map[string]interface{})["tables"].([]map[string]interface{})
+	if _, present := tables[0]["cells"]; present {
+		t.Error("cells should be absent without includeText")
+	}
+}
+
 func TestHandleTableSetCell_TextShortcut(t *testing.T) {
 	s, docID := newEditTestDoc(t)
 

--- a/cmd/docxgo/handlers_test.go
+++ b/cmd/docxgo/handlers_test.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/mmonterroca/docxgo/v2/domain"
 )
 
 // ─── Protocol tests ───────────────────────────────────────────────────────────
@@ -1060,6 +1062,122 @@ func TestHandleTableSetCell_InvalidItemLeavesCellIntact(t *testing.T) {
 	}
 	if got := cellText(t, s, docID, 0, 1, 1); got != before {
 		t.Errorf("cell text = %q, want %q (unchanged)", got, before)
+	}
+}
+
+// TestHandleParagraphSetText_MissingIndexIsRejected covers an omitted index
+// field. Index is a Go int, so an omitted field used to decode to 0 and
+// silently rewrite the first body paragraph instead of being rejected.
+func TestHandleParagraphSetText_MissingIndexIsRejected(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+	before := paragraphText(t, s, docID, 0)
+
+	resp := s.dispatch(makeRequest(2, "paragraph.setText", map[string]interface{}{
+		"documentId": docID, "text": "clobbered",
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Fatalf("expected VALIDATION_ERROR, got %+v", resp.Error)
+	}
+	if got := paragraphText(t, s, docID, 0); got != before {
+		t.Errorf("paragraph text = %q, want %q (unchanged)", got, before)
+	}
+}
+
+// TestHandleTableSetCell_MissingCoordinateIsRejected covers an omitted
+// rowIndex/columnIndex/tableIndex. Each is a Go int, so an omitted field used
+// to decode to 0 and silently address (or overwrite) the first table's first
+// cell instead of being rejected.
+func TestHandleTableSetCell_MissingCoordinateIsRejected(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+	before := cellText(t, s, docID, 0, 0, 0)
+
+	resp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1,
+		"text": "clobbered",
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Fatalf("expected VALIDATION_ERROR, got %+v", resp.Error)
+	}
+	if got := cellText(t, s, docID, 0, 0, 0); got != before {
+		t.Errorf("cell (0,0) text = %q, want %q (unchanged)", got, before)
+	}
+}
+
+// TestHandleTableSetCell_MisspelledContentFieldIsRejected covers a paragraph
+// item whose content field is misspelled (or the wrong shape) rather than
+// omitted entirely. json.Unmarshal drops unknown fields and accepts null
+// silently, so {"value":"Yes"} used to decode to an empty paragraphItem, pass
+// validateParagraphItem trivially (there is nothing invalid about an empty
+// item), and then clear the cell instead of reporting the typo.
+func TestHandleTableSetCell_MisspelledContentFieldIsRejected(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+	before := cellText(t, s, docID, 0, 1, 1)
+
+	resp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+		"paragraphs": []interface{}{
+			map[string]interface{}{"value": "Yes"},
+		},
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Fatalf("expected VALIDATION_ERROR, got %+v", resp.Error)
+	}
+	if got := cellText(t, s, docID, 0, 1, 1); got != before {
+		t.Errorf("cell text = %q, want %q (unchanged)", got, before)
+	}
+}
+
+// TestHandleTableSetCell_NullParagraphIsRejected covers a null element in the
+// paragraphs array. json.Unmarshal leaves the destination at its zero value
+// for a null source, so a null item used to decode to an empty paragraphItem
+// and silently clear the cell for the same reason as the misspelled-field
+// case above.
+func TestHandleTableSetCell_NullParagraphIsRejected(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+	before := cellText(t, s, docID, 0, 1, 1)
+
+	resp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+		"paragraphs": []interface{}{nil},
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Fatalf("expected VALIDATION_ERROR, got %+v", resp.Error)
+	}
+	if got := cellText(t, s, docID, 0, 1, 1); got != before {
+		t.Errorf("cell text = %q, want %q (unchanged)", got, before)
+	}
+}
+
+// TestHandleTableSetCell_RejectsVerticalMergeContinuation covers a cell that
+// is a vertical-merge continuation. Such a cell is still serialized (unlike a
+// horizontal-merge continuation), but Word renders the vMerge-restart cell's
+// content instead of its own, so a write there used to report success while
+// remaining invisible to the reader.
+func TestHandleTableSetCell_RejectsVerticalMergeContinuation(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	doc, ok := s.getDoc(docID)
+	if !ok {
+		t.Fatal("document not found")
+	}
+	row, err := doc.Tables()[0].Row(1)
+	if err != nil {
+		t.Fatalf("row: %v", err)
+	}
+	cell, err := row.Cell(1)
+	if err != nil {
+		t.Fatalf("cell: %v", err)
+	}
+	if err := cell.SetVMerge(domain.VMergeContinue); err != nil {
+		t.Fatalf("SetVMerge: %v", err)
+	}
+
+	resp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+		"text": "clobbered",
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Fatalf("expected VALIDATION_ERROR, got %+v", resp.Error)
 	}
 }
 

--- a/cmd/docxgo/handlers_test.go
+++ b/cmd/docxgo/handlers_test.go
@@ -1947,6 +1947,12 @@ func TestHandleSystemCapabilities(t *testing.T) {
 	if !result["batch"] {
 		t.Error("expected batch capability to be true")
 	}
+	if !result["replaceText"] {
+		t.Error("expected replaceText capability to be true")
+	}
+	if !result["cellEdit"] {
+		t.Error("expected cellEdit capability to be true")
+	}
 }
 
 // ─── System batch tests ──────────────────────────────────────────────────────

--- a/cmd/docxgo/handlers_test.go
+++ b/cmd/docxgo/handlers_test.go
@@ -708,6 +708,323 @@ func TestIntegration_CreateOpenInspectSave(t *testing.T) {
 	}
 }
 
+// ─── Edit handler tests ───────────────────────────────────────────────────────
+
+// newEditTestDoc creates an in-memory document with one paragraph and a 2x2
+// question/answer table, returning the server and documentId.
+func newEditTestDoc(t *testing.T) (*server, string) {
+	t.Helper()
+	s := newServer()
+	resp := s.dispatch(makeRequest(1, "document.create", map[string]interface{}{
+		"content": []interface{}{
+			map[string]interface{}{
+				"type": "paragraph",
+				"runs": []interface{}{
+					map[string]interface{}{"text": "Vendor: ACME Corp"},
+				},
+			},
+			map[string]interface{}{
+				"type": "table",
+				"rows": []interface{}{
+					map[string]interface{}{"cells": []interface{}{
+						map[string]interface{}{"paragraphs": []interface{}{
+							map[string]interface{}{"runs": []interface{}{map[string]interface{}{"text": "Question", "bold": true}}},
+						}},
+						map[string]interface{}{"paragraphs": []interface{}{
+							map[string]interface{}{"runs": []interface{}{map[string]interface{}{"text": "Answer", "bold": true}}},
+						}},
+					}},
+					map[string]interface{}{"cells": []interface{}{
+						map[string]interface{}{"paragraphs": []interface{}{
+							map[string]interface{}{"runs": []interface{}{map[string]interface{}{"text": "Do you encrypt data at rest?"}}},
+						}},
+						map[string]interface{}{"paragraphs": []interface{}{
+							map[string]interface{}{"runs": []interface{}{map[string]interface{}{"text": "TBD"}}},
+						}},
+					}},
+				},
+			},
+		},
+		"output": "buffer",
+	}))
+	if resp.Error != nil {
+		t.Fatalf("create failed: %+v", resp.Error)
+	}
+	docID := resp.Result.(map[string]interface{})["documentId"].(string)
+	return s, docID
+}
+
+func TestHandleReplaceText(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "document.replaceText", map[string]interface{}{
+		"documentId": docID,
+		"find":       "ACME Corp",
+		"replace":    "Reindeer AI",
+	}))
+	if resp.Error != nil {
+		t.Fatalf("replaceText failed: %+v", resp.Error)
+	}
+	result := resp.Result.(map[string]interface{})
+	if result["replaced"] != 1 {
+		t.Errorf("replaced = %v, want 1", result["replaced"])
+	}
+
+	listResp := s.dispatch(makeRequest(3, "paragraph.list", map[string]interface{}{
+		"documentId": docID,
+	}))
+	paras := listResp.Result.(map[string]interface{})["paragraphs"].([]map[string]interface{})
+	if paras[0]["text"] != "Vendor: Reindeer AI" {
+		t.Errorf("paragraph text = %q", paras[0]["text"])
+	}
+}
+
+func TestHandleReplaceText_ReachesTableCells(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "document.replaceText", map[string]interface{}{
+		"documentId": docID,
+		"find":       "TBD",
+		"replace":    "Yes, AES-256",
+	}))
+	if resp.Error != nil {
+		t.Fatalf("replaceText failed: %+v", resp.Error)
+	}
+	if got := resp.Result.(map[string]interface{})["replaced"]; got != 1 {
+		t.Errorf("replaced = %v, want 1", got)
+	}
+
+	cellResp := s.dispatch(makeRequest(3, "table.getCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+	}))
+	if cellResp.Error != nil {
+		t.Fatalf("getCell failed: %+v", cellResp.Error)
+	}
+	if got := cellResp.Result.(map[string]interface{})["text"]; got != "Yes, AES-256" {
+		t.Errorf("cell text = %q", got)
+	}
+}
+
+func TestHandleReplaceText_Validation(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "document.replaceText", map[string]interface{}{
+		"documentId": docID, "find": "", "replace": "x",
+	}))
+	if resp.Error == nil {
+		t.Error("expected error for empty find")
+	}
+
+	resp = s.dispatch(makeRequest(3, "document.replaceText", map[string]interface{}{
+		"documentId": "doc-999", "find": "a", "replace": "b",
+	}))
+	if resp.Error == nil || resp.Error.Code != "NOT_FOUND" {
+		t.Errorf("expected NOT_FOUND for unknown doc, got %+v", resp.Error)
+	}
+}
+
+func TestHandleParagraphSetText(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "paragraph.setText", map[string]interface{}{
+		"documentId": docID,
+		"index":      0,
+		"runs": []interface{}{
+			map[string]interface{}{"text": "Completed by ", "italic": true},
+			map[string]interface{}{"text": "Reindeer", "bold": true},
+		},
+	}))
+	if resp.Error != nil {
+		t.Fatalf("setText failed: %+v", resp.Error)
+	}
+
+	listResp := s.dispatch(makeRequest(3, "paragraph.list", map[string]interface{}{
+		"documentId": docID,
+	}))
+	paras := listResp.Result.(map[string]interface{})["paragraphs"].([]map[string]interface{})
+	if paras[0]["text"] != "Completed by Reindeer" {
+		t.Errorf("paragraph text = %q", paras[0]["text"])
+	}
+}
+
+func TestHandleParagraphSetText_IndexOutOfRange(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "paragraph.setText", map[string]interface{}{
+		"documentId": docID, "index": 99, "text": "x",
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Errorf("expected VALIDATION_ERROR, got %+v", resp.Error)
+	}
+}
+
+func TestHandleTableGetCell(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "table.getCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 0,
+	}))
+	if resp.Error != nil {
+		t.Fatalf("getCell failed: %+v", resp.Error)
+	}
+	result := resp.Result.(map[string]interface{})
+	if result["text"] != "Do you encrypt data at rest?" {
+		t.Errorf("cell text = %q", result["text"])
+	}
+	if result["paragraphCount"] != 1 {
+		t.Errorf("paragraphCount = %v, want 1", result["paragraphCount"])
+	}
+
+	resp = s.dispatch(makeRequest(3, "table.getCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 5, "rowIndex": 0, "columnIndex": 0,
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Errorf("expected VALIDATION_ERROR for bad table index, got %+v", resp.Error)
+	}
+}
+
+func TestHandleTableSetCell_TextShortcut(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+		"text": "Yes — AES-256 at rest, TLS 1.3 in transit.",
+	}))
+	if resp.Error != nil {
+		t.Fatalf("setCell failed: %+v", resp.Error)
+	}
+
+	cellResp := s.dispatch(makeRequest(3, "table.getCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+	}))
+	if got := cellResp.Result.(map[string]interface{})["text"]; got != "Yes — AES-256 at rest, TLS 1.3 in transit." {
+		t.Errorf("cell text = %q", got)
+	}
+}
+
+func TestHandleTableSetCell_RichParagraphs(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+		"paragraphs": []interface{}{
+			map[string]interface{}{"runs": []interface{}{map[string]interface{}{"text": "Yes.", "bold": true}}},
+			map[string]interface{}{"runs": []interface{}{map[string]interface{}{"text": "See SOC 2 report, section 4."}}},
+		},
+	}))
+	if resp.Error != nil {
+		t.Fatalf("setCell failed: %+v", resp.Error)
+	}
+	result := resp.Result.(map[string]interface{})
+	if result["paragraphCount"] != 2 {
+		t.Errorf("paragraphCount = %v, want 2", result["paragraphCount"])
+	}
+
+	cellResp := s.dispatch(makeRequest(3, "table.getCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+	}))
+	if got := cellResp.Result.(map[string]interface{})["text"]; got != "Yes.\nSee SOC 2 report, section 4." {
+		t.Errorf("cell text = %q", got)
+	}
+}
+
+func TestHandleTableSetCell_TextAndParagraphsConflict(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 0, "columnIndex": 0,
+		"text":       "x",
+		"paragraphs": []interface{}{map[string]interface{}{"text": "y"}},
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Errorf("expected VALIDATION_ERROR, got %+v", resp.Error)
+	}
+}
+
+// TestIntegration_EditRoundTrip exercises the questionnaire flow: open a saved
+// document, replace text, fill an answer cell, rewrite a paragraph, save, then
+// reopen and verify all edits survived serialization.
+func TestIntegration_EditRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	docPath := dir + "/questionnaire.docx"
+	editedPath := dir + "/questionnaire-filled.docx"
+
+	s, docID := newEditTestDoc(t)
+	saveResp := s.dispatch(makeRequest(2, "document.save", map[string]interface{}{
+		"documentId": docID, "output": "file", "filePath": docPath,
+	}))
+	if saveResp.Error != nil {
+		t.Fatalf("save failed: %+v", saveResp.Error)
+	}
+
+	openResp := s.dispatch(makeRequest(3, "document.open", map[string]interface{}{
+		"filePath": docPath,
+	}))
+	if openResp.Error != nil {
+		t.Fatalf("open failed: %+v", openResp.Error)
+	}
+	openedID := openResp.Result.(map[string]interface{})["documentId"].(string)
+
+	for i, req := range []map[string]interface{}{
+		{"documentId": openedID, "find": "ACME Corp", "replace": "Reindeer AI"},
+	} {
+		resp := s.dispatch(makeRequest(10+i, "document.replaceText", req))
+		if resp.Error != nil {
+			t.Fatalf("replaceText failed: %+v", resp.Error)
+		}
+		if got := resp.Result.(map[string]interface{})["replaced"]; got != 1 {
+			t.Fatalf("replaced = %v, want 1", got)
+		}
+	}
+	setCellResp := s.dispatch(makeRequest(20, "table.setCell", map[string]interface{}{
+		"documentId": openedID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+		"text": "Yes — AES-256.",
+	}))
+	if setCellResp.Error != nil {
+		t.Fatalf("setCell failed: %+v", setCellResp.Error)
+	}
+	setParaResp := s.dispatch(makeRequest(21, "paragraph.setText", map[string]interface{}{
+		"documentId": openedID, "index": 0, "text": "Vendor: Reindeer AI (reviewed)",
+	}))
+	if setParaResp.Error != nil {
+		t.Fatalf("paragraph.setText failed: %+v", setParaResp.Error)
+	}
+
+	saveResp = s.dispatch(makeRequest(22, "document.save", map[string]interface{}{
+		"documentId": openedID, "output": "file", "filePath": editedPath,
+	}))
+	if saveResp.Error != nil {
+		t.Fatalf("save edited failed: %+v", saveResp.Error)
+	}
+
+	// Reopen and verify the edits survived the round trip.
+	reopenResp := s.dispatch(makeRequest(23, "document.open", map[string]interface{}{
+		"filePath": editedPath,
+	}))
+	if reopenResp.Error != nil {
+		t.Fatalf("reopen failed: %+v", reopenResp.Error)
+	}
+	reopenedID := reopenResp.Result.(map[string]interface{})["documentId"].(string)
+
+	listResp := s.dispatch(makeRequest(24, "paragraph.list", map[string]interface{}{
+		"documentId": reopenedID,
+	}))
+	paras := listResp.Result.(map[string]interface{})["paragraphs"].([]map[string]interface{})
+	if paras[0]["text"] != "Vendor: Reindeer AI (reviewed)" {
+		t.Errorf("reopened paragraph text = %q", paras[0]["text"])
+	}
+
+	cellResp := s.dispatch(makeRequest(25, "table.getCell", map[string]interface{}{
+		"documentId": reopenedID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+	}))
+	if cellResp.Error != nil {
+		t.Fatalf("getCell after reopen failed: %+v", cellResp.Error)
+	}
+	if got := cellResp.Result.(map[string]interface{})["text"]; got != "Yes — AES-256." {
+		t.Errorf("reopened cell text = %q", got)
+	}
+}
+
 // ─── runExec tests ────────────────────────────────────────────────────────────
 
 func TestRunExec_WithRequestFlag(t *testing.T) {

--- a/cmd/docxgo/main.go
+++ b/cmd/docxgo/main.go
@@ -87,6 +87,8 @@ func capabilitiesMap() map[string]bool {
 		"batch":         true,
 		"applyPatch":    true,
 		"setLanguage":   true,
+		"replaceText":   true,
+		"cellEdit":      true,
 		"streaming":     false,
 		"partialUpdate": false,
 	}

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -763,7 +763,7 @@ Lists all paragraphs in a document with their text and style.
 
 Replaces a body paragraph's content by index (the same index reported by `paragraph.list`). This clears all of the paragraph's existing runs before writing the new content, so it is a full replacement, not an append.
 
-Accepts the same content fields as `paragraph.add`. Passing only `style` (no `text` and no `runs`) clears the paragraph's runs and writes nothing back — the paragraph is emptied, not left unchanged. This method only addresses paragraphs in the document body; paragraphs inside table cells or headers/footers are not reachable by index here — use `table.setCell` for cell content.
+Accepts the same content fields as `paragraph.add`, but decoded strictly: an unrecognized field or a `null` value is rejected rather than silently treated as absent, since a typo in a request that replaces content must not read as "clear it". Passing only `style` (no `text` and no `runs`) clears the paragraph's runs and writes nothing back — the paragraph is emptied, not left unchanged. This method only addresses paragraphs in the document body; paragraphs inside table cells or headers/footers are not reachable by index here — use `table.setCell` for cell content.
 
 **Params:**
 
@@ -923,9 +923,11 @@ Replaces a single cell's content by table, row, and column index.
 
 Provide exactly one of `text` (a shortcut that writes one plain paragraph) or `paragraphs` (rich paragraph items, same shape as `paragraph.add`). Supplying **both** is rejected, and so is supplying **neither** — this method replaces the cell's content, so a request that names no content at all (a misspelled field, say) is an error rather than a silent wipe. To empty a cell, pass `"paragraphs": []` or `"text": ""`.
 
-The whole request is validated before the cell is touched: if any paragraph item is malformed or rejected, the call fails and the cell keeps its original content.
+The whole request is validated before the cell is touched: if any paragraph item is malformed or rejected, the call fails and the cell keeps its original content. Unlike `paragraph.add`, each paragraph item here is decoded strictly — an unrecognized field or a `null` item is rejected rather than silently treated as an empty paragraph, since a typo in a request that replaces content must not read as "clear it".
 
 Writes to a cell covered by a horizontal merge are rejected. Such a cell is never written to the file, so accepting the write would report success and then silently drop the content on save — target the leading cell of the merged region instead.
+
+Writes to a vertical-merge continuation cell are rejected too. Unlike a horizontal-merge continuation, this cell is still written to the file, but Word renders the vertical-merge-restart cell's content in its place, so the write would report success while remaining invisible — target the topmost cell of the merged region instead.
 
 The cell can grow to fit more paragraphs than it had, but it cannot shrink: paragraphs beyond the new content are left in place as empty paragraphs, since `domain.TableCell` only exposes adding paragraphs, not removing them. `paragraphCount` in the result reflects the cell's paragraph count after the write, which may be larger than the number of items you provided.
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -649,7 +649,12 @@ Applies a sequence of patch operations to an existing document sequentially. **T
 
 Replaces every occurrence of a literal string with another, across body paragraphs, table cells, headers, and footers.
 
-Matching is case-sensitive. Text fragmented across runs with identical formatting is matched as if it were one run; a match spanning runs with *different* formatting is still replaced, taking the formatting of the first run it touches — which flattens that formatting. For example, replacing `": PENDING ("` with `": DONE ("` in `"Status: **PENDING** (review)"` produces `"Status: DONE (review)"` with the bold lost, because the match spans the plain/bold boundary. A match that touches a run containing a field (page number, TOC, MERGEFIELD, hyperlink), a break, or an image is left untouched and counted in `skipped` instead — rewriting that run's text would corrupt or silently discard the non-text content.
+Matching is case-sensitive. Text fragmented across runs with identical formatting is matched as if it were one run; a match spanning runs with *different* formatting is still replaced, taking the formatting of the first run it touches — which flattens that formatting. For example, replacing `": PENDING ("` with `": DONE ("` in `"Status: **PENDING** (review)"` produces `"Status: DONE (review)"` with the bold lost, because the match spans the plain/bold boundary.
+
+Some matches are reported in `skipped` instead of being replaced:
+
+- A match touching a run that carries a **field** (page number, TOC, MERGEFIELD, hyperlink) is always skipped. Word regenerates a field's displayed text when it opens the document, so replacing it would report a change that never appears.
+- A match spanning **several** runs is also skipped when any of them carries a line/page break or an image, because collapsing those runs would leave that content stranded in the middle of the replacement. A match that fits inside a *single* run carrying a break or image is replaced normally, and the break or image is preserved.
 
 This does not reach into tables nested inside other tables, or into tables placed inside a header or footer — the same traversal limits as `template.render`/`template.inspect`, which share the underlying paragraph walk.
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -23,10 +23,14 @@ The `docxgo` CLI binary exposes the full docxgo library API as a JSON-RPC servic
   - [document.addContent](#documentaddcontent)
   - [document.addPageBreak](#documentaddpagebreak)
   - [document.applyPatch](#documentapplypatch)
+  - [document.replaceText](#documentreplacetext)
   - [paragraph.add](#paragraphadd)
   - [paragraph.list](#paragraphlist)
+  - [paragraph.setText](#paragraphsettext)
   - [table.add](#tableadd)
   - [table.list](#tablelist)
+  - [table.getCell](#tablegetcell)
+  - [table.setCell](#tablesetcell)
   - [section.add](#sectionadd)
   - [template.inspect](#templateinspect)
   - [template.render](#templaterender)
@@ -222,6 +226,8 @@ Returns a map of supported features for the current binary.
   "batch": true,
   "applyPatch": true,
   "setLanguage": true,
+  "replaceText": true,
+  "cellEdit": true,
   "streaming": false,
   "partialUpdate": false
 }
@@ -639,6 +645,44 @@ Applies a sequence of patch operations to an existing document sequentially. **T
 
 ---
 
+### document.replaceText
+
+Replaces every occurrence of a literal string with another, across body paragraphs, table cells, headers, and footers.
+
+Matching is case-sensitive. Text fragmented across runs with identical formatting is matched as if it were one run; a match spanning runs with *different* formatting is still replaced, taking the formatting of the first run it touches — which flattens that formatting. For example, replacing `": PENDING ("` with `": DONE ("` in `"Status: **PENDING** (review)"` produces `"Status: DONE (review)"` with the bold lost, because the match spans the plain/bold boundary. A match that touches a run containing a field (page number, TOC, MERGEFIELD, hyperlink), a break, or an image is left untouched and counted in `skipped` instead — rewriting that run's text would corrupt or silently discard the non-text content.
+
+This does not reach into tables nested inside other tables, or into tables placed inside a header or footer — the same traversal limits as `template.render`/`template.inspect`, which share the underlying paragraph walk.
+
+**Params:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `documentId` | String | Yes | Session document ID |
+| `find` | String | Yes | Literal text to search for; must not be empty |
+| `replace` | String | Yes | Replacement text; an empty string deletes each match |
+
+**Success result:**
+
+```json
+{ "replaced": 2, "skipped": 1 }
+```
+
+**Example:**
+
+```json
+{
+  "id": 11,
+  "method": "document.replaceText",
+  "params": {
+    "documentId": "doc-1",
+    "find": "{{status}}",
+    "replace": "Approved"
+  }
+}
+```
+
+---
+
 ### paragraph.add
 
 Adds a single paragraph to an existing document. Supports the same paragraph properties as the content array (style, alignment, spacing, runs, etc.).
@@ -710,6 +754,44 @@ Lists all paragraphs in a document with their text and style.
 
 ---
 
+### paragraph.setText
+
+Replaces a body paragraph's content by index (the same index reported by `paragraph.list`). This clears all of the paragraph's existing runs before writing the new content, so it is a full replacement, not an append.
+
+Accepts the same content fields as `paragraph.add`. Passing only `style` (no `text` and no `runs`) clears the paragraph's runs and writes nothing back — the paragraph is emptied, not left unchanged. This method only addresses paragraphs in the document body; paragraphs inside table cells or headers/footers are not reachable by index here — use `table.setCell` for cell content.
+
+**Params:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `documentId` | String | Yes | Session document ID |
+| `index` | Number | Yes | Zero-based body paragraph index, as reported by `paragraph.list` |
+| `text` \| `runs` \| `style` \| ... | — | No | Same content fields as `paragraph.add` |
+
+**Success result:**
+
+```json
+{ "ok": true, "index": 0 }
+```
+
+**Example:**
+
+```json
+{
+  "id": 12,
+  "method": "paragraph.setText",
+  "params": {
+    "documentId": "doc-1",
+    "index": 0,
+    "runs": [
+      { "text": "Completed", "bold": true }
+    ]
+  }
+}
+```
+
+---
+
 ### table.add
 
 Adds a table to an existing document. Uses the same table format as the content array.
@@ -770,6 +852,7 @@ Lists all tables in a document with their dimensions.
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `documentId` | String | Yes | Session document ID |
+| `includeText` | Boolean | No | When true, adds each table's cell texts to the listing (default `false`) |
 
 **Success result:**
 
@@ -780,6 +863,89 @@ Lists all tables in a document with their dimensions.
     { "index": 0, "rows": 3, "columns": 2 },
     { "index": 1, "rows": 5, "columns": 4 }
   ]
+}
+```
+
+With `includeText: true`, each table item also gets a `cells` key: a `[][]string` of one row per table row, and one entry per **actual** cell in that row (a ragged/merged-cell row reports its real cells, not padded to `columns`). Each cell's paragraphs are joined with `"\n"`. The `cells` key is entirely absent when `includeText` is omitted or `false`.
+
+```json
+{
+  "count": 1,
+  "tables": [
+    {
+      "index": 0,
+      "rows": 2,
+      "columns": 2,
+      "cells": [
+        ["Question", "Answer"],
+        ["Do you encrypt data at rest?", "TBD"]
+      ]
+    }
+  ]
+}
+```
+
+---
+
+### table.getCell
+
+Reads a single cell's content by table, row, and column index.
+
+**Params:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `documentId` | String | Yes | Session document ID |
+| `tableIndex` | Number | Yes | Zero-based table index, as reported by `table.list` |
+| `rowIndex` | Number | Yes | Zero-based row index |
+| `columnIndex` | Number | Yes | Zero-based column index |
+
+**Success result:**
+
+```json
+{ "text": "TBD", "paragraphs": ["TBD"], "paragraphCount": 1 }
+```
+
+`text` is the cell's paragraphs joined with `"\n"`.
+
+---
+
+### table.setCell
+
+Replaces a single cell's content by table, row, and column index.
+
+Provide either `text` (a shortcut that writes one plain paragraph) or `paragraphs` (rich paragraph items, same shape as `paragraph.add`) — not both. The cell can grow to fit more paragraphs than it had, but it cannot shrink: paragraphs beyond the new content are left in place as empty paragraphs, since `domain.TableCell` only exposes adding paragraphs, not removing them. `paragraphCount` in the result reflects the cell's paragraph count after the write, which may be larger than the number of items you provided. To clear a cell, pass `"paragraphs": []` rather than `"text": ""` — an empty `text` is indistinguishable from omitting it.
+
+**Params:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `documentId` | String | Yes | Session document ID |
+| `tableIndex` | Number | Yes | Zero-based table index |
+| `rowIndex` | Number | Yes | Zero-based row index |
+| `columnIndex` | Number | Yes | Zero-based column index |
+| `text` | String | No | Plain-text shortcut; mutually exclusive with `paragraphs` |
+| `paragraphs` | Array | No | Rich paragraph items; mutually exclusive with `text` |
+
+**Success result:**
+
+```json
+{ "ok": true, "paragraphCount": 1 }
+```
+
+**Example:**
+
+```json
+{
+  "id": 13,
+  "method": "table.setCell",
+  "params": {
+    "documentId": "doc-1",
+    "tableIndex": 0,
+    "rowIndex": 1,
+    "columnIndex": 1,
+    "text": "Yes"
+  }
 }
 ```
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -653,8 +653,8 @@ Matching is case-sensitive. Text fragmented across runs with identical formattin
 
 Some matches are reported in `skipped` instead of being replaced:
 
-- A match touching a run that carries a **field** (page number, TOC, MERGEFIELD, hyperlink) is always skipped. Word regenerates a field's displayed text when it opens the document, so replacing it would report a change that never appears.
-- A match spanning **several** runs is also skipped when any of them carries a line/page break or an image, because collapsing those runs would leave that content stranded in the middle of the replacement. A match that fits inside a *single* run carrying a break or image is replaced normally, and the break or image is preserved.
+- A match touching a run that carries a **field** (page number, TOC, MERGEFIELD, hyperlink) is always skipped. Word regenerates a field's displayed text when it opens the document, so replacing it would report a change that never appears. This includes a field on a run holding no text of its own — the shape Word uses for a MERGEFIELD, where the field sits in an empty run immediately before the run holding its display text.
+- A match spanning **several** runs is also skipped when any run between its ends carries a line/page break or an image, because collapsing those runs would leave that content stranded in the middle of the replacement. A match that fits inside a *single* run carrying a break or image is replaced normally, and the break or image is preserved.
 
 This does not reach into tables nested inside other tables, or into tables placed inside a header or footer — the same traversal limits as `template.render`/`template.inspect`, which share the underlying paragraph walk.
 
@@ -871,7 +871,9 @@ Lists all tables in a document with their dimensions.
 }
 ```
 
-With `includeText: true`, each table item also gets a `cells` key: a `[][]string` of one row per table row, and one entry per **actual** cell in that row (a ragged/merged-cell row reports its real cells, not padded to `columns`). Each cell's paragraphs are joined with `"\n"`. The `cells` key is entirely absent when `includeText` is omitted or `false`.
+With `includeText: true`, each table item also gets a `cells` key: a `[][]string` of one row per table row, and one entry per cell that row actually holds. Each cell's paragraphs are joined with `"\n"`. The `cells` key is entirely absent when `includeText` is omitted or `false`.
+
+Note what this does **not** tell you about merged cells. A document read via `document.open` is reconstructed with every row padded to the full column grid, with the cells covered by a horizontal merge kept as empty placeholders — so a 4-column row made of two 2-column merges lists as `["Overview", "", "Detail", ""]`, not as two entries. Those empty strings are merge continuations, not empty cells, and `table.setCell` rejects writes to them (their content is never serialized). Only tables built in-session via `document.create` with genuinely ragged rows report fewer cells than `columns`.
 
 ```json
 {
@@ -919,7 +921,13 @@ Reads a single cell's content by table, row, and column index.
 
 Replaces a single cell's content by table, row, and column index.
 
-Provide either `text` (a shortcut that writes one plain paragraph) or `paragraphs` (rich paragraph items, same shape as `paragraph.add`) — not both. The cell can grow to fit more paragraphs than it had, but it cannot shrink: paragraphs beyond the new content are left in place as empty paragraphs, since `domain.TableCell` only exposes adding paragraphs, not removing them. `paragraphCount` in the result reflects the cell's paragraph count after the write, which may be larger than the number of items you provided. To clear a cell, pass `"paragraphs": []` rather than `"text": ""` — an empty `text` is indistinguishable from omitting it.
+Provide exactly one of `text` (a shortcut that writes one plain paragraph) or `paragraphs` (rich paragraph items, same shape as `paragraph.add`). Supplying **both** is rejected, and so is supplying **neither** — this method replaces the cell's content, so a request that names no content at all (a misspelled field, say) is an error rather than a silent wipe. To empty a cell, pass `"paragraphs": []` or `"text": ""`.
+
+The whole request is validated before the cell is touched: if any paragraph item is malformed or rejected, the call fails and the cell keeps its original content.
+
+Writes to a cell covered by a horizontal merge are rejected. Such a cell is never written to the file, so accepting the write would report success and then silently drop the content on save — target the leading cell of the merged region instead.
+
+The cell can grow to fit more paragraphs than it had, but it cannot shrink: paragraphs beyond the new content are left in place as empty paragraphs, since `domain.TableCell` only exposes adding paragraphs, not removing them. `paragraphCount` in the result reflects the cell's paragraph count after the write, which may be larger than the number of items you provided.
 
 **Params:**
 
@@ -929,8 +937,8 @@ Provide either `text` (a shortcut that writes one plain paragraph) or `paragraph
 | `tableIndex` | Number | Yes | Zero-based table index |
 | `rowIndex` | Number | Yes | Zero-based row index |
 | `columnIndex` | Number | Yes | Zero-based column index |
-| `text` | String | No | Plain-text shortcut; mutually exclusive with `paragraphs` |
-| `paragraphs` | Array | No | Rich paragraph items; mutually exclusive with `text` |
+| `text` | String | One of the two | Plain-text shortcut; mutually exclusive with `paragraphs`. `""` empties the cell |
+| `paragraphs` | Array | One of the two | Rich paragraph items; mutually exclusive with `text`. `[]` empties the cell |
 
 **Success result:**
 

--- a/internal/core/field.go
+++ b/internal/core/field.go
@@ -24,6 +24,12 @@ type docxField struct {
 	result     string
 	isDirty    bool // Indicates if field needs recalculation
 	properties map[string]string
+	// err records a rejection from one of the New*Field constructors — a
+	// caller-supplied value that would have broken out of the field code's
+	// quoted argument (e.g. a `"` in a hyperlink URL or a STYLEREF style
+	// name). The field is left with its safe default code; run.AddField
+	// checks this via ValidationError and refuses to attach the field.
+	err error
 }
 
 // NewField creates a new field with the specified type.
@@ -62,28 +68,63 @@ func NewTOCField(switches map[string]string) domain.Field {
 	}
 
 	// Rebuild code with switches
-	field.code = field.buildTOCCode()
+	code, err := field.buildTOCCode()
+	if err != nil {
+		field.err = err
+		return field
+	}
+	field.code = code
 
 	return field
 }
 
 // NewHyperlinkField creates a hyperlink field.
+//
+// url must not contain a double quote: it is interpolated inside a quoted
+// field-code argument, and Word's field-code syntax has no escape the
+// docxgo reader can round-trip (see extractQuotedStrings in
+// internal/reader/reconstruct.go). A url containing one is rejected — the
+// field is left with a safe default code and no url/display property, and
+// run.AddField refuses to attach it — rather than producing a corrupted or
+// injectable field code.
 func NewHyperlinkField(url, displayText string) domain.Field {
 	field := NewField(domain.FieldTypeHyperlink).(*docxField)
+	safe := strings.ReplaceAll(url, `"`, "")
+	if safe != url {
+		field.err = errors.NewValidationError("NewHyperlinkField", "url", url,
+			`url must not contain a double quote`)
+		return field
+	}
 	field.properties["url"] = url
 	field.properties["display"] = displayText
-	field.code = fmt.Sprintf(`HYPERLINK "%s"`, url)
+	field.code = fmt.Sprintf(`HYPERLINK "%s"`, safe)
 	field.result = displayText
 	field.isDirty = false
 	return field
 }
 
-// NewStyleRefField creates a STYLEREF field.
+// NewStyleRefField creates a STYLEREF field. styleName is subject to the
+// same quoting constraint as NewHyperlinkField's url.
 func NewStyleRefField(styleName string) domain.Field {
 	field := NewField(domain.FieldTypeStyleRef).(*docxField)
+	safe := strings.ReplaceAll(styleName, `"`, "")
+	if safe != styleName {
+		field.err = errors.NewValidationError("NewStyleRefField", "styleName", styleName,
+			`styleName must not contain a double quote`)
+		return field
+	}
 	field.properties["style"] = styleName
-	field.code = fmt.Sprintf(`STYLEREF "%s"`, styleName)
+	field.code = fmt.Sprintf(`STYLEREF "%s"`, safe)
 	return field
+}
+
+// ValidationError reports a rejection recorded by NewHyperlinkField,
+// NewStyleRefField, or NewTOCField. run.AddField checks this via a type
+// assertion and refuses to attach a field that failed construction.
+func (f *docxField) ValidationError() error {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.err
 }
 
 // Type returns the field type.
@@ -212,13 +253,19 @@ func (f *docxField) getDefaultCode() string {
 	}
 }
 
-// buildTOCCode builds a TOC field code with switches.
-func (f *docxField) buildTOCCode() string {
+// buildTOCCode builds a TOC field code with switches. levels is subject to
+// the same quoting constraint as NewHyperlinkField's url.
+func (f *docxField) buildTOCCode() (string, error) {
 	code := constants.FieldCodeTOC
 
 	// Heading levels (default 1-3)
 	if levels, ok := f.properties["levels"]; ok {
-		code += fmt.Sprintf(` \\o "%s"`, levels)
+		safe := strings.ReplaceAll(levels, `"`, "")
+		if safe != levels {
+			return "", errors.NewValidationError("NewTOCField", "levels", levels,
+				`levels must not contain a double quote`)
+		}
+		code += fmt.Sprintf(` \\o "%s"`, safe)
 	} else {
 		code += ` \\o "1-3"`
 	}
@@ -242,7 +289,7 @@ func (f *docxField) buildTOCCode() string {
 	// Use styles
 	code += ` \\u`
 
-	return code
+	return code, nil
 }
 
 // SetProperty sets a field property (for advanced customization).

--- a/internal/core/run.go
+++ b/internal/core/run.go
@@ -209,6 +209,12 @@ func (r *run) AddField(field domain.Field) error {
 		return errors.InvalidArgument("Run.AddField", "field", nil, "field cannot be nil")
 	}
 
+	if validator, ok := field.(interface{ ValidationError() error }); ok {
+		if err := validator.ValidationError(); err != nil {
+			return errors.Wrap(err, "Run.AddField")
+		}
+	}
+
 	if field.Type() == domain.FieldTypeHyperlink {
 		accessor, ok := field.(interface {
 			GetProperty(string) (string, bool)

--- a/npm/README.md
+++ b/npm/README.md
@@ -402,10 +402,14 @@ The following JSON-RPC methods are available:
 | `document.addContent` | Append content items to an opened document |
 | `document.addPageBreak` | Append a page break |
 | `document.applyPatch` | Apply multi-operation patches sequentially (not atomic) |
+| `document.replaceText` | Find-and-replace a literal string across the document |
 | `paragraph.add` | Add a single paragraph |
 | `paragraph.list` | List all paragraphs |
+| `paragraph.setText` | Replace a body paragraph's content by index |
 | `table.add` | Add a single table |
-| `table.list` | List all tables |
+| `table.list` | List all tables (optionally with cell text) |
+| `table.getCell` | Read a single table cell's content |
+| `table.setCell` | Replace a single table cell's content |
 | `section.add` | Add a section break |
 | `template.inspect` | Find template placeholders |
 | `template.render` | Render template with data |

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -71,8 +71,13 @@ export type {
   AddPageBreakParams,
   ParagraphAddParams,
   ParagraphListParams,
+  ParagraphSetTextParams,
   TableAddParams,
   TableListParams,
+  TableCellRef,
+  TableGetCellParams,
+  TableSetCellParams,
+  ReplaceTextParams,
   SectionAddParams,
   CloseParams,
   // Results
@@ -91,6 +96,9 @@ export type {
   ParagraphListResult,
   TableInfo,
   TableListResult,
+  TableCellResult,
+  TableSetCellResult,
+  ReplaceTextResult,
   // System
   PingResult,
   SystemVersionResult,

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -160,6 +160,8 @@ export interface ParagraphBordersDef {
 /** A paragraph content item. */
 export interface ParagraphItem {
   type: 'paragraph';
+  /** Plain-text shortcut for a single unformatted run. Ignored when `runs` is given. */
+  text?: string;
   style?: string;
   alignment?: Alignment;
   spacingBefore?: number;
@@ -451,6 +453,8 @@ export interface TableInfo {
   index: number;
   rows: number;
   columns: number;
+  /** Present only when table.list was called with `includeText: true`. */
+  cells?: string[][];
 }
 
 export interface TableListResult {

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -300,6 +300,8 @@ export interface AddPageBreakParams {
 
 export interface ParagraphAddParams {
   documentId: string;
+  /** Plain-text shortcut for a single unformatted run. Ignored when `runs` is given. */
+  text?: string;
   style?: string;
   alignment?: Alignment;
   spacingBefore?: number;
@@ -343,7 +345,11 @@ export interface TableCellRef {
 
 export type TableGetCellParams = TableCellRef;
 
-/** Provide either `text` or `paragraphs`, not both. */
+/**
+ * Provide exactly one of `text` or `paragraphs` — supplying both, or neither,
+ * is rejected. Both replace the cell's content, so `text: ''` and
+ * `paragraphs: []` are meaningful requests to empty it.
+ */
 export interface TableSetCellParams extends TableCellRef {
   text?: string;
   paragraphs?: Array<Omit<ParagraphItem, 'type'>>;

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -315,6 +315,11 @@ export interface ParagraphListParams {
   documentId: string;
 }
 
+/** Replaces a body paragraph's content by index (as reported by paragraph.list). */
+export interface ParagraphSetTextParams extends ParagraphAddParams {
+  index: number;
+}
+
 export interface TableAddParams {
   documentId: string;
   rows?: TableRowDef[];
@@ -325,6 +330,29 @@ export interface TableAddParams {
 
 export interface TableListParams {
   documentId: string;
+  /** When true, adds each table's cell texts to the listing. */
+  includeText?: boolean;
+}
+
+export interface TableCellRef {
+  documentId: string;
+  tableIndex: number;
+  rowIndex: number;
+  columnIndex: number;
+}
+
+export type TableGetCellParams = TableCellRef;
+
+/** Provide either `text` or `paragraphs`, not both. */
+export interface TableSetCellParams extends TableCellRef {
+  text?: string;
+  paragraphs?: Array<Omit<ParagraphItem, 'type'>>;
+}
+
+export interface ReplaceTextParams {
+  documentId: string;
+  find: string;
+  replace: string;
 }
 
 export interface SectionAddParams {
@@ -422,6 +450,27 @@ export interface TableInfo {
 export interface TableListResult {
   count: number;
   tables: TableInfo[];
+}
+
+/** Result of table.getCell. */
+export interface TableCellResult {
+  /** The cell's paragraphs joined with "\n". */
+  text: string;
+  paragraphs: string[];
+  paragraphCount: number;
+}
+
+/** Result of table.setCell. The cell can grow but never shrink; this is the
+ * paragraph count after the write, which may exceed what was written. */
+export interface TableSetCellResult {
+  ok: boolean;
+  paragraphCount: number;
+}
+
+/** Result of document.replaceText. */
+export interface ReplaceTextResult {
+  replaced: number;
+  skipped: number;
 }
 
 // ─── System Types ────────────────────────────────────────────────────────────

--- a/pkg/template/replace.go
+++ b/pkg/template/replace.go
@@ -60,6 +60,13 @@ type runSpan struct {
 // scan resumes just past the inserted replacement, so a replacement that
 // itself contains find is never re-matched.
 func replaceInParagraph(para domain.Paragraph, find, replace string) (replaced, skipped int, err error) {
+	// Consolidation never changes a paragraph's concatenated text, only run
+	// boundaries — so a paragraph with no match anywhere must be left
+	// untouched rather than restructured as a side effect of searching it.
+	if _, full := paragraphSpans(para); !strings.Contains(full, find) {
+		return 0, 0, nil
+	}
+
 	if err := ConsolidateRuns(para); err != nil {
 		return 0, 0, err
 	}

--- a/pkg/template/replace.go
+++ b/pkg/template/replace.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Misael Monterroca
+//
+// See LICENSE for the full copyright notice, including predecessor authors,
+// and CREDITS.md for the project genealogy.
+
+package template
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mmonterroca/docxgo/v2/domain"
+)
+
+// ReplaceResult reports the outcome of a ReplaceText call.
+type ReplaceResult struct {
+	// Replaced is the number of occurrences that were replaced.
+	Replaced int
+	// Skipped is the number of occurrences that were found but left
+	// untouched because the match spans a run with non-text content
+	// (fields, breaks, or images).
+	Skipped int
+}
+
+// ReplaceText replaces every occurrence of find with replace across the
+// document: body paragraphs, table cells, headers, and footers. The document
+// is modified in place.
+//
+// Matching is literal and case-sensitive. Runs in each paragraph are first
+// consolidated (see ConsolidateRuns), so text fragmented across runs with
+// identical formatting is matched. A match that spans runs with different
+// formatting is replaced too: the replacement takes the formatting of the
+// first spanned run. Matches that span a run containing fields, breaks, or
+// images are skipped and counted in ReplaceResult.Skipped.
+func ReplaceText(doc domain.Document, find, replace string) (ReplaceResult, error) {
+	if find == "" {
+		return ReplaceResult{}, fmt.Errorf("template: find text must not be empty")
+	}
+
+	var result ReplaceResult
+	err := walkParagraphs(doc, func(para domain.Paragraph, _ paragraphContext) error {
+		replaced, skipped, err := replaceInParagraph(para, find, replace)
+		result.Replaced += replaced
+		result.Skipped += skipped
+		return err
+	})
+	return result, err
+}
+
+// runSpan maps a run to its byte-offset range [start, end) within the
+// paragraph's concatenated text.
+type runSpan struct {
+	run        domain.Run
+	start, end int
+}
+
+// replaceInParagraph replaces occurrences of find within a single paragraph.
+// After each successful replacement the paragraph text is rebuilt and the
+// scan resumes just past the inserted replacement, so a replacement that
+// itself contains find is never re-matched.
+func replaceInParagraph(para domain.Paragraph, find, replace string) (replaced, skipped int, err error) {
+	if err := ConsolidateRuns(para); err != nil {
+		return 0, 0, err
+	}
+
+	cursor := 0
+	for {
+		spans, full := paragraphSpans(para)
+		if cursor >= len(full) {
+			break
+		}
+		rel := strings.Index(full[cursor:], find)
+		if rel < 0 {
+			break
+		}
+		start := cursor + rel
+		end := start + len(find)
+
+		ok, err := replaceSpan(spans, start, end, replace)
+		if err != nil {
+			return replaced, skipped, err
+		}
+		if ok {
+			replaced++
+			cursor = start + len(replace)
+		} else {
+			skipped++
+			cursor = end
+		}
+	}
+	return replaced, skipped, nil
+}
+
+// paragraphSpans returns the paragraph's runs with their byte-offset ranges
+// and the concatenated paragraph text.
+func paragraphSpans(para domain.Paragraph) ([]runSpan, string) {
+	runs := para.Runs()
+	spans := make([]runSpan, 0, len(runs))
+	var sb strings.Builder
+	off := 0
+	for _, r := range runs {
+		t := r.Text()
+		spans = append(spans, runSpan{run: r, start: off, end: off + len(t)})
+		sb.WriteString(t)
+		off += len(t)
+	}
+	return spans, sb.String()
+}
+
+// replaceSpan writes replace over the byte range [start, end) of the
+// paragraph text. A match confined to a single run is always replaceable;
+// a match spanning several runs is replaceable only if every spanned run is
+// text-only. Returns false (and no error) when the match must be skipped.
+func replaceSpan(spans []runSpan, start, end int, replace string) (bool, error) {
+	var spanned []runSpan
+	for _, s := range spans {
+		// Zero-width (empty) runs cannot contribute match text.
+		if s.end > s.start && s.start < end && s.end > start {
+			spanned = append(spanned, s)
+		}
+	}
+	if len(spanned) == 0 {
+		return false, nil
+	}
+
+	if len(spanned) > 1 {
+		for _, s := range spanned {
+			if !isTextOnly(s.run) {
+				return false, nil
+			}
+		}
+	}
+
+	first := spanned[0]
+	last := spanned[len(spanned)-1]
+	firstText := first.run.Text()
+	lastText := last.run.Text()
+
+	if len(spanned) == 1 {
+		newText := firstText[:start-first.start] + replace + firstText[end-first.start:]
+		return true, first.run.SetText(newText)
+	}
+
+	if err := first.run.SetText(firstText[:start-first.start] + replace); err != nil {
+		return false, err
+	}
+	for _, s := range spanned[1 : len(spanned)-1] {
+		if err := s.run.SetText(""); err != nil {
+			return false, err
+		}
+	}
+	return true, last.run.SetText(lastText[end-last.start:])
+}

--- a/pkg/template/replace.go
+++ b/pkg/template/replace.go
@@ -116,9 +116,11 @@ func paragraphSpans(para domain.Paragraph) ([]runSpan, string) {
 }
 
 // replaceSpan writes replace over the byte range [start, end) of the
-// paragraph text. A match confined to a single run is always replaceable;
-// a match spanning several runs is replaceable only if every spanned run is
-// text-only. Returns false (and no error) when the match must be skipped.
+// paragraph text. A match is replaceable only if every run it spans —
+// whether that's one run or several — is text-only; a match touching a run
+// with a field, break, or image is skipped, since rewriting that run's text
+// would corrupt or silently discard the non-text content. Returns false
+// (and no error) when the match must be skipped.
 func replaceSpan(spans []runSpan, start, end int, replace string) (bool, error) {
 	var spanned []runSpan
 	for _, s := range spans {
@@ -131,11 +133,9 @@ func replaceSpan(spans []runSpan, start, end int, replace string) (bool, error) 
 		return false, nil
 	}
 
-	if len(spanned) > 1 {
-		for _, s := range spanned {
-			if !isTextOnly(s.run) {
-				return false, nil
-			}
+	for _, s := range spanned {
+		if !isTextOnly(s.run) {
+			return false, nil
 		}
 	}
 

--- a/pkg/template/replace.go
+++ b/pkg/template/replace.go
@@ -18,8 +18,8 @@ type ReplaceResult struct {
 	// Replaced is the number of occurrences that were replaced.
 	Replaced int
 	// Skipped is the number of occurrences that were found but left
-	// untouched because the match spans a run with non-text content
-	// (fields, breaks, or images).
+	// untouched because replacing them would not survive serialization.
+	// See ReplaceText for exactly which run contents cause a skip.
 	Skipped int
 }
 
@@ -31,8 +31,15 @@ type ReplaceResult struct {
 // consolidated (see ConsolidateRuns), so text fragmented across runs with
 // identical formatting is matched. A match that spans runs with different
 // formatting is replaced too: the replacement takes the formatting of the
-// first spanned run. Matches that span a run containing fields, breaks, or
-// images are skipped and counted in ReplaceResult.Skipped.
+// first spanned run.
+//
+// A match touching a run that carries a field is always skipped and counted
+// in ReplaceResult.Skipped — such a run's text is never serialized, so
+// rewriting it would report a replacement Word does not make. A match
+// spanning several runs is likewise skipped when any of them carries a break
+// or an image, since blanking a spanned run would strand that content in the
+// middle of the replacement. A match confined to a single run carrying a
+// break or an image is replaced, and the break or image is preserved.
 func ReplaceText(doc domain.Document, find, replace string) (ReplaceResult, error) {
 	if find == "" {
 		return ReplaceResult{}, fmt.Errorf("template: find text must not be empty")
@@ -116,11 +123,8 @@ func paragraphSpans(para domain.Paragraph) ([]runSpan, string) {
 }
 
 // replaceSpan writes replace over the byte range [start, end) of the
-// paragraph text. A match is replaceable only if every run it spans —
-// whether that's one run or several — is text-only; a match touching a run
-// with a field, break, or image is skipped, since rewriting that run's text
-// would corrupt or silently discard the non-text content. Returns false
-// (and no error) when the match must be skipped.
+// paragraph text, subject to the run-content rules documented on
+// ReplaceText. Returns false (and no error) when the match must be skipped.
 func replaceSpan(spans []runSpan, start, end int, replace string) (bool, error) {
 	var spanned []runSpan
 	for _, s := range spans {
@@ -133,9 +137,28 @@ func replaceSpan(spans []runSpan, start, end int, replace string) (bool, error) 
 		return false, nil
 	}
 
+	// A field-bearing run's text is never serialized: the paragraph
+	// serializer routes it through expandRunWithFields, which emits the
+	// field's own result instead. Rewriting that run's text would report a
+	// replacement Word never makes, so skip the match however few runs it
+	// spans.
 	for _, s := range spanned {
-		if !isTextOnly(s.run) {
+		if len(s.run.Fields()) > 0 {
 			return false, nil
+		}
+	}
+
+	// Breaks and images are the opposite case: a run carrying one still has
+	// its text serialized normally, and SetText leaves the break or image
+	// alone, so a match confined to that single run is safely replaceable.
+	// Across several runs it is not — blanking a spanned middle run's text
+	// would strand its break or image in the middle of the replacement — so
+	// only the multi-run path applies the stricter test.
+	if len(spanned) > 1 {
+		for _, s := range spanned {
+			if !isTextOnly(s.run) {
+				return false, nil
+			}
 		}
 	}
 

--- a/pkg/template/replace.go
+++ b/pkg/template/replace.go
@@ -126,10 +126,18 @@ func paragraphSpans(para domain.Paragraph) ([]runSpan, string) {
 // paragraph text, subject to the run-content rules documented on
 // ReplaceText. Returns false (and no error) when the match must be skipped.
 func replaceSpan(spans []runSpan, start, end int, replace string) (bool, error) {
+	// Runs that actually carry matched text. Zero-width runs contribute no
+	// match text, so only these are ever rewritten below — but they are not
+	// the whole story for deciding whether the match may be rewritten at
+	// all, which is what the two scans further down widen.
+	lo, hi := -1, -1
 	var spanned []runSpan
-	for _, s := range spans {
-		// Zero-width (empty) runs cannot contribute match text.
+	for i, s := range spans {
 		if s.end > s.start && s.start < end && s.end > start {
+			if lo < 0 {
+				lo = i
+			}
+			hi = i
 			spanned = append(spanned, s)
 		}
 	}
@@ -139,10 +147,21 @@ func replaceSpan(spans []runSpan, start, end int, replace string) (bool, error) 
 
 	// A field-bearing run's text is never serialized: the paragraph
 	// serializer routes it through expandRunWithFields, which emits the
-	// field's own result instead. Rewriting that run's text would report a
-	// replacement Word never makes, so skip the match however few runs it
-	// spans.
-	for _, s := range spanned {
+	// field's own result instead. Rewriting around it would report a
+	// replacement Word never makes, so any field vetoes the match however
+	// few runs it spans.
+	//
+	// The scan starts before the first matched run because Word stores a
+	// MERGEFIELD as an empty field-bearing run immediately followed by the
+	// run holding its display text (see replaceParagraph in merge.go): the
+	// field carries no text of its own, so an overlap test alone never sees
+	// it, yet replacing the display text would leave the field live beside
+	// the replacement.
+	fieldLo := lo
+	for fieldLo > 0 && spans[fieldLo-1].end == spans[fieldLo-1].start {
+		fieldLo--
+	}
+	for _, s := range spans[fieldLo : hi+1] {
 		if len(s.run.Fields()) > 0 {
 			return false, nil
 		}
@@ -150,12 +169,13 @@ func replaceSpan(spans []runSpan, start, end int, replace string) (bool, error) 
 
 	// Breaks and images are the opposite case: a run carrying one still has
 	// its text serialized normally, and SetText leaves the break or image
-	// alone, so a match confined to that single run is safely replaceable.
-	// Across several runs it is not — blanking a spanned middle run's text
-	// would strand its break or image in the middle of the replacement — so
-	// only the multi-run path applies the stricter test.
+	// alone, so a match confined to a single run is safely replaceable.
+	// Across several runs it is not — the runs between the ends are blanked,
+	// and a break or image among them would be stranded in the middle of the
+	// replacement. That includes zero-width runs interleaved between the
+	// matched ones, the shape the reader produces for a standalone <w:br/>.
 	if len(spanned) > 1 {
-		for _, s := range spanned {
+		for _, s := range spans[lo : hi+1] {
 			if !isTextOnly(s.run) {
 				return false, nil
 			}

--- a/pkg/template/replace_test.go
+++ b/pkg/template/replace_test.go
@@ -7,6 +7,7 @@
 package template
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/mmonterroca/docxgo/v2/domain"
@@ -194,5 +195,116 @@ func TestReplaceText_NoMatch(t *testing.T) {
 	}
 	if got := para.Text(); got != "nothing to see" {
 		t.Errorf("paragraph text = %q, want unchanged", got)
+	}
+}
+
+// TestReplaceText_NoMatchDoesNotMutate guards against ReplaceText
+// restructuring runs it never needed to touch. ConsolidateRuns only moves
+// run boundaries — it never changes a paragraph's concatenated text — so a
+// paragraph containing no occurrence of find must come out with exactly the
+// same runs it went in with, in the body, in a table cell, and in a header.
+func TestReplaceText_NoMatchDoesNotMutate(t *testing.T) {
+	doc := core.NewDocument()
+
+	bodyPara, _ := doc.AddParagraph()
+	for _, chunk := range []string{"Not ", "Applic", "able"} {
+		r, _ := bodyPara.AddRun()
+		r.SetText(chunk)
+	}
+
+	table, _ := doc.AddTable(1, 1)
+	cell, _ := table.Rows()[0].Cell(0)
+	cellPara, _ := cell.AddParagraph()
+	for _, chunk := range []string{"Cell ", "Text"} {
+		r, _ := cellPara.AddRun()
+		r.SetText(chunk)
+	}
+
+	section := doc.Sections()[0]
+	header, err := section.Header(domain.HeaderDefault)
+	if err != nil {
+		t.Fatalf("Header: %v", err)
+	}
+	headerPara, _ := header.AddParagraph()
+	for _, chunk := range []string{"Header ", "Text"} {
+		r, _ := headerPara.AddRun()
+		r.SetText(chunk)
+	}
+
+	wantBodyRuns := len(bodyPara.Runs())
+	wantCellRuns := len(cellPara.Runs())
+	wantHeaderRuns := len(headerPara.Runs())
+
+	result, err := ReplaceText(doc, "absent from every paragraph", "x")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 0 || result.Skipped != 0 {
+		t.Errorf("result = %+v, want zero result", result)
+	}
+
+	if got := len(bodyPara.Runs()); got != wantBodyRuns {
+		t.Errorf("body paragraph run count = %d, want %d (unchanged)", got, wantBodyRuns)
+	}
+	if got := len(cellPara.Runs()); got != wantCellRuns {
+		t.Errorf("table cell paragraph run count = %d, want %d (unchanged)", got, wantCellRuns)
+	}
+	if got := len(headerPara.Runs()); got != wantHeaderRuns {
+		t.Errorf("header paragraph run count = %d, want %d (unchanged)", got, wantHeaderRuns)
+	}
+}
+
+// TestReplaceText_SkipsFieldInSingleRun pins the fix for a match confined to
+// a single run that also carries a field. Rewriting that run's text with
+// SetText would leave the field markup pointing at text Word no longer sees,
+// and Word re-renders the field's own result on open — silently discarding
+// the edit — so a match here must be skipped like any other non-text run.
+func TestReplaceText_SkipsFieldInSingleRun(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r, _ := para.AddRun()
+	if err := r.AddField(core.NewPageNumberField()); err != nil {
+		t.Fatalf("AddField: %v", err)
+	}
+	if err := r.SetText("Page 1 of 10"); err != nil {
+		t.Fatalf("SetText: %v", err)
+	}
+
+	result, err := ReplaceText(doc, "Page 1 of 10", "Page 1 of Y")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 0 || result.Skipped != 1 {
+		t.Errorf("result = %+v, want 0 replaced / 1 skipped", result)
+	}
+	if got := para.Text(); got != "Page 1 of 10" {
+		t.Errorf("paragraph text = %q, want unchanged", got)
+	}
+	if len(r.Fields()) != 1 {
+		t.Errorf("field was dropped from the run")
+	}
+}
+
+// TestReplaceText_DeletionMatchesStdlibSemantics fixes the deletion
+// semantics as intentional, matching strings.ReplaceAll's non-overlapping
+// left-to-right scan: a match created by an earlier deletion, starting
+// before the point the scan resumed from, is not retroactively found.
+func TestReplaceText_DeletionMatchesStdlibSemantics(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r, _ := para.AddRun()
+	r.SetText("aabb")
+
+	result, err := ReplaceText(doc, "ab", "")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+
+	want := strings.ReplaceAll("aabb", "ab", "")
+	if got := para.Text(); got != want {
+		t.Errorf("paragraph text = %q, want %q (matches strings.ReplaceAll)", got, want)
+	}
+	if result.Replaced != 1 {
+		t.Errorf("replaced = %d, want 1", result.Replaced)
 	}
 }

--- a/pkg/template/replace_test.go
+++ b/pkg/template/replace_test.go
@@ -285,6 +285,37 @@ func TestReplaceText_SkipsFieldInSingleRun(t *testing.T) {
 	}
 }
 
+// TestReplaceText_ReplacesInSingleRunCarryingABreak pins the other half of
+// the run-content rule. Unlike a field, a break's run still has its text
+// serialized normally, and SetText leaves the break itself alone — so a
+// match confined to that one run is replaceable, and skipping it would lose
+// a legitimate replacement rather than prevent a bad one.
+func TestReplaceText_ReplacesInSingleRunCarryingABreak(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r, _ := para.AddRun()
+	if err := r.SetText("Line one and TODO"); err != nil {
+		t.Fatalf("SetText: %v", err)
+	}
+	if err := r.AddBreak(domain.BreakTypeLine); err != nil {
+		t.Fatalf("AddBreak: %v", err)
+	}
+
+	result, err := ReplaceText(doc, "TODO", "done")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 1 || result.Skipped != 0 {
+		t.Errorf("result = %+v, want 1 replaced / 0 skipped", result)
+	}
+	if got := para.Text(); got != "Line one and done" {
+		t.Errorf("paragraph text = %q", got)
+	}
+	if len(r.Breaks()) != 1 {
+		t.Errorf("break count = %d, want 1 (preserved)", len(r.Breaks()))
+	}
+}
+
 // TestReplaceText_DeletionMatchesStdlibSemantics fixes the deletion
 // semantics as intentional, matching strings.ReplaceAll's non-overlapping
 // left-to-right scan: a match created by an earlier deletion, starting

--- a/pkg/template/replace_test.go
+++ b/pkg/template/replace_test.go
@@ -316,6 +316,87 @@ func TestReplaceText_ReplacesInSingleRunCarryingABreak(t *testing.T) {
 	}
 }
 
+// TestReplaceText_SkipsMergefieldCarriedOnAnEmptyRun covers the shape Word
+// uses for a mail-merge field: an empty run holding the MERGEFIELD followed
+// by a separate run holding its display text. The field run carries no match
+// text of its own, so a naive overlap test never sees it — but replacing the
+// display text while the field survives leaves the saved document with both
+// the field and the replacement, and a field update in Word reverts the
+// visible text while the replacement lingers. merge.go handles this shape
+// explicitly; replace.go must at least refuse it.
+func TestReplaceText_SkipsMergefieldCarriedOnAnEmptyRun(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+
+	mergeField := core.NewField(domain.FieldTypeCustom)
+	if err := mergeField.SetCode("MERGEFIELD Name"); err != nil {
+		t.Fatalf("SetCode: %v", err)
+	}
+	fieldRun, _ := para.AddRun()
+	if err := fieldRun.AddField(mergeField); err != nil {
+		t.Fatalf("AddField: %v", err)
+	}
+	// The field run carries the field but no text of its own.
+	if err := fieldRun.SetText(""); err != nil {
+		t.Fatalf("SetText: %v", err)
+	}
+
+	textRun, _ := para.AddRun()
+	if err := textRun.SetText("«Name»"); err != nil {
+		t.Fatalf("SetText: %v", err)
+	}
+
+	result, err := ReplaceText(doc, "«Name»", "Alice")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 0 || result.Skipped != 1 {
+		t.Errorf("result = %+v, want 0 replaced / 1 skipped", result)
+	}
+	if got := textRun.Text(); got != "«Name»" {
+		t.Errorf("display text = %q, want unchanged", got)
+	}
+	if len(fieldRun.Fields()) != 1 {
+		t.Errorf("field was dropped from the run")
+	}
+}
+
+// TestReplaceText_SkipsBreakOnAnEmptyRunBetweenMatchedRuns covers the
+// standalone <w:r><w:br/></w:r> shape the reader produces. The break run
+// carries no match text, so it is not part of the spliced span — but it sits
+// between two runs that are, and it survives the replacement stranded in the
+// middle of the text that replaced them.
+func TestReplaceText_SkipsBreakOnAnEmptyRunBetweenMatchedRuns(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+
+	r1, _ := para.AddRun()
+	r1.SetText("Hello")
+
+	breakRun, _ := para.AddRun()
+	if err := breakRun.AddBreak(domain.BreakTypeLine); err != nil {
+		t.Fatalf("AddBreak: %v", err)
+	}
+	breakRun.SetText("")
+
+	r3, _ := para.AddRun()
+	r3.SetText("World")
+
+	result, err := ReplaceText(doc, "HelloWorld", "Hi")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 0 || result.Skipped != 1 {
+		t.Errorf("result = %+v, want 0 replaced / 1 skipped", result)
+	}
+	if got := para.Text(); got != "HelloWorld" {
+		t.Errorf("paragraph text = %q, want unchanged", got)
+	}
+	if len(breakRun.Breaks()) != 1 {
+		t.Errorf("break count = %d, want 1", len(breakRun.Breaks()))
+	}
+}
+
 // TestReplaceText_DeletionMatchesStdlibSemantics fixes the deletion
 // semantics as intentional, matching strings.ReplaceAll's non-overlapping
 // left-to-right scan: a match created by an earlier deletion, starting

--- a/pkg/template/replace_test.go
+++ b/pkg/template/replace_test.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2024-2026 Misael Monterroca
+//
+// See LICENSE for the full copyright notice, including predecessor authors,
+// and CREDITS.md for the project genealogy.
+
+package template
+
+import (
+	"testing"
+
+	"github.com/mmonterroca/docxgo/v2/domain"
+	"github.com/mmonterroca/docxgo/v2/internal/core"
+)
+
+func TestReplaceText_SingleRun(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r, _ := para.AddRun()
+	r.SetText("The answer is TODO for now.")
+
+	result, err := ReplaceText(doc, "TODO", "42")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 1 || result.Skipped != 0 {
+		t.Errorf("result = %+v, want 1 replaced / 0 skipped", result)
+	}
+	if got := para.Text(); got != "The answer is 42 for now." {
+		t.Errorf("paragraph text = %q", got)
+	}
+}
+
+func TestReplaceText_SplitAcrossIdenticalRuns(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	// Word-style fragmentation: same formatting, split mid-word.
+	for _, chunk := range []string{"Not ", "Applic", "able"} {
+		r, _ := para.AddRun()
+		r.SetText(chunk)
+	}
+
+	result, err := ReplaceText(doc, "Not Applicable", "Yes")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 1 {
+		t.Errorf("replaced = %d, want 1", result.Replaced)
+	}
+	if got := para.Text(); got != "Yes" {
+		t.Errorf("paragraph text = %q", got)
+	}
+}
+
+func TestReplaceText_SpanningDifferentFormatting(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r1, _ := para.AddRun()
+	r1.SetText("Status: ")
+	r2, _ := para.AddRun()
+	r2.SetText("PENDING")
+	r2.SetBold(true)
+	r3, _ := para.AddRun()
+	r3.SetText(" (review)")
+
+	// Match spans the normal/bold boundary; consolidation cannot merge these.
+	result, err := ReplaceText(doc, ": PENDING (", ": DONE (")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 1 {
+		t.Errorf("replaced = %d, want 1", result.Replaced)
+	}
+	if got := para.Text(); got != "Status: DONE (review)" {
+		t.Errorf("paragraph text = %q", got)
+	}
+}
+
+func TestReplaceText_MultipleOccurrences(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r, _ := para.AddRun()
+	r.SetText("aaa bbb aaa bbb aaa")
+
+	result, err := ReplaceText(doc, "aaa", "X")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 3 {
+		t.Errorf("replaced = %d, want 3", result.Replaced)
+	}
+	if got := para.Text(); got != "X bbb X bbb X" {
+		t.Errorf("paragraph text = %q", got)
+	}
+}
+
+func TestReplaceText_ReplacementContainsFind(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r, _ := para.AddRun()
+	r.SetText("go go")
+
+	result, err := ReplaceText(doc, "go", "go faster")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 2 {
+		t.Errorf("replaced = %d, want 2", result.Replaced)
+	}
+	if got := para.Text(); got != "go faster go faster" {
+		t.Errorf("paragraph text = %q", got)
+	}
+}
+
+func TestReplaceText_InTableCell(t *testing.T) {
+	doc := core.NewDocument()
+	table, _ := doc.AddTable(1, 2)
+	cell, _ := table.Rows()[0].Cell(1)
+	para, _ := cell.AddParagraph()
+	r, _ := para.AddRun()
+	r.SetText("{answer pending}")
+
+	result, err := ReplaceText(doc, "{answer pending}", "SOC 2 Type II")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 1 {
+		t.Errorf("replaced = %d, want 1", result.Replaced)
+	}
+	if got := para.Text(); got != "SOC 2 Type II" {
+		t.Errorf("cell paragraph text = %q", got)
+	}
+}
+
+func TestReplaceText_SkipsSpanOverNonTextRun(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r1, _ := para.AddRun()
+	r1.SetText("before")
+	r1.SetBold(true) // prevent consolidation with r2
+	r2, _ := para.AddRun()
+	r2.SetText("after")
+	r2.AddBreak(domain.BreakTypeLine)
+
+	result, err := ReplaceText(doc, "beforeafter", "X")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 0 || result.Skipped != 1 {
+		t.Errorf("result = %+v, want 0 replaced / 1 skipped", result)
+	}
+	if got := para.Text(); got != "beforeafter" {
+		t.Errorf("paragraph text = %q, want unchanged", got)
+	}
+}
+
+func TestReplaceText_EmptyFindErrors(t *testing.T) {
+	doc := core.NewDocument()
+	if _, err := ReplaceText(doc, "", "x"); err == nil {
+		t.Fatal("expected error for empty find")
+	}
+}
+
+func TestReplaceText_DeleteWithEmptyReplacement(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r, _ := para.AddRun()
+	r.SetText("Remove [DRAFT] marker")
+
+	result, err := ReplaceText(doc, "[DRAFT] ", "")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 1 {
+		t.Errorf("replaced = %d, want 1", result.Replaced)
+	}
+	if got := para.Text(); got != "Remove marker" {
+		t.Errorf("paragraph text = %q", got)
+	}
+}
+
+func TestReplaceText_NoMatch(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	r, _ := para.AddRun()
+	r.SetText("nothing to see")
+
+	result, err := ReplaceText(doc, "absent", "x")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 0 || result.Skipped != 0 {
+		t.Errorf("result = %+v, want zero result", result)
+	}
+	if got := para.Text(); got != "nothing to see" {
+		t.Errorf("paragraph text = %q, want unchanged", got)
+	}
+}


### PR DESCRIPTION
Disposable — verifies the field-code quote fix drives /language:go alerts to 0 on top of #83. Will be closed and the branch deleted after verification.