### PR TITLE
fix: preserve per-side paragraph indentation on read and via the CLI

### DIFF
--- a/cmd/docxgo/handlers.go
+++ b/cmd/docxgo/handlers.go
@@ -517,12 +517,15 @@ type lineSpacingDef struct {
 	Value int    `json:"value,omitempty"` // in twips
 }
 
-// indentDef defines paragraph indentation.
+// indentDef defines paragraph indentation. Each field is a pointer so a
+// caller can set one side explicitly (including to 0, overriding a style's
+// own value on just that side) without touching the other three — see
+// domain.Paragraph.SetIndentLeft/Right/FirstLine/Hanging.
 type indentDef struct {
-	Left      int `json:"left,omitempty"`
-	Right     int `json:"right,omitempty"`
-	FirstLine int `json:"firstLine,omitempty"`
-	Hanging   int `json:"hanging,omitempty"`
+	Left      *int `json:"left,omitempty"`
+	Right     *int `json:"right,omitempty"`
+	FirstLine *int `json:"firstLine,omitempty"`
+	Hanging   *int `json:"hanging,omitempty"`
 }
 
 // numberingDef defines a numbering reference.
@@ -1813,12 +1816,18 @@ func applyParagraph(para domain.Paragraph, item paragraphItem) error {
 		_ = para.SetLineSpacing(parseLineSpacing(item.LineSpacing))
 	}
 	if item.Indent != nil {
-		_ = para.SetIndent(domain.Indentation{
-			Left:      item.Indent.Left,
-			Right:     item.Indent.Right,
-			FirstLine: item.Indent.FirstLine,
-			Hanging:   item.Indent.Hanging,
-		})
+		if item.Indent.Left != nil {
+			_ = para.SetIndentLeft(*item.Indent.Left)
+		}
+		if item.Indent.Right != nil {
+			_ = para.SetIndentRight(*item.Indent.Right)
+		}
+		if item.Indent.FirstLine != nil {
+			_ = para.SetIndentFirstLine(*item.Indent.FirstLine)
+		}
+		if item.Indent.Hanging != nil {
+			_ = para.SetIndentHanging(*item.Indent.Hanging)
+		}
 	}
 	if item.Numbering != nil {
 		_ = para.SetNumbering(domain.NumberingReference{

--- a/cmd/docxgo/handlers_test.go
+++ b/cmd/docxgo/handlers_test.go
@@ -1022,6 +1022,43 @@ func TestHandleTableSetCell_ShrinksParagraphCount(t *testing.T) {
 	}
 }
 
+// TestHandleParagraphAdd_IndentSideCanBeSetExplicitlyToZero covers the CLI
+// side of #76: indentDef fields used to be plain ints, so an explicit
+// "right": 0 from a JSON caller was indistinguishable from omitting "right"
+// altogether -- both produced Left/Right/FirstLine/Hanging{0,0,0,0} fed to
+// a single SetIndent call, and the serializer dropped the zero side rather
+// than emitting it. Pointer fields let the handler call SetIndentRight only
+// when the caller actually sent "right", preserving the explicit zero.
+func TestHandleParagraphAdd_IndentSideCanBeSetExplicitlyToZero(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "paragraph.add", map[string]interface{}{
+		"documentId": docID,
+		"text":       "indented",
+		"indent":     map[string]interface{}{"left": 720, "right": 0},
+	}))
+	if resp.Error != nil {
+		t.Fatalf("paragraph.add failed: %+v", resp.Error)
+	}
+
+	xml := string(documentSavedXML(t, s, docID))
+	idx := strings.Index(xml, "<w:ind ")
+	if idx == -1 {
+		t.Fatalf("no <w:ind> element found in saved document.xml: %s", xml)
+	}
+	end := strings.Index(xml[idx:], ">")
+	if end == -1 {
+		t.Fatalf("malformed <w:ind> element")
+	}
+	indTag := xml[idx : idx+end+1]
+	if !strings.Contains(indTag, `w:left="720"`) {
+		t.Errorf("expected explicit left=720, got %s", indTag)
+	}
+	if !strings.Contains(indTag, `w:right="0"`) {
+		t.Errorf("expected explicit right=0 to survive, got %s", indTag)
+	}
+}
+
 func TestHandleTableSetCell_TextAndParagraphsConflict(t *testing.T) {
 	s, docID := newEditTestDoc(t)
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -702,7 +702,7 @@ Adds a single paragraph to an existing document. Supports the same paragraph pro
 | `spacingBefore` | Number | No | Spacing before (twips). Omit to leave unset; `0` is honored as an explicit override, including over a style's own spacing |
 | `spacingAfter` | Number | No | Spacing after (twips). Omit to leave unset; `0` is honored as an explicit override, including over a style's own spacing |
 | `lineSpacing` | Object | No | `{ "rule": "auto", "value": 360 }` |
-| `indent` | Object | No | `{ "left", "right", "firstLine", "hanging" }` |
+| `indent` | Object | No | `{ "left", "right", "firstLine", "hanging" }`. Each side is independent: omit a side to leave it unset, or set it to `0` to explicitly override a style's own value on just that side |
 | `numbering` | Object | No | `{ "id": 1, "level": 0 }` |
 | `borders` | Object | No | Paragraph borders |
 | `runs` | Array | No | Text runs (same format as content paragraphs) |

--- a/docs/V2_API_GUIDE.md
+++ b/docs/V2_API_GUIDE.md
@@ -297,6 +297,29 @@ run, _ := para.AddRun()
 run.SetText("Centered text")
 ```
 
+#### Paragraph Indentation
+
+```go
+para, _ := doc.AddParagraph()
+
+// SetIndent replaces all four sides at once. A side left at its zero value
+// is indistinguishable from a side you didn't intend to touch.
+para.SetIndent(domain.Indentation{Left: 720, FirstLine: 240})
+
+// To set exactly one side -- including to 0, to override a style's own
+// value on just that side without affecting the others -- use the
+// per-side setters instead:
+para.SetIndentLeft(720)
+para.SetIndentRight(0)
+para.SetIndentFirstLine(240)
+para.SetIndentHanging(0)
+```
+
+`SetIndentFirstLine` and `SetIndentHanging` don't enforce the mutual
+exclusivity that `SetIndent` does (a paragraph can't have both a first-line
+and a hanging indent) -- each is independent, so a caller using both is
+responsible for not setting both.
+
 #### Text Formatting
 
 Available methods (both APIs):

--- a/domain/paragraph.go
+++ b/domain/paragraph.go
@@ -66,8 +66,29 @@ type Paragraph interface {
 	// Indent returns the paragraph's indentation settings.
 	Indent() Indentation
 
-	// SetIndent sets the paragraph's indentation.
+	// SetIndent sets the paragraph's indentation. All four sides are set
+	// together, so a side left at its zero value is indistinguishable from
+	// one the caller didn't intend to touch — to set one side explicitly
+	// (including to zero, overriding a style's own value on just that side)
+	// without affecting the others, use SetIndentLeft/Right/FirstLine/Hanging.
 	SetIndent(indent Indentation) error
+
+	// SetIndentLeft sets only the left indentation, leaving the other three
+	// sides untouched — unlike SetIndent, an explicit 0 here is distinguishable
+	// from a side that was never set.
+	SetIndentLeft(twips int) error
+
+	// SetIndentRight is SetIndentLeft's counterpart for the right side.
+	SetIndentRight(twips int) error
+
+	// SetIndentFirstLine is SetIndentLeft's counterpart for the first-line
+	// indent. It does not clear an existing hanging indent; SetIndent's
+	// mutual-exclusivity check does not apply here, so a caller using both
+	// this and SetIndentHanging is responsible for not setting both.
+	SetIndentFirstLine(twips int) error
+
+	// SetIndentHanging is SetIndentLeft's counterpart for the hanging indent.
+	SetIndentHanging(twips int) error
 
 	// SpacingBefore returns spacing before the paragraph (in twips).
 	SpacingBefore() int

--- a/internal/core/paragraph.go
+++ b/internal/core/paragraph.go
@@ -48,13 +48,23 @@ type paragraph struct {
 	spacingBeforeSet bool
 	spacingAfterSet  bool
 	lineSpacingSet   bool
-	numbering        *domain.NumberingReference
-	borders          domain.ParagraphBorders
-	idGen            IDGenerator
-	relManager       *manager.RelationshipManager
-	bookmarkID       string // ID for bookmark (if this paragraph needs one for TOC)
-	bookmarkName     string // Name for bookmark (e.g., "_Toc123456")
-	mediaManager     *manager.MediaManager
+	// indent*Set mirror the spacing flags above, but per side rather than per
+	// call: SetIndent takes the whole domain.Indentation struct at once, so a
+	// single "was SetIndent ever called" flag couldn't tell "Left was set"
+	// from "Right was set" -- which the reader needs, since it must mark only
+	// the sides actually present in a source <w:ind> element (see
+	// SetIndentLeft and friends below).
+	indentLeftSet      bool
+	indentRightSet     bool
+	indentFirstLineSet bool
+	indentHangingSet   bool
+	numbering          *domain.NumberingReference
+	borders            domain.ParagraphBorders
+	idGen              IDGenerator
+	relManager         *manager.RelationshipManager
+	bookmarkID         string // ID for bookmark (if this paragraph needs one for TOC)
+	bookmarkName       string // Name for bookmark (e.g., "_Toc123456")
+	mediaManager       *manager.MediaManager
 }
 
 // NewParagraph creates a new Paragraph.
@@ -424,8 +434,86 @@ func (p *paragraph) SetIndent(indent domain.Indentation) error {
 			"cannot have both first line indent and hanging indent")
 	}
 
+	// SetIndent replaces the whole struct in one call and deliberately does
+	// not touch the indent*Set flags: a zero-valued side in the struct is
+	// indistinguishable from a side the caller didn't intend to set, so
+	// marking all four here would claim explicit intent SetIndent's signature
+	// cannot actually express. Callers that need one side's zero value to
+	// override a style explicitly must use SetIndentLeft/Right/FirstLine/
+	// Hanging instead, each of which marks only its own side.
 	p.indent = indent
 	return nil
+}
+
+// SetIndentLeft sets only the left indentation, leaving the other three
+// sides and their set-flags untouched. Unlike SetIndent, an explicit 0 here
+// is distinguishable from a side that was never set, so the serializer can
+// emit it even when it overrides a style's own non-zero value.
+func (p *paragraph) SetIndentLeft(twips int) error {
+	if twips < constants.MinIndent || twips > constants.MaxIndent {
+		return errors.InvalidArgument("Paragraph.SetIndentLeft", "twips", twips,
+			"left indent must be between -31680 and 31680 twips (-22 to 22 inches)")
+	}
+	p.indent.Left = twips
+	p.indentLeftSet = true
+	return nil
+}
+
+// IndentLeftSet reports whether SetIndentLeft was ever called.
+func (p *paragraph) IndentLeftSet() bool {
+	return p.indentLeftSet
+}
+
+// SetIndentRight is SetIndentLeft's counterpart for the right side.
+func (p *paragraph) SetIndentRight(twips int) error {
+	if twips < constants.MinIndent || twips > constants.MaxIndent {
+		return errors.InvalidArgument("Paragraph.SetIndentRight", "twips", twips,
+			"right indent must be between -31680 and 31680 twips (-22 to 22 inches)")
+	}
+	p.indent.Right = twips
+	p.indentRightSet = true
+	return nil
+}
+
+// IndentRightSet reports whether SetIndentRight was ever called.
+func (p *paragraph) IndentRightSet() bool {
+	return p.indentRightSet
+}
+
+// SetIndentFirstLine is SetIndentLeft's counterpart for the first-line
+// indent. Setting it does not clear an existing hanging indent -- the
+// mutual-exclusivity check lives in SetIndent, which sees the whole struct
+// at once; a caller using the per-side setters is responsible for not
+// setting both.
+func (p *paragraph) SetIndentFirstLine(twips int) error {
+	if twips < 0 || twips > constants.MaxIndent {
+		return errors.InvalidArgument("Paragraph.SetIndentFirstLine", "twips", twips,
+			"first line indent must be between 0 and 31680 twips (0 to 22 inches)")
+	}
+	p.indent.FirstLine = twips
+	p.indentFirstLineSet = true
+	return nil
+}
+
+// IndentFirstLineSet reports whether SetIndentFirstLine was ever called.
+func (p *paragraph) IndentFirstLineSet() bool {
+	return p.indentFirstLineSet
+}
+
+// SetIndentHanging is SetIndentLeft's counterpart for the hanging indent.
+func (p *paragraph) SetIndentHanging(twips int) error {
+	if twips < 0 || twips > constants.MaxIndent {
+		return errors.InvalidArgument("Paragraph.SetIndentHanging", "twips", twips,
+			"hanging indent must be between 0 and 31680 twips (0 to 22 inches)")
+	}
+	p.indent.Hanging = twips
+	p.indentHangingSet = true
+	return nil
+}
+
+// IndentHangingSet reports whether SetIndentHanging was ever called.
+func (p *paragraph) IndentHangingSet() bool {
+	return p.indentHangingSet
 }
 
 // SpacingBefore returns spacing before the paragraph (in twips).

--- a/internal/reader/reader_test.go
+++ b/internal/reader/reader_test.go
@@ -7,11 +7,13 @@
 package reader
 
 import (
+	"archive/zip"
 	"bytes"
 	"fmt"
 	"image"
 	"image/color"
 	"image/png"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -20,6 +22,34 @@ import (
 	"github.com/mmonterroca/docxgo/v2/internal/core"
 	"github.com/mmonterroca/docxgo/v2/pkg/constants"
 )
+
+// documentXML unzips a .docx buffer and returns the raw word/document.xml
+// bytes, so tests can assert on what was actually serialized rather than on
+// in-memory accessor values that can diverge from it.
+func documentXML(t *testing.T, docxBytes []byte) string {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(docxBytes), int64(len(docxBytes)))
+	if err != nil {
+		t.Fatalf("zip.NewReader: %v", err)
+	}
+	for _, f := range zr.File {
+		if f.Name != "word/document.xml" {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open word/document.xml: %v", err)
+		}
+		defer rc.Close()
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			t.Fatalf("read word/document.xml: %v", err)
+		}
+		return string(data)
+	}
+	t.Fatalf("word/document.xml not found in package")
+	return ""
+}
 
 func TestLoadPackageFromBytes(t *testing.T) {
 	doc := core.NewDocument()
@@ -893,5 +923,153 @@ func TestReconstructDocumentTable(t *testing.T) {
 		if got := paras[0].Text(); got != expected {
 			t.Fatalf("unexpected text in cell %d: %q", idx, got)
 		}
+	}
+}
+
+// indElementXML returns the self-closing <w:ind .../> tag from a
+// word/document.xml string. Page margins (<w:pgMar>) also carry
+// left/right/header/footer attributes, so callers must not grep the whole
+// document for these attribute names — only this element's own text.
+func indElementXML(t *testing.T, docXML string) string {
+	t.Helper()
+	idx := strings.Index(docXML, "<w:ind ")
+	if idx == -1 {
+		t.Fatalf("no <w:ind> element found in document.xml: %s", docXML)
+	}
+	end := strings.Index(docXML[idx:], ">")
+	if end == -1 {
+		t.Fatalf("malformed <w:ind> element in document.xml")
+	}
+	return docXML[idx : idx+end+1]
+}
+
+// TestApplyParagraphIndentation_ExplicitZeroSideSurvivesRoundTrip pins the
+// defect #76 describes: a source <w:ind> that explicitly names a side (even
+// with value 0, e.g. to override an inherited style) must come back out with
+// that side explicit, not silently dropped because 0 looks the same as
+// "never set". Before the per-side setters, applyParagraphIndentation read
+// the attribute into a merged domain.Indentation and called SetIndent once,
+// which cannot distinguish "right was 0 in the source" from "right was never
+// mentioned" — both look like the zero value and only the explicit-set path
+// added here tells them apart on serialization.
+func TestApplyParagraphIndentation_ExplicitZeroSideSurvivesRoundTrip(t *testing.T) {
+	doc := core.NewDocument()
+	para, err := doc.AddParagraph()
+	if err != nil {
+		t.Fatalf("AddParagraph: %v", err)
+	}
+	run, err := para.AddRun()
+	if err != nil {
+		t.Fatalf("AddRun: %v", err)
+	}
+	if err := run.SetText("indent sample"); err != nil {
+		t.Fatalf("SetText: %v", err)
+	}
+
+	props, err := parseXMLTree([]byte(
+		`<w:pPr xmlns:w="` + constants.NamespaceMain + `"><w:ind w:left="720" w:right="0"/></w:pPr>`,
+	))
+	if err != nil {
+		t.Fatalf("parseXMLTree: %v", err)
+	}
+	if err := applyParagraphIndentation(para, props); err != nil {
+		t.Fatalf("applyParagraphIndentation: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	indXML := indElementXML(t, documentXML(t, buf.Bytes()))
+	if !strings.Contains(indXML, `w:left="720"`) {
+		t.Fatalf("expected explicit left=720, got %s", indXML)
+	}
+	if !strings.Contains(indXML, `w:right="0"`) {
+		t.Fatalf("expected explicit right=0 to survive round-trip, got %s", indXML)
+	}
+}
+
+// TestApplyParagraphIndentation_OmittedSidesStayOmitted is the mirror guard:
+// a source <w:ind> that names only "left" must not cause the other three
+// sides to be written as explicit zero, which would clobber a style's own
+// non-zero indentation on a side this element never touched.
+func TestApplyParagraphIndentation_OmittedSidesStayOmitted(t *testing.T) {
+	doc := core.NewDocument()
+	para, err := doc.AddParagraph()
+	if err != nil {
+		t.Fatalf("AddParagraph: %v", err)
+	}
+	run, err := para.AddRun()
+	if err != nil {
+		t.Fatalf("AddRun: %v", err)
+	}
+	if err := run.SetText("indent sample"); err != nil {
+		t.Fatalf("SetText: %v", err)
+	}
+
+	props, err := parseXMLTree([]byte(
+		`<w:pPr xmlns:w="` + constants.NamespaceMain + `"><w:ind w:left="720"/></w:pPr>`,
+	))
+	if err != nil {
+		t.Fatalf("parseXMLTree: %v", err)
+	}
+	if err := applyParagraphIndentation(para, props); err != nil {
+		t.Fatalf("applyParagraphIndentation: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := doc.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+
+	indXML := indElementXML(t, documentXML(t, buf.Bytes()))
+	if !strings.Contains(indXML, `w:left="720"`) {
+		t.Fatalf("expected explicit left=720, got %s", indXML)
+	}
+	for _, attr := range []string{"w:right=", "w:firstLine=", "w:hanging="} {
+		if strings.Contains(indXML, attr) {
+			t.Fatalf("expected %s to stay omitted, got %s", attr, indXML)
+		}
+	}
+}
+
+// TestApplyParagraphIndentation_AllowsFirstLineAndHangingBothPresent pins a
+// deliberate, previously-untested behavior change: SetIndent rejects a
+// struct with both FirstLine and Hanging set (they are mutually exclusive in
+// Word's model), so a source <w:ind> naming both used to fail the whole
+// document load. The per-side setters apply independently and carry no such
+// cross-field check, so a document reader is now more tolerant of documents
+// where both attributes are present in the source XML.
+func TestApplyParagraphIndentation_AllowsFirstLineAndHangingBothPresent(t *testing.T) {
+	doc := core.NewDocument()
+	para, err := doc.AddParagraph()
+	if err != nil {
+		t.Fatalf("AddParagraph: %v", err)
+	}
+	run, err := para.AddRun()
+	if err != nil {
+		t.Fatalf("AddRun: %v", err)
+	}
+	if err := run.SetText("indent sample"); err != nil {
+		t.Fatalf("SetText: %v", err)
+	}
+
+	props, err := parseXMLTree([]byte(
+		`<w:pPr xmlns:w="` + constants.NamespaceMain + `"><w:ind w:firstLine="360" w:hanging="720"/></w:pPr>`,
+	))
+	if err != nil {
+		t.Fatalf("parseXMLTree: %v", err)
+	}
+	if err := applyParagraphIndentation(para, props); err != nil {
+		t.Fatalf("applyParagraphIndentation: %v, expected both attributes to apply independently", err)
+	}
+
+	indent := para.Indent()
+	if indent.FirstLine != 360 {
+		t.Fatalf("expected FirstLine=360, got %d", indent.FirstLine)
+	}
+	if indent.Hanging != 720 {
+		t.Fatalf("expected Hanging=720, got %d", indent.Hanging)
 	}
 }

--- a/internal/reader/reconstruct.go
+++ b/internal/reader/reconstruct.go
@@ -331,22 +331,28 @@ func applyParagraphAlignment(para domain.Paragraph, props *Element) error {
 	return nil
 }
 
+// applyParagraphIndentation applies each attribute present in a source
+// <w:ind> element via its own SetIndentLeft/Right/FirstLine/Hanging call,
+// one per attribute actually present. A single merged SetIndent call would
+// mark all four sides as explicitly set (see SetIndent's doc comment) even
+// for the three this element never mentioned, and on re-serialization that
+// would emit e.g. right="0" for a paragraph whose source <w:ind> only ever
+// specified left, clobbering a style's own right indentation on a side this
+// element never touched.
 func applyParagraphIndentation(para domain.Paragraph, props *Element) error {
 	ind := findChild(props, "ind")
 	if ind == nil {
 		return nil
 	}
 
-	current := para.Indent()
-	changed := false
-
 	if val, ok := getAttr(ind, "left"); ok && val != "" {
 		twips, err := strconv.Atoi(val)
 		if err != nil {
 			return errors.WrapWithContext(err, opApplyParagraphIndent, map[string]interface{}{"attr": "left", "value": val})
 		}
-		current.Left = twips
-		changed = true
+		if err := para.SetIndentLeft(twips); err != nil {
+			return errors.Wrap(err, opApplyParagraphIndent)
+		}
 	}
 
 	if val, ok := getAttr(ind, "right"); ok && val != "" {
@@ -354,8 +360,9 @@ func applyParagraphIndentation(para domain.Paragraph, props *Element) error {
 		if err != nil {
 			return errors.WrapWithContext(err, opApplyParagraphIndent, map[string]interface{}{"attr": "right", "value": val})
 		}
-		current.Right = twips
-		changed = true
+		if err := para.SetIndentRight(twips); err != nil {
+			return errors.Wrap(err, opApplyParagraphIndent)
+		}
 	}
 
 	if val, ok := getAttr(ind, "firstLine"); ok && val != "" {
@@ -363,8 +370,9 @@ func applyParagraphIndentation(para domain.Paragraph, props *Element) error {
 		if err != nil {
 			return errors.WrapWithContext(err, opApplyParagraphIndent, map[string]interface{}{"attr": "firstLine", "value": val})
 		}
-		current.FirstLine = twips
-		changed = true
+		if err := para.SetIndentFirstLine(twips); err != nil {
+			return errors.Wrap(err, opApplyParagraphIndent)
+		}
 	}
 
 	if val, ok := getAttr(ind, "hanging"); ok && val != "" {
@@ -372,12 +380,7 @@ func applyParagraphIndentation(para domain.Paragraph, props *Element) error {
 		if err != nil {
 			return errors.WrapWithContext(err, opApplyParagraphIndent, map[string]interface{}{"attr": "hanging", "value": val})
 		}
-		current.Hanging = twips
-		changed = true
-	}
-
-	if changed {
-		if err := para.SetIndent(current); err != nil {
+		if err := para.SetIndentHanging(twips); err != nil {
 			return errors.Wrap(err, opApplyParagraphIndent)
 		}
 	}

--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -520,14 +520,19 @@ func (s *ParagraphSerializer) serializeProperties(para domain.Paragraph) *xml.Pa
 		}
 	}
 
-	// Indentation
+	// Indentation. Each side is gated independently, the same way spacing is
+	// below: an explicit 0 on just one side (e.g. SetIndent to zero out a
+	// style's right indent while leaving left alone) must be emitted for that
+	// side without stamping the other three sides as explicitly zero too.
 	indent := para.Indent()
-	if indent.Left != 0 || indent.Right != 0 || indent.FirstLine != 0 || indent.Hanging != 0 {
+	leftSet, rightSet, firstLineSet, hangingSet := indentSetFlags(para)
+	if indent.Left != 0 || indent.Right != 0 || indent.FirstLine != 0 || indent.Hanging != 0 ||
+		leftSet || rightSet || firstLineSet || hangingSet {
 		props.Indentation = &xml.Indentation{
-			Left:      intPtrIfNotZero(indent.Left),
-			Right:     intPtrIfNotZero(indent.Right),
-			FirstLine: intPtrIfNotZero(indent.FirstLine),
-			Hanging:   intPtrIfNotZero(indent.Hanging),
+			Left:      explicitOrNonZero(indent.Left, leftSet),
+			Right:     explicitOrNonZero(indent.Right, rightSet),
+			FirstLine: explicitOrNonZero(indent.FirstLine, firstLineSet),
+			Hanging:   explicitOrNonZero(indent.Hanging, hangingSet),
 		}
 	}
 
@@ -569,11 +574,11 @@ func (s *ParagraphSerializer) serializeProperties(para domain.Paragraph) *xml.Pa
 
 	if before != 0 || after != 0 || beforeSet || afterSet || lineDeparts {
 		spacing := &xml.Spacing{
-			Before: spacingAttr(before, beforeSet),
-			After:  spacingAttr(after, afterSet),
+			Before: explicitOrNonZero(before, beforeSet),
+			After:  explicitOrNonZero(after, afterSet),
 		}
 		if lineDeparts {
-			spacing.Line = spacingAttr(lineSpacing.Value, lineSet)
+			spacing.Line = explicitOrNonZero(lineSpacing.Value, lineSet)
 			spacing.LineRule = s.lineSpacingRuleToString(lineSpacing.Rule)
 		}
 		props.Spacing = spacing
@@ -1026,16 +1031,44 @@ func spacingSetFlags(para domain.Paragraph) (beforeSet, afterSet, lineSet bool) 
 	return false, false, false
 }
 
-// spacingAttr returns a pointer to value for XML serialization: present
+// explicitOrNonZero returns a pointer to value for XML serialization: present
 // whenever the caller explicitly set the property, even at zero, so it
-// overrides a style's own spacing instead of being mistaken for "unset".
+// overrides a style's own value instead of being mistaken for "unset".
 // Otherwise it falls back to omitting zero, letting docDefaults or the
-// paragraph's style supply the value.
-func spacingAttr(value int, explicitlySet bool) *int {
+// paragraph's style supply the value. Shared by spacing and indentation.
+func explicitOrNonZero(value int, explicitlySet bool) *int {
 	if explicitlySet {
 		return intPtr(value)
 	}
 	return intPtrIfNotZero(value)
+}
+
+// indentSetter exposes whether a paragraph's individual indentation fields
+// were ever set, letting the serializer emit an explicit 0 on just the sides
+// the caller touched instead of either all four or none. Implemented by the
+// concrete paragraph type in internal/core; see serializeProperties.
+//
+// SetIndent takes the whole domain.Indentation struct in one call, so it
+// cannot itself express "only Left was set" -- the per-field setters this
+// interface exposes are concrete-type-only (not part of domain.Paragraph)
+// and exist specifically so the reader can mark only the attributes present
+// in a source <w:ind> element, without SetIndent's all-or-nothing granularity
+// forcing a re-serialized document to claim sides the source never set.
+type indentSetter interface {
+	IndentLeftSet() bool
+	IndentRightSet() bool
+	IndentFirstLineSet() bool
+	IndentHangingSet() bool
+}
+
+// indentSetFlags returns whether para's four indentation fields were
+// explicitly set, degrading to all-false for any domain.Paragraph
+// implementation that doesn't expose indentSetter.
+func indentSetFlags(para domain.Paragraph) (leftSet, rightSet, firstLineSet, hangingSet bool) {
+	if p, ok := para.(indentSetter); ok {
+		return p.IndentLeftSet(), p.IndentRightSet(), p.IndentFirstLineSet(), p.IndentHangingSet()
+	}
+	return false, false, false, false
 }
 
 func intPtrIfNotZero(i int) *int {


### PR DESCRIPTION
## Summary

Indentation had the same unset-vs-zero ambiguity spacing had before #69: `SetIndent` takes the whole `domain.Indentation` struct at once, so a side left at 0 is indistinguishable from a side the caller never touched. This showed up most visibly on read — a source `<w:ind>` naming only one side (e.g. `left`) round-tripped with the other three sides re-serialized as explicit `0`, clobbering a style's own indentation on sides the source document never mentioned.

## Changes

- **`domain.Paragraph`** gains four new methods: `SetIndentLeft`, `SetIndentRight`, `SetIndentFirstLine`, `SetIndentHanging`. Each marks only its own side as explicitly set. `SetIndent` itself is unchanged — a pre-existing pinned test (`TestParagraphSerializer_PartialIndentOmitsOtherSides`) already relies on its current whole-struct semantics, so the new capability is additive, not a retrofit.
- **Reader**: `applyParagraphIndentation` now calls the per-side setters directly for whichever attributes are actually present in the source `<w:ind>`, instead of merging everything into one `SetIndent` call.
- **Serializer**: the indentation block now emits each side independently via the same explicitly-set-gated helper spacing already uses (renamed `spacingAttr` → `explicitOrNonZero` since it's now shared by both).
- **CLI**: `indentDef`'s four fields become `*int` (mirroring v2.9.0's `spacingBefore`/`spacingAfter` fix), so a JSON caller can send `"right": 0` and have it survive, distinct from omitting `"right"` altogether.

Promoting the four setters to the public `domain.Paragraph` interface (rather than a concrete-type-only escape hatch) follows the precedent set by `TableCell.RemoveParagraph` earlier in this batch — `internal/core` is the repo's only implementor of `domain.Paragraph`, so there's no wrapped/mock/third-party implementation this could break.

**Deliberate, tested behavior change**: `SetIndentFirstLine`/`SetIndentHanging` don't enforce the mutual-exclusion check `SetIndent` has (a paragraph can't have both a first-line and a hanging indent per Word's model). Each side is now independent, so a source document naming both attributes loads successfully instead of failing the whole document read. Pinned by `TestApplyParagraphIndentation_AllowsFirstLineAndHangingBothPresent`.

Closes #76.

## Test plan

- [x] `TestApplyParagraphIndentation_ExplicitZeroSideSurvivesRoundTrip` — confirmed failing pre-fix (silently drops `right="0"`)
- [x] `TestApplyParagraphIndentation_OmittedSidesStayOmitted` — mirror guard against the original all-four-clobbered regression
- [x] `TestApplyParagraphIndentation_AllowsFirstLineAndHangingBothPresent` — confirmed failing pre-fix (document load errors out)
- [x] `TestHandleParagraphAdd_IndentSideCanBeSetExplicitlyToZero` — CLI-level, confirmed failing pre-fix
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` and `go test -race ./...` pass on all packages
- [x] `golangci-lint run` — 0 issues
- [x] `examples/test_all.sh` — 10/10 pass
- [x] `npm run lint && npm test` — pass