### PR TITLE
fix: wire NewDocumentBuilder's page size, margins, and default font options

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -198,6 +198,49 @@ func NewDocumentBuilder(opts ...Option) *DocumentBuilder {
 		}
 	}
 
+	if config.PageSize != nil || config.Margins != nil {
+		if sec, err := doc.DefaultSection(); err != nil {
+			builder.errors = append(builder.errors, err)
+		} else {
+			if config.PageSize != nil {
+				if err := sec.SetPageSize(domain.PageSize{Width: config.PageSize.Width, Height: config.PageSize.Height}); err != nil {
+					builder.errors = append(builder.errors, err)
+				}
+			}
+			if config.Margins != nil {
+				// domain.Margins also carries Header/Footer, which docx.Margins
+				// doesn't expose. Start from the section's current margins (a
+				// fresh NewDocument section, so its own defaults) and overwrite
+				// only the four sides WithMargins actually configures, instead
+				// of a naive struct literal that would zero Header/Footer.
+				merged := sec.Margins()
+				merged.Top = config.Margins.Top
+				merged.Bottom = config.Margins.Bottom
+				merged.Left = config.Margins.Left
+				merged.Right = config.Margins.Right
+				if err := sec.SetMargins(merged); err != nil {
+					builder.errors = append(builder.errors, err)
+				}
+			}
+		}
+	}
+
+	if config.DefaultFont != nil {
+		if setter, ok := doc.(interface{ SetDefaultFont(string) error }); ok {
+			if err := setter.SetDefaultFont(*config.DefaultFont); err != nil {
+				builder.errors = append(builder.errors, err)
+			}
+		}
+	}
+
+	if config.DefaultFontSize != nil {
+		if setter, ok := doc.(interface{ SetDefaultFontSize(int) error }); ok {
+			if err := setter.SetDefaultFontSize(*config.DefaultFontSize); err != nil {
+				builder.errors = append(builder.errors, err)
+			}
+		}
+	}
+
 	// Apply theme if provided
 	if config.Theme != nil {
 		// Use type assertion to get Theme interface

--- a/builder_test.go
+++ b/builder_test.go
@@ -54,6 +54,23 @@ func readZipPart(t *testing.T, doc domain.Document, part string) string {
 	return ""
 }
 
+// docDefaultsFragment extracts the <w:docDefaults>...</w:docDefaults>
+// element from a styles.xml string. Individual named styles (Heading8,
+// Quote, etc.) carry their own w:rFonts/w:sz, so a plain substring search
+// over the whole file would find those instead of docDefaults.
+func docDefaultsFragment(t *testing.T, stylesXML string) string {
+	t.Helper()
+	start := strings.Index(stylesXML, "<w:docDefaults>")
+	if start == -1 {
+		t.Fatalf("no <w:docDefaults> found in styles.xml: %s", stylesXML)
+	}
+	end := strings.Index(stylesXML[start:], "</w:docDefaults>")
+	if end == -1 {
+		t.Fatalf("no closing </w:docDefaults> found in styles.xml: %s", stylesXML)
+	}
+	return stylesXML[start : start+end+len("</w:docDefaults>")]
+}
+
 func TestDocumentBuilder_Build(t *testing.T) {
 	t.Run("builds document with paragraph", func(t *testing.T) {
 		builder := NewDocumentBuilder()
@@ -844,10 +861,15 @@ func TestBuilder_ErrorAccumulation(t *testing.T) {
 
 func TestOptions_Validation(t *testing.T) {
 	t.Run("WithDefaultFont validates font name", func(t *testing.T) {
-		doc, err := NewDocumentBuilder(
+		// A paragraph must be added: Build() also fails on an empty document,
+		// and without content that unrelated error would mask whether the
+		// empty font name was actually rejected.
+		builder := NewDocumentBuilder(
 			WithDefaultFont(""),
-		).Build()
+		)
+		builder.AddParagraph().Text("Test").End()
 
+		doc, err := builder.Build()
 		if err == nil {
 			t.Fatal("expected error for empty font name, got nil")
 		}
@@ -857,10 +879,12 @@ func TestOptions_Validation(t *testing.T) {
 	})
 
 	t.Run("WithDefaultFontSize validates font size", func(t *testing.T) {
-		doc, err := NewDocumentBuilder(
+		builder := NewDocumentBuilder(
 			WithDefaultFontSize(0),
-		).Build()
+		)
+		builder.AddParagraph().Text("Test").End()
 
+		doc, err := builder.Build()
 		if err == nil {
 			t.Fatal("expected error for invalid font size, got nil")
 		}
@@ -916,8 +940,12 @@ func TestOptions_Validation(t *testing.T) {
 
 func TestDocumentBuilder_Options(t *testing.T) {
 	t.Run("WithPageSize sets page size", func(t *testing.T) {
+		// The document's actual default page size is A4 (internal/core's
+		// NewSection), not Letter — using Legal here means the assertion
+		// fails if WithPageSize is a no-op, unlike a size that happens to
+		// coincide with either default.
 		builder := NewDocumentBuilder(
-			WithPageSize(Letter),
+			WithPageSize(Legal),
 		)
 		builder.AddParagraph().Text("Test").End()
 
@@ -931,22 +959,18 @@ func TestDocumentBuilder_Options(t *testing.T) {
 			t.Fatal("expected at least one section")
 		}
 
-		// Note: Default is A4, so we just verify a document was created
-		// The page size conversion is handled by the builder
-		if doc == nil {
-			t.Error("expected document to be created")
+		got := sections[0].PageSize()
+		if got.Width != Legal.Width || got.Height != Legal.Height {
+			t.Errorf("expected page size %+v, got %+v", Legal, got)
 		}
 	})
 
 	t.Run("WithMargins sets margins", func(t *testing.T) {
-		margins := Margins{
-			Top:    1440,
-			Bottom: 1440,
-			Left:   1440,
-			Right:  1440,
-		}
+		// NarrowMargins (720 on all four sides) differs from the section's
+		// own default (1440) on every field WithMargins configures, so this
+		// fails if the option is a no-op instead of passing by coincidence.
 		builder := NewDocumentBuilder(
-			WithMargins(margins),
+			WithMargins(NarrowMargins),
 		)
 		builder.AddParagraph().Text("Test").End()
 
@@ -960,9 +984,16 @@ func TestDocumentBuilder_Options(t *testing.T) {
 			t.Fatal("expected at least one section")
 		}
 
-		actualMargins := sections[0].Margins()
-		if actualMargins.Top != margins.Top || actualMargins.Left != margins.Left {
-			t.Errorf("expected margins %+v, got %+v", margins, actualMargins)
+		got := sections[0].Margins()
+		if got.Top != NarrowMargins.Top || got.Bottom != NarrowMargins.Bottom ||
+			got.Left != NarrowMargins.Left || got.Right != NarrowMargins.Right {
+			t.Errorf("expected top/bottom/left/right %+v, got %+v", NarrowMargins, got)
+		}
+		// docx.Margins has no Header/Footer fields; domain.Margins does.
+		// WithMargins must not zero them out — it should preserve whatever
+		// the section already had (the section's own default, 720).
+		if got.Header != domain.DefaultMargins.Header || got.Footer != domain.DefaultMargins.Footer {
+			t.Errorf("expected header/footer to stay at the section default (720 each), got %+v", got)
 		}
 	})
 
@@ -1733,5 +1764,85 @@ func TestOpenDocument_RoundTripsExplicitZeroSpacing(t *testing.T) {
 	}
 	if !strings.Contains(fragment, `w:after="0"`) {
 		t.Errorf(`expected w:after="0" to survive an open+resave round trip, got: %s`, fragment)
+	}
+}
+
+// TestWithDefaultFont_WritesDocDefaults pins #45: WithDefaultFont used to be
+// a silent no-op (the Config field was set but NewDocumentBuilder never read
+// it), so the font name never reached the generated document at all.
+func TestWithDefaultFont_WritesDocDefaults(t *testing.T) {
+	builder := NewDocumentBuilder(
+		WithDefaultFont("Georgia"),
+	)
+	builder.AddParagraph().Text("Test").End()
+
+	doc, err := builder.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	styles := readZipPart(t, doc, "word/styles.xml")
+	docDefaults := docDefaultsFragment(t, styles)
+	if !strings.Contains(docDefaults, `w:ascii="Georgia"`) || !strings.Contains(docDefaults, `w:hAnsi="Georgia"`) {
+		t.Errorf("expected docDefaults to reference Georgia, got: %s", docDefaults)
+	}
+}
+
+// TestWithDefaultFontSize_WritesDocDefaults mirrors
+// TestWithDefaultFont_WritesDocDefaults for the size half of the same bug.
+func TestWithDefaultFontSize_WritesDocDefaults(t *testing.T) {
+	builder := NewDocumentBuilder(
+		WithDefaultFontSize(32), // 16pt
+	)
+	builder.AddParagraph().Text("Test").End()
+
+	doc, err := builder.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	styles := readZipPart(t, doc, "word/styles.xml")
+	docDefaults := docDefaultsFragment(t, styles)
+	if !strings.Contains(docDefaults, `<w:sz w:val="32"`) {
+		t.Errorf("expected docDefaults to contain w:sz w:val=\"32\", got: %s", docDefaults)
+	}
+	if !strings.Contains(docDefaults, `<w:szCs w:val="32"`) {
+		t.Errorf("expected docDefaults to contain w:szCs w:val=\"32\", got: %s", docDefaults)
+	}
+}
+
+// TestWithoutBuilderOptions_NoRegression is the byte-identity guard for #45:
+// a builder with none of WithDefaultFont/WithDefaultFontSize/WithPageSize/
+// WithMargins set must produce output identical to before those options
+// were wired up — no docDefaults rFonts/sz, A4 page size, 1440 margins.
+// Unlike the other tests in this file, this one must pass before and after
+// the fix; it exists to catch the fix accidentally becoming the new default.
+func TestWithoutBuilderOptions_NoRegression(t *testing.T) {
+	builder := NewDocumentBuilder()
+	builder.AddParagraph().Text("Test").End()
+
+	doc, err := builder.Build()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	styles := readZipPart(t, doc, "word/styles.xml")
+	docDefaults := docDefaultsFragment(t, styles)
+	if strings.Contains(docDefaults, "w:rFonts") {
+		t.Errorf("expected no docDefaults w:rFonts without WithDefaultFont, got: %s", docDefaults)
+	}
+	if strings.Contains(docDefaults, "<w:sz ") || strings.Contains(docDefaults, "<w:szCs ") {
+		t.Errorf("expected no docDefaults w:sz/w:szCs without WithDefaultFontSize, got: %s", docDefaults)
+	}
+
+	sections := doc.Sections()
+	if len(sections) == 0 {
+		t.Fatal("expected at least one section")
+	}
+	if got := sections[0].PageSize(); got != domain.PageSizeA4 {
+		t.Errorf("expected default page size to stay A4, got %+v", got)
+	}
+	if got := sections[0].Margins(); got != domain.DefaultMargins {
+		t.Errorf("expected default margins to stay %+v, got %+v", domain.DefaultMargins, got)
 	}
 }

--- a/internal/core/document.go
+++ b/internal/core/document.go
@@ -52,6 +52,8 @@ type document struct {
 	numberingTarget string
 	backgroundColor *domain.Color
 	language        *domain.Language
+	defaultFont     *string
+	defaultFontSize *int
 
 	// Preserved parts for round-trip operations (read-modify-write).
 	// When set, these parts are written verbatim to preserve original content.
@@ -397,7 +399,7 @@ func (d *document) WriteTo(w io.Writer) (int64, error) {
 	appProps := ser.SerializeAppProperties(d)
 
 	// Serialize styles (used only if no preserved styles are available)
-	styles := ser.SerializeStyles(d.styleManager, d.language)
+	styles := ser.SerializeStyles(d.styleManager, d.language, d.defaultFont, d.defaultFontSize)
 
 	mediaFiles := d.mediaManager.All()
 
@@ -574,6 +576,39 @@ func (d *document) SetLanguageRaw(lang *domain.Language) {
 	}
 	langCopy := *lang
 	d.language = &langCopy
+}
+
+// SetDefaultFont sets the document's default run font, written to
+// styles.xml's w:docDefaults/w:rPrDefault. Not part of domain.Document —
+// NewDocumentBuilder always starts from a fresh NewDocument(), which has no
+// preserved styles.xml to conflict with, so there's no round-trip guard to
+// write here the way SetLanguage needs one. Reached only via
+// NewDocumentBuilder's own type-assertion (mirrors SetLanguageRaw).
+func (d *document) SetDefaultFont(name string) error {
+	if d == nil {
+		return errors.InvalidState("Document.SetDefaultFont", "document is nil")
+	}
+	if name == "" {
+		return errors.InvalidArgument("Document.SetDefaultFont", "name", name, "font name must not be empty")
+	}
+	d.defaultFont = &name
+	return nil
+}
+
+// SetDefaultFontSize sets the document's default run font size in
+// half-points, written to the same w:docDefaults/w:rPrDefault as
+// SetDefaultFont. See SetDefaultFont regarding why this isn't part of
+// domain.Document.
+func (d *document) SetDefaultFontSize(halfPoints int) error {
+	if d == nil {
+		return errors.InvalidState("Document.SetDefaultFontSize", "document is nil")
+	}
+	if halfPoints <= 0 {
+		return errors.InvalidArgument("Document.SetDefaultFontSize", "halfPoints", halfPoints,
+			"font size must be a positive number of half-points")
+	}
+	d.defaultFontSize = &halfPoints
+	return nil
 }
 
 // StyleManager returns the style manager for this document.

--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -1321,10 +1321,12 @@ func documentDefaultParagraphProperties() *xml.ParagraphDefaults {
 	}
 }
 
-// SerializeStyles converts a domain.StyleManager to xml.Styles. When lang is
-// non-nil, it is written as the document's default proofing language
-// (w:docDefaults/w:rPrDefault/w:rPr/w:lang).
-func (s *DocumentSerializer) SerializeStyles(styleManager domain.StyleManager, lang *domain.Language) *xml.Styles {
+// SerializeStyles converts a domain.StyleManager to xml.Styles, writing lang,
+// defaultFont, and defaultFontSize (any of which may be nil) into
+// w:docDefaults/w:rPrDefault. docDefaults sits below the Normal style in the
+// OOXML cascade, so a theme's own font/size on Normal still wins over these —
+// they only take effect for styles that don't set their own.
+func (s *DocumentSerializer) SerializeStyles(styleManager domain.StyleManager, lang *domain.Language, defaultFont *string, defaultFontSize *int) *xml.Styles {
 	xmlStyles := xml.NewStyles()
 
 	// Include Word's latent style catalog to avoid auto-added styles during repair
@@ -1333,12 +1335,19 @@ func (s *DocumentSerializer) SerializeStyles(styleManager domain.StyleManager, l
 	xmlStyles.DocDefaults = &xml.DocDefaults{
 		ParaDefaults: documentDefaultParagraphProperties(),
 	}
-	if lang != nil {
-		xmlStyles.DocDefaults.RunDefaults = &xml.RunDefaults{
-			Properties: &xml.RunProperties{
-				Lang: &xml.Language{Val: lang.Val, EastAsia: lang.EastAsia, Bidi: lang.Bidi},
-			},
+	if lang != nil || defaultFont != nil || defaultFontSize != nil {
+		props := &xml.RunProperties{}
+		if lang != nil {
+			props.Lang = &xml.Language{Val: lang.Val, EastAsia: lang.EastAsia, Bidi: lang.Bidi}
 		}
+		if defaultFont != nil {
+			props.Font = &xml.Font{ASCII: *defaultFont, HAnsi: *defaultFont}
+		}
+		if defaultFontSize != nil {
+			props.Size = &xml.HalfPt{Val: *defaultFontSize}
+			props.SizeCS = &xml.HalfPt{Val: *defaultFontSize}
+		}
+		xmlStyles.DocDefaults.RunDefaults = &xml.RunDefaults{Properties: props}
 	}
 
 	// Serialize all styles from the style manager

--- a/internal/serializer/serializer_test.go
+++ b/internal/serializer/serializer_test.go
@@ -789,7 +789,7 @@ func TestDocumentSerializer_TableStyleBorders(t *testing.T) {
 	sm := doc.StyleManager()
 
 	ser := serializer.NewDocumentSerializer()
-	xmlStyles := ser.SerializeStyles(sm, nil)
+	xmlStyles := ser.SerializeStyles(sm, nil, nil, nil)
 
 	// Find the TableGrid style
 	var tableGridStyle *xmlstructs.Style
@@ -878,7 +878,7 @@ func TestDocumentSerializer_DocDefaultsStateZeroSpacing(t *testing.T) {
 	sm := doc.StyleManager()
 
 	ser := serializer.NewDocumentSerializer()
-	xmlStyles := ser.SerializeStyles(sm, nil)
+	xmlStyles := ser.SerializeStyles(sm, nil, nil, nil)
 
 	if xmlStyles.DocDefaults == nil || xmlStyles.DocDefaults.ParaDefaults == nil {
 		t.Fatal("expected w:docDefaults/w:pPrDefault to be set")
@@ -939,7 +939,7 @@ func TestParagraphSerializer_StyledParagraphSpacingNotClobbered(t *testing.T) {
 	// i.e. there's something real for the paragraph to inherit.
 	sm := doc.StyleManager()
 	docSer := serializer.NewDocumentSerializer()
-	xmlStyles := docSer.SerializeStyles(sm, nil)
+	xmlStyles := docSer.SerializeStyles(sm, nil, nil, nil)
 
 	var heading1 *xmlstructs.Style
 	for _, s := range xmlStyles.Styles {

--- a/internal/writer/writer_test.go
+++ b/internal/writer/writer_test.go
@@ -217,12 +217,12 @@ func TestSerializeStyles_PPrDefaultPresentRegardlessOfLang(t *testing.T) {
 	sm := manager.NewStyleManager()
 	ser := serializer.NewDocumentSerializer()
 
-	withoutLang := ser.SerializeStyles(sm, nil)
+	withoutLang := ser.SerializeStyles(sm, nil, nil, nil)
 	if withoutLang.DocDefaults == nil || withoutLang.DocDefaults.ParaDefaults == nil {
 		t.Fatal("expected ParaDefaults to be set even without a language")
 	}
 
-	withLang := ser.SerializeStyles(sm, &domain.Language{Val: "en-US"})
+	withLang := ser.SerializeStyles(sm, &domain.Language{Val: "en-US"}, nil, nil)
 	if withLang.DocDefaults == nil || withLang.DocDefaults.ParaDefaults == nil {
 		t.Fatal("expected ParaDefaults to be set alongside a language")
 	}

--- a/options.go
+++ b/options.go
@@ -8,15 +8,20 @@ package docx
 
 import (
 	"github.com/mmonterroca/docxgo/v2/domain"
-	"github.com/mmonterroca/docxgo/v2/pkg/constants"
 )
 
 // Config contains configuration options for document creation.
+//
+// DefaultFont, DefaultFontSize, PageSize, and Margins are pointers so
+// NewDocumentBuilder can tell "the caller set this" apart from "the caller
+// never touched this" — the same distinction Language already needed. A
+// caller who passes none of these options gets a document byte-identical to
+// one built before these fields existed.
 type Config struct {
-	DefaultFont      string
-	DefaultFontSize  int
-	PageSize         PageSize
-	Margins          Margins
+	DefaultFont      *string
+	DefaultFontSize  *int
+	PageSize         *PageSize
+	Margins          *Margins
 	StrictValidation bool
 	Metadata         *domain.Metadata
 	Language         *Language
@@ -90,19 +95,21 @@ var (
 // Option is a function that configures a Config.
 type Option func(*Config)
 
-// defaultConfig returns the default configuration.
+// defaultConfig returns the default configuration. DefaultFont,
+// DefaultFontSize, PageSize, and Margins are left nil: NewDocumentBuilder
+// only touches the document's actual defaults (A4, 1" margins, Calibri
+// 11pt) when the caller explicitly sets one of these options.
 func defaultConfig() *Config {
 	return &Config{
-		DefaultFont:      constants.DefaultFontName,
-		DefaultFontSize:  constants.DefaultFontSize,
-		PageSize:         Letter,
-		Margins:          NormalMargins,
 		StrictValidation: false,
 		Metadata:         &domain.Metadata{},
 	}
 }
 
-// WithDefaultFont sets the default font for the document.
+// WithDefaultFont sets the document's default run font, written to
+// styles.xml's w:docDefaults/w:rPrDefault — below the Normal style in the
+// OOXML cascade, so a theme applied via WithTheme still wins for any style
+// that sets its own font.
 //
 // Example:
 //
@@ -111,11 +118,13 @@ func defaultConfig() *Config {
 //	)
 func WithDefaultFont(font string) Option {
 	return func(c *Config) {
-		c.DefaultFont = font
+		c.DefaultFont = &font
 	}
 }
 
-// WithDefaultFontSize sets the default font size in half-points.
+// WithDefaultFontSize sets the document's default run font size in
+// half-points, written to the same w:docDefaults/w:rPrDefault as
+// WithDefaultFont.
 //
 // Example:
 //
@@ -124,11 +133,11 @@ func WithDefaultFont(font string) Option {
 //	)
 func WithDefaultFontSize(halfPoints int) Option {
 	return func(c *Config) {
-		c.DefaultFontSize = halfPoints
+		c.DefaultFontSize = &halfPoints
 	}
 }
 
-// WithPageSize sets the page size for the document.
+// WithPageSize sets the page size for the document's default section.
 //
 // Example:
 //
@@ -137,11 +146,13 @@ func WithDefaultFontSize(halfPoints int) Option {
 //	)
 func WithPageSize(size PageSize) Option {
 	return func(c *Config) {
-		c.PageSize = size
+		c.PageSize = &size
 	}
 }
 
-// WithMargins sets the page margins for the document.
+// WithMargins sets the page margins for the document's default section.
+// Margins has four fields (Top/Bottom/Left/Right); the section's header and
+// footer distances are left at their existing values.
 //
 // Example:
 //
@@ -150,18 +161,18 @@ func WithPageSize(size PageSize) Option {
 //	)
 func WithMargins(margins Margins) Option {
 	return func(c *Config) {
-		c.Margins = margins
+		c.Margins = &margins
 	}
 }
 
-// WithStrictValidation enables strict validation of the document structure.
-// When enabled, Build() will perform more rigorous checks.
+// WithStrictValidation is a no-op.
 //
-// Example:
-//
-//	builder := docx.NewDocumentBuilder(
-//	    docx.WithStrictValidation(),
-//	)
+// Deprecated: there has never been a strict-validation subsystem for this to
+// enable — Build()'s Validate() call always runs the same checks regardless
+// of this option. Config.StrictValidation is kept only so existing callers
+// don't fail to compile; it is never read. See
+// https://github.com/mmonterroca/docxgo/issues/92 for the tracking issue on
+// giving this real semantics.
 func WithStrictValidation() Option {
 	return func(c *Config) {
 		c.StrictValidation = true


### PR DESCRIPTION
## Summary

`WithDefaultFont`, `WithDefaultFontSize`, `WithPageSize`, and `WithMargins` were silent no-ops: `NewDocumentBuilder` built a `Config` from every applied `Option` but only ever read `Metadata` and `Theme` off it. Calling any of these four compiled, ran without error, and produced a document completely unaffected by the value passed in.

The existing tests for this were false positives:
- `TestOptions_Validation`'s font/size subtests passed via `"document is empty"` from `Build()`, not from any font validation (the subtests never added a paragraph).
- `TestDocumentBuilder_Options/WithMargins` asserted `1440`, which is what a section gets by default regardless of the option.
- `TestDocumentBuilder_Options/WithPageSize` asserted nothing about the page size at all.

## Changes

- `Config.DefaultFont/DefaultFontSize/PageSize/Margins` become pointers, so `NewDocumentBuilder` can tell "the caller set this" from "the caller never touched this" — the same distinction `Language` already needed. A builder with none of these options set still produces byte-identical output (`TestWithoutBuilderOptions_NoRegression` pins this).
- `WithPageSize`/`WithMargins` now flow into `doc.DefaultSection()`. Margins needs care converting `docx.Margins` (4 fields) to `domain.Margins` (6 fields, including `Header`/`Footer`): the fix reads the section's current margins and overwrites only the four sides `WithMargins` actually configures, instead of a naive struct literal that would zero the header/footer distances.
- `WithDefaultFont`/`WithDefaultFontSize` now write into `styles.xml`'s `w:docDefaults/w:rPrDefault` via two new concrete-type-only setters on `*document` (`SetDefaultFont`/`SetDefaultFontSize`), reached through the same type-assertion pattern `SetLanguageRaw` already established — not added to `domain.Document`, since `NewDocumentBuilder` always starts from a fresh `NewDocument()` with nothing to guard against. `docDefaults` sits below the Normal style in the OOXML cascade, so a theme's own font/size on Normal still wins. Verified against `DocxValidator` that a `docDefaults` font absent from `fontTable.xml` still validates — the `fontTable` append itself is deferred to a follow-up issue rather than guessing panose bytes for an arbitrary font name.
- `WithStrictValidation` is deprecated rather than given invented semantics: there was never a validation subsystem for it to enable, and choosing behavior now as part of a no-op bugfix would bake undiscussed policy into a permanent public contract. Filed #92 to design real semantics separately.
- The CLI is untouched — `applyDocOptions` already applies `pageSize`/`margins` directly to `doc.DefaultSection()` without going through the builder, and `docOptions` doesn't expose `defaultFont`/`defaultFontSize` at all. Exposing them over RPC is new surface, not a fix.

Closes #45.

## Test plan

- [x] `TestOptions_Validation/WithDefaultFont_validates_font_name` and `.../WithDefaultFontSize_validates_font_size` rewritten to add a paragraph first, confirmed failing pre-fix for the right reason
- [x] `TestDocumentBuilder_Options/WithPageSize_sets_page_size` rewritten with `Legal` (not A4/Letter), confirmed failing pre-fix
- [x] `TestDocumentBuilder_Options/WithMargins_sets_margins` rewritten with `NarrowMargins` + Header/Footer preservation check, confirmed failing pre-fix
- [x] `TestWithDefaultFont_WritesDocDefaults`, `TestWithDefaultFontSize_WritesDocDefaults` — confirmed failing pre-fix
- [x] `TestWithoutBuilderOptions_NoRegression` — byte-identity guard, passes before and after
- [x] `examples/02_intermediate` output manually verified: `docDefaults` now carries Arial/22, `<w:pgSz w:w="12240" w:h="15840">` (Letter) — confirms the fix reaches real callers, not just tests
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` and `go test -race ./...` pass on all packages
- [x] `golangci-lint run` — 0 issues
- [x] `examples/test_all.sh` — 10/10 pass
- [x] `npm run lint && npm test` — pass