### PR TITLE
ci: run gofmt and the race detector, require CodeQL to merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,15 @@ jobs:
         with:
           version: v2.5.0
           args: --timeout=5m
-          only-new-issues: ${{ github.event_name == 'pull_request' }}
+
+      - name: Check formatting
+        run: |
+          unformatted=$(gofmt -l ./cmd ./pkg ./internal ./domain ./themes .)
+          if [ -n "$unformatted" ]; then
+            echo "$unformatted"
+            echo "The files above are not gofmt-formatted. Run: gofmt -w <file>"
+            exit 1
+          fi
 
       - name: Get dependencies
         run: go mod download
@@ -41,6 +49,9 @@ jobs:
 
       - name: Run tests
         run: go test -v ./...
+
+      - name: Run tests with race detector
+        run: go test -race ./...
 
       - name: Test examples
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,14 @@ git push origin feature/your-feature-name
 - Engage in discussion if needed
 - Once approved, maintainers will merge to `master`
 
+#### Required checks
+
+`master` requires three status checks to pass before a PR can merge:
+`Lint, Build and Test`, `Node.js Tests`, and `CodeQL` (GitHub's code-scanning
+aggregate check — separate from the per-language `Analyze (...)` jobs, which
+are informational only). `master` does not currently require an approving
+review before merge — required checks are the actual merge gate.
+
 #### 9. Release Process
 
 Periodically, maintainers will:

--- a/internal/core/paragraph.go
+++ b/internal/core/paragraph.go
@@ -84,6 +84,7 @@ func (p *paragraph) AddRun() (domain.Run, error) {
 }
 
 // AddField adds a field to the paragraph.
+//
 // Deprecated: Use AddRun() and run.AddField() instead for better control.
 func (p *paragraph) AddField(_ domain.FieldType) (domain.Field, error) {
 	return nil, errors.Unsupported("Paragraph.AddField", "use AddRun() and run.AddField() instead")


### PR DESCRIPTION
## Summary

- CI now runs `gofmt -l` and `go test -race ./...`, both asked for by `CONTRIBUTING.md` but never actually checked.
- Dropped `only-new-issues` from the golangci-lint step so "Lint, Build and Test" checks the whole repo, not just the PR's diff — the backlog was a single pre-existing `gocritic` nit (`internal/core/paragraph.go`), fixed in the same commit.
- The `master` branch ruleset now requires `Lint, Build and Test`, `Node.js Tests`, and `CodeQL` (the GHAS aggregate check) to pass before merge. Verified beforehand via a throwaway docs-only PR that `CodeQL` reports even when a PR touches no code (it scans the whole checked-out tree). Also added a `RepositoryRole: Admin` bypass actor to the ruleset — there was none before, so a context that stopped reporting would have blocked every merge including the owner's.
- `CONTRIBUTING.md` documents the three required checks — previously undocumented anywhere.

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l ./cmd ./pkg ./internal ./domain ./themes .` clean.
- [x] `go test ./...` and `go test -race ./...` both pass.
- [x] `golangci-lint run` (full repo, no `only-new-issues`) reports 0 issues.
- [x] `examples/test_all.sh` 10/10.
- [x] Ruleset change verified live: `bypass_actors` now includes the admin role, `required_status_checks` lists the three contexts.