### PR TITLE
[throwaway] verify CodeQL reports on a docs-only PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,3 +200,4 @@ docxgo v2 is distributed under the MIT license ([LICENSE](LICENSE)). Its Git his
 
 - **Support:** [GitHub Issues](https://github.com/mmonterroca/docxgo/issues) for bugs, questions, and feature requests
 - **Email:** misael@monterroca.com
+


### PR DESCRIPTION
Disposable — checking whether the GHAS aggregate CodeQL check produces a check-run on a PR with no analyzable code changes, before making it a required status check. Will be closed after verification.