### PR TITLE
release: prepare v2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## v2.10.0 — 2026-07-27
+
+### Added
+
+- **In-place editing RPC methods, recovered from #64** (PR #83; originally contributed by @asaf-ramati1 in #64). That PR was closed unmerged after its source fork was deleted, but GitHub retained the two commits under `refs/pull/64/head` — they're merged here with original authorship intact, not reimplemented or squashed. Adds `document.replaceText`, `paragraph.setText`, `table.getCell`, `table.setCell`, and a `includeText` flag on `table.list`, plus the underlying Go API: `template.ReplaceText(doc, find, replace) (ReplaceResult, error)`, which replaces every occurrence of `find` across body paragraphs, table cells, headers, and footers, consolidating fragmented runs first and skipping (not corrupting) matches that touch a field, break, or image in a way that can't be replaced safely.
+- `domain.TableCell.RemoveParagraph(index int) error` (#84), so `table.setCell` can actually shrink a cell's paragraph count instead of leaving cleared-but-present leftovers. `paragraphCount` in the result now always equals the number of items provided.
+- `domain.Paragraph.SetIndentLeft/SetIndentRight/SetIndentFirstLine/SetIndentHanging(twips int) error` (#76), each setting exactly one side of a paragraph's indentation — including to 0, to explicitly override a style's own value on just that side — without touching the other three the way `SetIndent`'s whole-struct call must. The CLI's `paragraph.add`/`paragraph.setText` `indent` fields become nullable (`*int` server-side) for the same reason v2.9.0 did this for spacing.
+
+### Fixed
+
+- **Rejected double quotes in generated field-code arguments** (#85, critical CodeQL `go/unsafe-quoting`). `NewHyperlinkField`'s `url`, `NewStyleRefField`'s `styleName`, and `NewTOCField`'s `"levels"` switch were interpolated unescaped inside a quoted argument of the generated Word field code — a value containing `"` broke out of the quoted argument and injected arbitrary field-code syntax. Escaping was ruled out: the reader's field-code parser splits on bare quotes with no escape awareness, so any `\"` scheme would corrupt docxgo's own open→save round-trip. A value containing a quote is rejected instead, surfaced through `run.AddField` — the one chokepoint every field must pass through to reach a run's XML. The fix uses `strings.ReplaceAll` as the barrier (not an early-return `strings.Contains` guard): CodeQL's `go/unsafe-quoting` only recognizes a `ReplaceAll`-shaped sanitizer, not guard-and-return, so a semantically-equivalent early-return form would have left the alerts open.
+- **`ReplaceText` no longer mutates the whole document on a miss.** It called `ConsolidateRuns` unconditionally on every paragraph before checking for a match, so a `document.replaceText` whose `find` string appears nowhere still rewrote run structure across the entire body, every table cell, and every header/footer. Fixed by checking the concatenated paragraph text first.
+- **A match inside a run carrying a field is now skipped, not silently discarded.** The single-run skip guard was gated on `len(spanned) > 1`, so e.g. a PAGE field's cached text could be replaced in memory while the serializer discarded the change at write time — the RPC still reported it as `replaced`.
+- **`table.setCell` can now shrink a cell's paragraph count**, using the new `TableCell.RemoveParagraph` above instead of clearing-but-keeping leftover paragraphs.
+- **A source `<w:ind>` naming only some sides no longer clobbers the others on save.** The reader merged every attribute it read into one `SetIndent` call, which can't distinguish "this side was 0 in the source" from "this side was never mentioned" — so a document with only `left` set in its source XML came back out with `right`/`firstLine`/`hanging` as explicit `0`, silently overriding a style's own indentation on sides the source never touched. The reader now calls the new per-side setters above directly, one per attribute actually present.
+- **`WithDefaultFont`, `WithDefaultFontSize`, `WithPageSize`, and `WithMargins` are no longer silent no-ops** (#45). `NewDocumentBuilder` built a `Config` from every applied `Option` but only ever read `Metadata` and `Theme` off it — the other four compiled, ran without error, and produced a document completely unaffected by the value passed in. `WithPageSize`/`WithMargins` now flow into the default section; `WithDefaultFont`/`WithDefaultFontSize` now write into `styles.xml`'s `w:docDefaults/w:rPrDefault`, below the Normal style in the OOXML cascade so a theme's own font/size still wins. `WithStrictValidation` is deprecated rather than given invented semantics — there was never a validation subsystem for it to enable (see `### Compatibility`).
+
+### Changed
+
+- **CI now runs `gofmt -l` and `go test -race ./...`**, both required by `CONTRIBUTING.md` but never actually checked, and the golangci-lint step no longer limits itself to `only-new-issues`, so "Lint, Build and Test" checks the whole repository.
+- **`Lint, Build and Test`, `Node.js Tests`, and `CodeQL` are now required status checks** on the `master` branch ruleset — previously nothing was required to pass before merge. A `RepositoryRole: Admin` bypass actor was added at the same time (there was none before), so a context that stops reporting can't block every merge including the owner's.
+- `CONTRIBUTING.md` documents the three required checks.
+
+### Compatibility
+
+- **New public Go interface methods, not breaking.** `domain.TableCell.RemoveParagraph` and `domain.Paragraph.SetIndentLeft/Right/FirstLine/Hanging` follow the precedent of `domain.Document`'s two additions in v2.6.0 and `Paragraph.RemoveRun` itself in v2.3.0: each has exactly one implementor in this repo, and no exported API accepts one of these interfaces from a caller — only returns one.
+- `WithStrictValidation` is deprecated (no-op, as it always has been); `Config.StrictValidation` is kept only so existing callers don't fail to compile. See #92 for the follow-up to give it real semantics.
+- A builder that calls none of `WithDefaultFont`/`WithDefaultFontSize`/`WithPageSize`/`WithMargins` produces byte-identical output to before this release. A builder that does call them now gets the document it asked for, for the first time — most notably, `WithPageSize(docx.Letter)` previously had zero effect (the section always defaulted to A4 regardless), so a caller relying on that option now sees a real page-size change.
+- CLI: `paragraph.add`/`paragraph.setText`'s `indent` fields (`left`/`right`/`firstLine`/`hanging`) become nullable (`*int` server-side); omitting a field is unchanged, but `0` now behaves differently (honored, rather than silently dropped) on a side the caller explicitly set.
+- A source document whose `<w:ind>` names both `firstLine` and `hanging` on the same paragraph now loads successfully (each side applies independently) instead of failing the whole document read, which `SetIndent`'s mutual-exclusivity check used to do.
+
+---
+
 ## v2.9.1 — 2026-07-27
 
 ### Fixed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration Guide: v1 → docxgo v2
 
-**Current target:** v2.9.1
+**Current target:** v2.10.0
 **Minimum Go version:** 1.23
 
 This guide covers migration from the historical `fumiama/go-docx` API to the
@@ -27,7 +27,7 @@ For the complete current API, see the [API guide](docs/V2_API_GUIDE.md) and
 ## 1. Update the module
 
 ```bash
-go get github.com/mmonterroca/docxgo/v2@v2.9.1
+go get github.com/mmonterroca/docxgo/v2@v2.10.0
 go mod tidy
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Since v2.7.0 it also ships a JSON-RPC command-line interface and a Node.js wrapp
 - **Proofing language** — `WithLanguage` / `WithLanguageEx` for spell-check, grammar, hyphenation
 - **Production quality** — clean architecture, explicit errors, thread-safe internals
 
-**Status:** v2.9.1 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
+**Status:** v2.10.0 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
 
 ---
 

--- a/RELEASE_NOTES_v2.10.0.md
+++ b/RELEASE_NOTES_v2.10.0.md
@@ -1,0 +1,178 @@
+# Release Notes - v2.10.0
+
+**Release Date:** July 27, 2026
+
+## Summary
+
+v2.10.0 bundles a batch of work that would otherwise have shipped as several
+small patch releases: a critical security fix, in-place editing RPC methods
+recovered from a closed pull request, mandatory CI checks, and three
+correctness fixes that had been documented as known limitations for a while.
+It's a minor release — new public interface methods, no breaking changes.
+
+## Added
+
+### In-place editing RPC methods, recovered from #64
+
+This release recovers and completes #64, originally contributed by
+@asaf-ramati1. That pull request was closed unmerged after its source fork
+was deleted — but GitHub retained the two commits under `refs/pull/64/head`,
+so they're merged here with original authorship intact, not reimplemented or
+squashed.
+
+Adds five new surfaces:
+
+- `document.replaceText` (and the underlying `template.ReplaceText(doc, find,
+  replace) (ReplaceResult, error)` Go API) — replaces every occurrence of
+  `find` across body paragraphs, table cells, headers, and footers. Runs are
+  consolidated first so text Word fragmented across runs with identical
+  formatting is matched. A match touching a run that carries a field is
+  always skipped (such a run's text is never serialized, so "replacing" it
+  would report a change Word never makes); a match spanning several runs is
+  skipped if any of them carries a break or image, but a match confined to a
+  single run carrying either is replaced safely.
+- `paragraph.setText` — replaces a paragraph's entire text content in one
+  call.
+- `table.getCell` / `table.setCell` — read and write a single cell's content
+  directly, without walking the whole table.
+- `table.list` gains an `includeText` flag to return cell text inline.
+
+Two defects were found and fixed as part of recovering this work (not present
+in the original #64 diff): `ReplaceText` called `ConsolidateRuns`
+unconditionally on every paragraph before checking for a match, so a call
+whose `find` string matched nothing still rewrote run structure across the
+entire document; and a match inside a run carrying a field could be replaced
+in memory while the serializer silently discarded the change at write time,
+with the RPC still reporting it as `replaced`.
+
+### New domain interface methods
+
+- `domain.TableCell.RemoveParagraph(index int) error` — lets `table.setCell`
+  actually shrink a cell's paragraph count instead of leaving cleared-but-
+  present leftovers behind.
+- `domain.Paragraph.SetIndentLeft` / `SetIndentRight` / `SetIndentFirstLine` /
+  `SetIndentHanging(twips int) error` — each sets exactly one side of a
+  paragraph's indentation, including to 0 to explicitly override a style's
+  own value on just that side, without the ambiguity `SetIndent`'s
+  whole-struct call has (a zero-valued side is indistinguishable from a side
+  that was never touched).
+
+Both follow the precedent set by `domain.Document`'s two additions in v2.6.0
+and `Paragraph.RemoveRun` itself in v2.3.0: each has exactly one implementor
+in this repo, and nothing in the public API accepts one of these interfaces
+from a caller — only returns one. Minor, not breaking.
+
+## Fixed
+
+### Field code injection via unescaped double quotes (critical, CodeQL `go/unsafe-quoting`)
+
+`NewHyperlinkField`'s `url`, `NewStyleRefField`'s `styleName`, and
+`NewTOCField`'s `"levels"` switch were interpolated directly inside a quoted
+argument of the generated Word field code. A value containing `"` broke out
+of that argument, letting arbitrary field-code syntax reach `word/document.xml`
+on save. The sink was reachable through the RPC layer via any field-style
+parameter read from JSON input on stdin.
+
+Escaping the quote was considered and rejected: the reader's own field-code
+parser splits instructions on bare quotes with no escape awareness, so any
+`\"`-style scheme would corrupt docxgo's own open→save round-trip. A value
+containing a quote is rejected instead, at construction. None of the three
+field constructors previously returned an error, so rejection is recorded on
+the field and surfaces the next time it's used — `Run.AddField` is the one
+place every field must pass through to reach a run's XML, so that's where the
+check lives.
+
+The fix combines a `strings.ReplaceAll`-shaped sanitizer with a
+compare-and-reject wrapper around it, rather than a simple
+`strings.Contains`-and-return-early guard: CodeQL's `go/unsafe-quoting` query
+only recognizes a `ReplaceAll`-shaped transformation as a barrier, not a
+guard-and-return, so the semantically equivalent early-return form would have
+left the alerts open despite being a correct fix.
+
+### `table.setCell` can now shrink a cell's paragraph count
+
+Writing fewer paragraphs than a cell already had used to clear the extra
+paragraphs' content but leave them present, so `paragraphCount` in the result
+could exceed the number of items actually written. `table.setCell` now
+removes the trailing paragraphs a shrinking write doesn't need, using the new
+`TableCell.RemoveParagraph`. `paragraphCount` now always equals the number of
+items provided.
+
+### Paragraph indentation no longer loses explicit sides on read
+
+A source `<w:ind>` element naming only some sides (say, just `left`) used to
+come back out of docxgo re-serialized with the *other* sides — `right`,
+`firstLine`, `hanging` — as explicit `0`, because the reader merged whatever
+it read into one `SetIndent` call, and that call can't tell "this side was 0
+in the source" apart from "this side was never mentioned." A style's own
+non-zero indentation on an untouched side was silently overridden as a
+result. The reader now calls the four new per-side setters directly, one per
+attribute actually present in the source, so a side the source document never
+mentioned stays untouched on save.
+
+### Builder options that used to do nothing
+
+`WithDefaultFont`, `WithDefaultFontSize`, `WithPageSize`, and `WithMargins`
+were silent no-ops: `NewDocumentBuilder` built a `Config` from every applied
+`Option` but only ever read `Metadata` and `Theme` off it. All four compiled,
+ran without error, and produced a document completely unaffected by the
+value passed in — the existing tests for this were false positives that
+happened to pass for unrelated reasons (an empty-document error, or a
+coincidental match with the actual default).
+
+`WithPageSize`/`WithMargins` now flow into the document's default section.
+`WithDefaultFont`/`WithDefaultFontSize` now write into `styles.xml`'s
+`w:docDefaults/w:rPrDefault`, which sits below the Normal style in the OOXML
+cascade — a theme applied via `WithTheme` still wins for any style that sets
+its own font or size.
+
+`WithStrictValidation` is deprecated rather than given invented semantics:
+there has never been a strict-validation subsystem for it to enable (the
+`service.NewValidator` from the original v2 design was never built), and
+choosing behavior now, as a side effect of a no-op bugfix, would have baked
+undiscussed policy into a permanent public contract. See #92 for the
+follow-up to design real semantics for it.
+
+## Changed
+
+### CI now enforces what CONTRIBUTING.md always asked for
+
+- `gofmt -l` and `go test -race ./...` now run in CI — both documented
+  requirements that were never actually checked.
+- The golangci-lint step no longer limits itself to `only-new-issues`, so
+  "Lint, Build and Test" checks the whole repository rather than just each
+  PR's diff.
+- **`Lint, Build and Test`, `Node.js Tests`, and `CodeQL` are now required
+  status checks** on the `master` branch ruleset. Previously nothing was
+  required to pass before a merge. A `RepositoryRole: Admin` bypass actor was
+  added to the ruleset at the same time — there was none before, so a
+  required context that stopped reporting could otherwise have blocked every
+  merge, including the repository owner's.
+- `CONTRIBUTING.md` documents the three required checks, which weren't
+  mentioned anywhere before.
+
+## Compatibility
+
+- **No breaking changes.** `domain.TableCell.RemoveParagraph` and
+  `domain.Paragraph.SetIndentLeft/Right/FirstLine/Hanging` are additive
+  interface methods; see **Added** above for why they don't break existing
+  implementors.
+- `WithStrictValidation` is deprecated (a no-op, as it always has been);
+  `Config.StrictValidation` is kept only so existing callers don't fail to
+  compile.
+- A builder calling none of `WithDefaultFont`/`WithDefaultFontSize`/
+  `WithPageSize`/`WithMargins` produces byte-identical output to before this
+  release. A builder that *does* call them gets, for the first time, the
+  document it actually asked for — most notably, `WithPageSize(docx.Letter)`
+  previously had zero effect (the section always defaulted to A4 regardless
+  of this option), so any caller relying on it will see a real page-size
+  change in generated output.
+- **CLI:** `paragraph.add`/`paragraph.setText`'s `indent` fields (`left`/
+  `right`/`firstLine`/`hanging`) become nullable (`*int` server-side).
+  Omitting a field is unchanged; `0` now behaves differently (honored, rather
+  than silently dropped) on a side the caller explicitly set.
+- A source document whose `<w:ind>` names both `firstLine` and `hanging` on
+  the same paragraph now loads successfully, with each side applied
+  independently, instead of failing the whole document read — which is what
+  `SetIndent`'s mutual-exclusivity check used to do when the reader routed
+  through it.

--- a/doc.go
+++ b/doc.go
@@ -289,7 +289,7 @@ This library generates Office Open XML (OOXML) documents compatible with:
 
 # Version
 
-Current version: 2.9.1 (see the Version constant for the authoritative value).
+Current version: 2.10.0 (see the Version constant for the authoritative value).
 
 This is a major rewrite of the original go-docx library with breaking changes.
 See the migration guide in MIGRATION.md for details.

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -66,7 +66,7 @@ Verify the installation:
 
 ```bash
 docxgo version
-# 2.9.1
+# 2.10.0
 ```
 
 ---
@@ -198,7 +198,7 @@ Returns version, protocol version, and platform information.
 ```json
 {
   "name": "docxgo",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "protocolVersion": "1.0",
   "goVersion": "go1.23.0",
   "platform": "darwin",
@@ -253,7 +253,7 @@ Executes multiple RPC requests in a single roundtrip. Each sub-request is proces
 {
   "responses": [
     { "result": { "status": "ok" } },
-    { "result": { "name": "docxgo", "version": "2.9.1", ... } },
+    { "result": { "name": "docxgo", "version": "2.10.0", ... } },
     { "error": { "code": "NOT_FOUND", "message": "..." } }
   ]
 }

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,7 +1,7 @@
 # docxgo v2 Implementation Status
 
 **Last Updated**: July 2026
-**Version**: 2.9.1 (Stable)
+**Version**: 2.10.0 (Stable)
 
 This document tracks the implementation status of all v2 features, helping developers understand what's available, what's in progress, and what's planned.
 
@@ -39,6 +39,7 @@ All development phases have been completed. The library has gone through multipl
 | v2.8.0      | Jul 2026 | Final MIT provenance determination, corrected notices, license-complete release artifacts |
 | v2.9.0      | Jul 2026 | Fixed npm-publish cascade, read-only `FindPlaceholders`, explicit zero spacing on styled paragraphs |
 | v2.9.1      | Jul 2026 | Code-review fixes: spacing emit gate no longer clobbers style line spacing, placeholder Location offsets corrected |
+| v2.10.0     | Jul 2026 | In-place editing RPC methods recovered from #64, field-code injection fix, mandatory CI checks (CodeQL), `table.setCell` shrink, per-side paragraph indentation, builder page size/margins/default font wiring |
 
 ---
 
@@ -419,5 +420,5 @@ Want to help implement missing features? See [CONTRIBUTING.md](../CONTRIBUTING.m
 ---
 
 **Last Updated**: July 2026
-**Status**: Production Ready (v2.9.1 Stable)
+**Status**: Production Ready (v2.10.0 Stable)
 **Maintained by**: Misael Monterroca ([@mmonterroca](https://github.com/mmonterroca))

--- a/docs/README.md
+++ b/docs/README.md
@@ -224,4 +224,4 @@ See: IMPLEMENTATION_STATUS.md - Features list
 ---
 
 **Last Updated**: July 2026  
-**Documentation Version**: v2.9.1
+**Documentation Version**: v2.10.0

--- a/docs/V2_API_GUIDE.md
+++ b/docs/V2_API_GUIDE.md
@@ -1,6 +1,6 @@
 # docxgo v2 API Guide
 
-**Version**: 2.9.1
+**Version**: 2.10.0
 **Last Updated**: July 2026
 
 ---
@@ -1024,4 +1024,4 @@ See [`examples/14_mail_merge/`](../examples/14_mail_merge/) for a complete worki
 ---
 
 **Last Updated**: July 2026
-**Version**: 2.9.1
+**Version**: 2.10.0

--- a/docs/V2_DESIGN.md
+++ b/docs/V2_DESIGN.md
@@ -1,8 +1,8 @@
 # docxgo v2 - Clean Architecture Design
 
-**Status**: ✅ v2.9.1 Stable
+**Status**: ✅ v2.10.0 Stable
 **Progress**: Production Ready (all core features complete)
-**Latest Release**: v2.9.1 (July 2026)
+**Latest Release**: v2.10.0 (July 2026)
 **Breaking Changes**: Yes (major version bump from original fork)
 
 > **Project Note**: This project is a substantially rewritten successor to `fumiama/go-docx`, focused on clean architecture, type safety, and modern Go practices. The Git history includes AGPL-era upstream snapshots; the completed [provenance audit](./PROVENANCE_AUDIT.md) determines that the current MIT release contains no protectable AGPL implementation.
@@ -525,7 +525,7 @@ if err := finalDoc.SaveAs("output.docx"); err != nil {
   - [x] Build() method with validation
 - [x] Create options.go with functional options (~200 lines)
   - [x] Config struct with defaults
-  - [x] 9 Option functions (WithDefaultFont, WithPageSize, WithMargins, WithStrictValidation, WithMetadata, WithTitle, WithAuthor, WithSubject)
+  - [x] 9 Option functions (WithDefaultFont, WithPageSize, WithMargins, WithStrictValidation, WithMetadata, WithTitle, WithAuthor, WithSubject) — WithStrictValidation deprecated in v2.10.0, never had real semantics (see #92)
   - [x] PageSize constants (A4, Letter, Legal, A3, Tabloid)
   - [x] Margins presets (Normal, Narrow, Wide)
 - [x] Add API convenience exports (~50 lines in docx.go)
@@ -1344,7 +1344,7 @@ See [CREDITS.md](../CREDITS.md) for complete project history.
 ---
 
 **Last Updated**: July 2026
-**Status**: ✅ v2.9.1 Stable
+**Status**: ✅ v2.10.0 Stable
 **Progress**: Production Ready (all core features complete)
 
 **Current State:**

--- a/docx.go
+++ b/docx.go
@@ -88,7 +88,7 @@ func reconstructFromPackage(pkg *reader.Package, op string) (domain.Document, er
 }
 
 // Version is the library version.
-const Version = "2.9.1"
+const Version = "2.10.0"
 
 // Common color constants exported for convenience.
 var (

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mmonterroca/docxgo",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mmonterroca/docxgo",
-      "version": "2.9.1",
+      "version": "2.10.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.3",
@@ -17,11 +17,11 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "@mmonterroca/docxgo-darwin-arm64": "2.9.1",
-        "@mmonterroca/docxgo-darwin-x64": "2.9.1",
-        "@mmonterroca/docxgo-linux-arm64": "2.9.1",
-        "@mmonterroca/docxgo-linux-x64": "2.9.1",
-        "@mmonterroca/docxgo-win32-x64": "2.9.1"
+        "@mmonterroca/docxgo-darwin-arm64": "2.10.0",
+        "@mmonterroca/docxgo-darwin-x64": "2.10.0",
+        "@mmonterroca/docxgo-linux-arm64": "2.10.0",
+        "@mmonterroca/docxgo-linux-x64": "2.10.0",
+        "@mmonterroca/docxgo-win32-x64": "2.10.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmonterroca/docxgo",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "Node.js wrapper for docxgo — create and manipulate Word documents via JSON-RPC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -50,10 +50,10 @@
     "typescript": "^5.4.0"
   },
   "optionalDependencies": {
-    "@mmonterroca/docxgo-darwin-arm64": "2.9.1",
-    "@mmonterroca/docxgo-darwin-x64": "2.9.1",
-    "@mmonterroca/docxgo-linux-arm64": "2.9.1",
-    "@mmonterroca/docxgo-linux-x64": "2.9.1",
-    "@mmonterroca/docxgo-win32-x64": "2.9.1"
+    "@mmonterroca/docxgo-darwin-arm64": "2.10.0",
+    "@mmonterroca/docxgo-darwin-x64": "2.10.0",
+    "@mmonterroca/docxgo-linux-arm64": "2.10.0",
+    "@mmonterroca/docxgo-linux-x64": "2.10.0",
+    "@mmonterroca/docxgo-win32-x64": "2.10.0"
   }
 }


### PR DESCRIPTION
## Summary

Prepares the v2.10.0 release: version bump, CHANGELOG, and release notes for the batch merged in this cycle.

- #86 (fix #85 — critical field-code injection, CodeQL `go/unsafe-quoting`)
- #83 (in-place editing RPC methods, recovered from #64, originally contributed by @asaf-ramati1)
- #89 (CI hardening — `gofmt`, race detector, mandatory `CodeQL`/`Lint, Build and Test`/`Node.js Tests` checks)
- #90 (fix #84 — `table.setCell` can now shrink a cell's paragraph count)
- #91 (fix #76 — per-side paragraph indentation, no longer clobbers untouched sides)
- #93 (fix #45 — builder's `WithDefaultFont`/`WithDefaultFontSize`/`WithPageSize`/`WithMargins` no longer no-ops)

See CHANGELOG.md and RELEASE_NOTES_v2.10.0.md for full details.

This is a markdown-and-version-bump-only PR (plus the npm lock regeneration) — no source changes.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` and `go test -race ./...` pass on all packages
- [x] `golangci-lint run` — 0 issues
- [x] `examples/test_all.sh` — 10/10 pass
- [x] `npm run lint && npm test` — pass
- [x] Verified `npm install` succeeds against the regenerated lock