### PR TITLE
fix: table.setCell can now shrink a cell's paragraph count

### DIFF
--- a/cmd/docxgo/handlers.go
+++ b/cmd/docxgo/handlers.go
@@ -1235,11 +1235,19 @@ func (s *server) handleTableSetCell(req *Request) Response {
 		items = append(items, pItem)
 	}
 
-	// Replace the cell's content: clear every existing paragraph, then write
-	// the new items into existing paragraphs (reusing their slots) and append
-	// paragraphs for any overflow. Cells cannot drop paragraphs, so leftover
-	// paragraphs beyond the new content stay as empty paragraphs.
+	// Replace the cell's content: reuse existing paragraph slots for as many
+	// items as there are, remove any trailing paragraphs the new content
+	// doesn't need, and append new paragraphs for any overflow.
+	// paragraphCount in the result always matches len(items).
 	existing := cell.Paragraphs()
+	for i := len(existing); i > len(items); i-- {
+		if err := cell.RemoveParagraph(i - 1); err != nil {
+			return errorResponse(req.ID, errors.ErrCodeInternal, "failed to remove paragraph: "+err.Error(), op)
+		}
+	}
+	if len(items) < len(existing) {
+		existing = existing[:len(items)]
+	}
 	for _, p := range existing {
 		p.ClearRuns()
 	}

--- a/cmd/docxgo/handlers_test.go
+++ b/cmd/docxgo/handlers_test.go
@@ -965,6 +965,63 @@ func TestHandleTableSetCell_RichParagraphs(t *testing.T) {
 	}
 }
 
+// TestHandleTableSetCell_ShrinksParagraphCount covers a write with fewer
+// paragraphs than the cell already had. It used to leave the leftover
+// paragraphs in place (cleared but present), so paragraphCount stayed at the
+// old, larger value instead of matching what was actually written.
+func TestHandleTableSetCell_ShrinksParagraphCount(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	growResp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+		"paragraphs": []interface{}{
+			map[string]interface{}{"text": "one"},
+			map[string]interface{}{"text": "two"},
+			map[string]interface{}{"text": "three"},
+		},
+	}))
+	if growResp.Error != nil {
+		t.Fatalf("setCell (grow) failed: %+v", growResp.Error)
+	}
+	if got := growResp.Result.(map[string]interface{})["paragraphCount"]; got != 3 {
+		t.Fatalf("paragraphCount after grow = %v, want 3", got)
+	}
+
+	shrinkResp := s.dispatch(makeRequest(3, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+		"paragraphs": []interface{}{
+			map[string]interface{}{"text": "only"},
+		},
+	}))
+	if shrinkResp.Error != nil {
+		t.Fatalf("setCell (shrink) failed: %+v", shrinkResp.Error)
+	}
+	if got := shrinkResp.Result.(map[string]interface{})["paragraphCount"]; got != 1 {
+		t.Errorf("paragraphCount after shrink = %v, want 1", got)
+	}
+
+	cellResp := s.dispatch(makeRequest(4, "table.getCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 1, "columnIndex": 1,
+	}))
+	result := cellResp.Result.(map[string]interface{})
+	if got := result["text"]; got != "only" {
+		t.Errorf("cell text = %q, want %q", got, "only")
+	}
+	if got := result["paragraphCount"]; got != 1 {
+		t.Errorf("getCell paragraphCount = %v, want 1", got)
+	}
+
+	// In-memory counts alone don't prove serialization shrank too --
+	// confirm the actual <w:p> count in the saved XML. newEditTestDoc's
+	// fixture is 1 body paragraph + 4 cells * 1 paragraph = 5 <w:p>
+	// elements; after growing one cell to 3 and shrinking it back to 1,
+	// the total must return to exactly 5.
+	xml := string(documentSavedXML(t, s, docID))
+	if got := strings.Count(xml, "<w:p "); got+strings.Count(xml, "<w:p>") != 5 {
+		t.Errorf("total <w:p> count = %d, want 5", got+strings.Count(xml, "<w:p>"))
+	}
+}
+
 func TestHandleTableSetCell_TextAndParagraphsConflict(t *testing.T) {
 	s, docID := newEditTestDoc(t)
 
@@ -979,6 +1036,45 @@ func TestHandleTableSetCell_TextAndParagraphsConflict(t *testing.T) {
 }
 
 // cellText reads a cell's text back through table.getCell.
+// documentSavedXML saves docID via document.save (buffer) and returns the raw
+// bytes of word/document.xml, for tests that need to verify serialized
+// output rather than just in-memory object counts.
+func documentSavedXML(t *testing.T, s *server, docID string) []byte {
+	t.Helper()
+	saveResp := s.dispatch(makeRequest(999, "document.save", map[string]interface{}{
+		"documentId": docID, "output": "buffer",
+	}))
+	if saveResp.Error != nil {
+		t.Fatalf("document.save: %+v", saveResp.Error)
+	}
+	dataStr := saveResp.Result.(map[string]interface{})["data"].(string)
+	docxBytes, err := base64.StdEncoding.DecodeString(dataStr)
+	if err != nil {
+		t.Fatalf("decode base64: %v", err)
+	}
+	zr, err := zip.NewReader(bytes.NewReader(docxBytes), int64(len(docxBytes)))
+	if err != nil {
+		t.Fatalf("read docx as zip: %v", err)
+	}
+	for _, f := range zr.File {
+		if f.Name != "word/document.xml" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open document.xml: %v", err)
+		}
+		defer rc.Close()
+		var buf bytes.Buffer
+		if _, err := buf.ReadFrom(rc); err != nil {
+			t.Fatalf("read document.xml: %v", err)
+		}
+		return buf.Bytes()
+	}
+	t.Fatal("word/document.xml not found in saved docx")
+	return nil
+}
+
 func cellText(t *testing.T, s *server, docID string, table, row, col int) string {
 	t.Helper()
 	resp := s.dispatch(makeRequest(99, "table.getCell", map[string]interface{}{

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -929,7 +929,7 @@ Writes to a cell covered by a horizontal merge are rejected. Such a cell is neve
 
 Writes to a vertical-merge continuation cell are rejected too. Unlike a horizontal-merge continuation, this cell is still written to the file, but Word renders the vertical-merge-restart cell's content in its place, so the write would report success while remaining invisible — target the topmost cell of the merged region instead.
 
-The cell can grow to fit more paragraphs than it had, but it cannot shrink: paragraphs beyond the new content are left in place as empty paragraphs, since `domain.TableCell` only exposes adding paragraphs, not removing them. `paragraphCount` in the result reflects the cell's paragraph count after the write, which may be larger than the number of items you provided.
+The cell's paragraph count always matches the number of items you provide: fewer items than the cell had removes the trailing paragraphs, more appends new ones. `paragraphCount` in the result always equals the number of items written.
 
 **Params:**
 

--- a/domain/table.go
+++ b/domain/table.go
@@ -68,6 +68,9 @@ type TableCell interface {
 	// AddParagraph adds a paragraph to this cell.
 	AddParagraph() (Paragraph, error)
 
+	// RemoveParagraph removes the paragraph at the given index.
+	RemoveParagraph(index int) error
+
 	// Paragraphs returns all paragraphs in this cell.
 	Paragraphs() []Paragraph
 

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -366,6 +366,64 @@ func TestTableCell_AddParagraph(t *testing.T) {
 	}
 }
 
+func TestTableCell_RemoveParagraph(t *testing.T) {
+	doc := core.NewDocument()
+	table, _ := doc.AddTable(1, 1)
+	row, _ := table.Row(0)
+	cell, _ := row.Cell(0)
+
+	p1, _ := cell.AddParagraph()
+	p1.AddRun()
+	p1.Runs()[0].SetText("first")
+
+	p2, _ := cell.AddParagraph()
+	p2.AddRun()
+	p2.Runs()[0].SetText("second")
+
+	p3, _ := cell.AddParagraph()
+	p3.AddRun()
+	p3.Runs()[0].SetText("third")
+
+	if err := cell.RemoveParagraph(1); err != nil {
+		t.Fatalf("RemoveParagraph(1) failed: %v", err)
+	}
+
+	paras := cell.Paragraphs()
+	if len(paras) != 2 {
+		t.Fatalf("expected 2 paragraphs, got %d", len(paras))
+	}
+	if paras[0].Text() != "first" {
+		t.Errorf("paras[0].Text() = %q, want %q", paras[0].Text(), "first")
+	}
+	if paras[1].Text() != "third" {
+		t.Errorf("paras[1].Text() = %q, want %q", paras[1].Text(), "third")
+	}
+}
+
+func TestTableCell_RemoveParagraph_OutOfRange(t *testing.T) {
+	doc := core.NewDocument()
+	table, _ := doc.AddTable(1, 1)
+	row, _ := table.Row(0)
+	cell, _ := row.Cell(0)
+	cell.AddParagraph()
+
+	tests := []struct {
+		name  string
+		index int
+	}{
+		{"negative index", -1},
+		{"equal to length", 1},
+		{"way out of range", 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := cell.RemoveParagraph(tt.index); err == nil {
+				t.Errorf("expected error for index %d, got nil", tt.index)
+			}
+		})
+	}
+}
+
 func TestParagraph_ClearRuns(t *testing.T) {
 	doc := core.NewDocument()
 	para, _ := doc.AddParagraph()

--- a/internal/core/table.go
+++ b/internal/core/table.go
@@ -261,6 +261,17 @@ func (c *tableCell) AddParagraph() (domain.Paragraph, error) {
 	return para, nil
 }
 
+// RemoveParagraph removes the paragraph at the given index.
+func (c *tableCell) RemoveParagraph(index int) error {
+	if index < 0 || index >= len(c.paragraphs) {
+		return errors.InvalidArgument("TableCell.RemoveParagraph", "index", index,
+			"paragraph index out of bounds")
+	}
+
+	c.paragraphs = append(c.paragraphs[:index], c.paragraphs[index+1:]...)
+	return nil
+}
+
 // Paragraphs returns all paragraphs in this cell.
 func (c *tableCell) Paragraphs() []domain.Paragraph {
 	paras := make([]domain.Paragraph, len(c.paragraphs))


### PR DESCRIPTION
## Summary

Closes #84.

- `domain.TableCell` gained `RemoveParagraph(index int) error`, mirroring `Paragraph.RemoveRun`'s shape and `Table.DeleteRow`'s slice-splice implementation.
- `handleTableSetCell` now removes trailing paragraphs a shrinking write doesn't need, instead of leaving them cleared-but-present. `paragraphCount` in the result now always equals the number of items you provided.
- One implementor in this repo (`*tableCell`), no exported API accepts a `domain.TableCell` from a caller — same precedent as `domain.Document`'s two additions in v2.6.0 and `RemoveRun` itself in v2.3.0. Minor addition, not breaking.

## Test plan

- [x] `TestTableCell_RemoveParagraph` / `TestTableCell_RemoveParagraph_OutOfRange` in `internal/core/core_test.go`.
- [x] `TestHandleTableSetCell_ShrinksParagraphCount` in `cmd/docxgo/handlers_test.go` — checks `paragraphCount` on both the grow and shrink writes, `getCell`'s text and count, and the actual `<w:p>` count in the saved `word/document.xml` (not just in-memory counts).
- [x] All new tests confirmed failing against pre-fix code via `git stash` (paragraphCount stuck at old value, text carrying leftover empty paragraphs, XML `<w:p>` count off by the leftover paragraphs).
- [x] `go build ./... && go vet ./... && gofmt -l` clean, `golangci-lint run` 0 issues.
- [x] `go test ./...` all pass.
- [x] `examples/test_all.sh` 10/10, `npm run lint` + `npm test` pass.