### PR TITLE
Fix 10 defects found in v2.10.0 post-hoc code review; release v2.11.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
           RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
         run: |
           if [ -z "$RELEASE_PAT" ]; then
-            echo "::warning::RELEASE_PAT is empty or missing — this release will be authored by github-actions[bot] instead of a real user. This is now cosmetic: the publish-npm job below invokes npm-publish.yml directly and no longer depends on the 'release: published' event that a bot-authored release can't fire. Still worth fixing so releases show a real author."
+            echo "::warning::RELEASE_PAT is empty or missing — falling back to github.token, so this release will be authored by github-actions[bot] instead of a real user. Still worth fixing so releases show a real author."
           fi
 
       - name: Create Release
@@ -126,8 +126,12 @@ jobs:
           generate_release_notes: true
           files: release-assets/*
           # Must be a `with:` input, not `env:` — the action's `token` input
-          # defaults to `${{ github.token }}`, which wins over any env var.
-          token: ${{ secrets.RELEASE_PAT }}
+          # defaults to `${{ github.token }}`, which wins over any env var,
+          # but an *empty* `with: token` also wins over that default and
+          # hard-fails the whole release. The `||` fallback keeps the
+          # "prefer a real user" intent while still working when the secret
+          # is unset.
+          token: ${{ secrets.RELEASE_PAT || github.token }}
 
   publish-npm:
     name: Publish to npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v2.11.0 — 2026-07-28
+## v2.11.0 — 2026-07-29
 
 v2.10.0 was merged and published without a code review — CI alone. A
 post-hoc review of that batch found ten confirmed defects that gofmt, `go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+## v2.11.0 — 2026-07-28
+
+v2.10.0 was merged and published without a code review — CI alone. A
+post-hoc review of that batch found ten confirmed defects that gofmt, `go
+vet`, `go test -race`, and golangci-lint cannot see by construction: they're
+about what the code *means*, not whether it compiles or races. This release
+fixes all ten in one batch rather than spreading them across several
+patches, since several touch the same request paths.
+
+### Fixed
+
+- **`document.replaceText`/`template.ReplaceText` no longer report a header or footer match as replaced when the write is discarded on save.** On a document opened via `document.open`, `WriteTo` writes preserved header/footer XML verbatim — an in-memory replacement there never reached the saved file, but the RPC reported it as `replaced` anyway. Those matches are now counted in `skipped` instead. `template.MergeTemplate` had the identical gap for placeholders inside a preserved header/footer; its `StrictMode` now surfaces them as missing keys rather than silently discarding the merge.
+- **`document.replaceText`, `table.getCell`, and `table.setCell` now decode params strictly.** They used plain `json.Unmarshal` for top-level params while nested paragraph items were already decoded strictly — a misspelled field (`replacement` instead of `replace`) silently decoded to a zero value indistinguishable from a deliberately minimal request, so a typo in a `replaceText` call deleted every occurrence of `find` and reported success.
+- **`paragraph.add`, `table.add`, and `document.addContent` no longer leave orphaned content behind when a request is rejected.** All three mutated the real document before content that could still fail (e.g. a field constructor rejecting a quote) had a chance to, so a rejected request could leave a stray, half-populated paragraph or table appended anyway. Each now validates against a scratch document first, the same pattern `paragraph.setText`/`table.setCell` already used.
+- **`SetIndent` no longer leaves a stale per-side flag from an earlier `SetIndentLeft`/`Right`/`FirstLine`/`Hanging` call.** A paragraph hydrated by the reader via `SetIndentLeft` and then given a `SetIndent` call for a different side kept the earlier flag, so the serializer emitted an explicit `w:left="0"` the `SetIndent` call never asked for — clobbering the paragraph's style indentation on that side. This was a round-trip regression introduced by v2.10.0's own indentation fix (#76). `SetIndent` now clears all four flags along with the struct it replaces.
+- **The serializer never emits both `w:ind`'s `firstLine` and `hanging` together.** `SetIndent` rejects setting both, but the per-side setters `SetIndentFirstLine`/`SetIndentHanging` don't share that check — reachable via the reader hydrating a source `<w:ind>` that already carries both attributes. Word treats the two as mutually exclusive even though the schema allows both; the serializer now emits only `hanging` when both are set, matching Word's own behavior.
+- **TOC field switches (`\o`, `\h`, `\n`, `\p`, `\z`, `\u`) are now written with a single backslash.** They were built as Go raw string literals containing two literal backslashes each — XML chardata escaping never touches a bare backslash, so the doubled backslash reached `word/document.xml` verbatim, and Word treats `\\o` as an unrecognized switch. A TOC field built by docxgo never actually applied any of its switches. Rebuilding an existing document doesn't change this on its own — only a document containing a TOC field constructed by `NewTOCField` (directly, or via `field: {type: "toc"}` in the RPC) is affected.
+- **`Field.SetCode` now rejects control characters and line breaks.** It previously accepted any non-blank string verbatim and `serializer.go` emits `Code()` straight into `<w:instrText>` — a way to reach the same class of corruption v2.10.0's field-code sanitizer (#85) exists to prevent, bypassing it entirely since `SetCode` sits outside the `New*Field` constructors' quote check. `SetCode` still accepts balanced quotes (e.g. `STYLEREF "Heading 1"`), since a well-formed instruction legitimately contains them. The reader hydrates a field's code from a real file's own `<w:instrText>` through a new, unexported `SetCodeRaw` path that bypasses this guard — the source file is the ground truth for a valid instruction, not this package's own validation, so `OpenDocument` doesn't fail on a normal `.docx` because of this new check.
+- **Release workflow no longer hard-fails when `RELEASE_PAT` is unset.** Passing an empty `secrets.RELEASE_PAT` as `softprops/action-gh-release`'s `token` input overrides the action's own fallback to `github.token` — an explicitly-passed empty `with:` input wins over the action's default, unlike an unset env var. `release.yml` now falls back explicitly (`secrets.RELEASE_PAT || github.token`), matching the degraded-but-working behavior the emptiness check next to it already documented.
+
+### Changed
+
+- **Docs corrected to match actual `paragraph.setText`/`table.setCell` behavior.** Both replace paragraph *content* (text and runs) only — any paragraph property (style, alignment, indent, spacing) omitted from the request keeps its existing value rather than being reset. `CLI_GUIDE.md` and the npm `ParagraphSetTextParams` JSDoc previously described these as full replacements without drawing that distinction.
+- **`TableSetCellResult`'s npm JSDoc corrected.** It said the cell "can grow but never shrink" — the pre-v2.10.0 behavior, which #84 (also v2.10.0) made false in the same release it shipped in.
+
+### Compatibility
+
+- **`document.replaceText`/`template.ReplaceText` response semantics change for documents with preserved headers/footers.** A call that used to report a header/footer match as `replaced` now reports it as `skipped`; the total match count is unchanged. Every other document shape is unaffected.
+- **`document.replaceText`, `table.getCell`, and `table.setCell` now reject a request containing an unrecognized top-level field**, where it used to be silently ignored. A well-formed request (no typos, no extra fields) is unaffected.
+- **TOC field code bytes change.** A document created with `NewTOCField`/`field: {type: "toc"}` under this release has single-backslash switches (`\o "1-3" \h \z \u`) instead of the doubled-backslash bytes v2.10.0 and earlier produced. This is a fix, not a behavior a caller could have depended on: the doubled-backslash form was never a working TOC field in Word.
+- **`Field.SetCode` (Go API only; not reachable from the RPC layer) now rejects a control character or line break** where it previously accepted anything non-blank. No CLI protocol or npm surface exposes `SetCode` directly.
+- No public Go interface changed. No new public Go, CLI protocol, or Node.js API surface.
+- **Retroactive note on v2.10.0's `Config` pointerization** (`### Compatibility` there described the change but not its concrete consequence): `docx.Config`'s `DefaultFont`/`DefaultFontSize`/`PageSize`/`Margins` fields becoming pointers is source-breaking for code that writes to a `*docx.Config` directly (e.g. a custom `docx.Option`), not for code that only calls `docx.With*` functions. `c.DefaultFont = "Arial"` no longer compiles. See `MIGRATION.md`.
+
+---
+
 ## v2.10.0 — 2026-07-27
 
 ### Added

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration Guide: v1 → docxgo v2
 
-**Current target:** v2.10.0
+**Current target:** v2.11.0
 **Minimum Go version:** 1.23
 
 This guide covers migration from the historical `fumiama/go-docx` API to the
@@ -27,9 +27,18 @@ For the complete current API, see the [API guide](docs/V2_API_GUIDE.md) and
 ## 1. Update the module
 
 ```bash
-go get github.com/mmonterroca/docxgo/v2@v2.10.0
+go get github.com/mmonterroca/docxgo/v2@v2.11.0
 go mod tidy
 ```
+
+> **v2.10.0 note:** `docx.Config`'s `DefaultFont`, `DefaultFontSize`,
+> `PageSize`, and `Margins` fields changed from plain values to pointers so
+> `NewDocumentBuilder` could tell "the caller set this" apart from "the
+> caller never touched this" (`Language` already worked this way). This only
+> affects code that writes to a `*docx.Config` directly — for example a
+> custom `docx.Option` (`func(*docx.Config)`) — not code that only calls
+> `docx.With*` functions. `c.DefaultFont = "Arial"` no longer compiles; use
+> `font := "Arial"; c.DefaultFont = &font` instead.
 
 Replace the old import:
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Since v2.7.0 it also ships a JSON-RPC command-line interface and a Node.js wrapp
 - **Proofing language** — `WithLanguage` / `WithLanguageEx` for spell-check, grammar, hyphenation
 - **Production quality** — clean architecture, explicit errors, thread-safe internals
 
-**Status:** v2.10.0 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
+**Status:** v2.11.0 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
 
 ---
 

--- a/RELEASE_NOTES_v2.11.0.md
+++ b/RELEASE_NOTES_v2.11.0.md
@@ -1,6 +1,6 @@
 # Release Notes - v2.11.0
 
-**Release Date:** July 28, 2026
+**Release Date:** July 29, 2026
 
 ## Summary
 

--- a/RELEASE_NOTES_v2.11.0.md
+++ b/RELEASE_NOTES_v2.11.0.md
@@ -1,0 +1,193 @@
+# Release Notes - v2.11.0
+
+**Release Date:** July 28, 2026
+
+## Summary
+
+v2.10.0 was merged and published to npm without a code review — CI alone. A
+post-hoc review of that release's full diff found ten confirmed defects that
+CI's gofmt, `go vet`, `go test -race`, and golangci-lint could not have
+caught, because none of them are the kind of defect those tools can see:
+they're about what the code *means*, not whether it compiles cleanly or
+races. v2.11.0 fixes all ten in one batch.
+
+Two are worth calling out specifically because they're silent data loss: a
+`document.replaceText` call could report a header or footer edit as applied
+when it was actually discarded on save, and a misspelled parameter name
+(`replacement` instead of `replace`) could delete a document's content while
+the RPC reported success.
+
+No public Go interface changed. If you're already on v2.10.0, upgrade —
+there's no reason to stay on it.
+
+## Fixed
+
+### `document.replaceText`/`MergeTemplate` no longer report header/footer edits that get discarded on save
+
+On a document opened via `document.open`, `WriteTo` writes the original
+header/footer XML back verbatim for round-trip fidelity — any in-memory
+mutation to a header or footer paragraph never reaches the saved file. Both
+`document.replaceText` and `template.MergeTemplate` mutated those paragraphs
+anyway and reported success: `replaceText` counted the match as `replaced`,
+and `MergeTemplate` treated the placeholder as filled.
+
+Both now recognize a document with preserved header/footer parts and treat
+header/footer matches as unwritable: `replaceText` reports them in `skipped`
+instead of `replaced`, and `MergeTemplate`'s `StrictMode` now surfaces them
+as missing keys rather than silently discarding the write. This is a
+document-wide check — if any header or footer part was preserved, every
+header/footer match is skipped, not just the one in the section that was
+actually touched.
+
+### Strict decoding closes a silent-deletion path in `document.replaceText`
+
+`document.replaceText`, `table.getCell`, and `table.setCell` decoded their
+top-level params with plain `json.Unmarshal`, unlike the nested paragraph
+items in the same requests, which were already decoded strictly. A
+misspelled top-level field silently decoded to Go's zero value —
+indistinguishable from a deliberately minimal request.
+
+Concretely: a `document.replaceText` request with `"replacement"` instead of
+`"replace"` decoded to an empty `Replace` string, deleted every occurrence of
+`find` in the document, and reported `{"replaced": N}` as a success. All
+three methods now reject an unrecognized field instead.
+
+### No orphaned content when `paragraph.add`/`table.add`/`document.addContent` reject a request
+
+All three appended to the real document before content that could still fail
+validation — most commonly a field constructor rejecting a double quote in a
+style name or URL — got the chance to. A rejected request could therefore
+leave a stray, half-populated paragraph or table behind even though the
+overall call returned an error.
+
+All three now validate against a scratch document first, the same pattern
+`paragraph.setText` and `table.setCell` already used. `document.addContent`
+validates every item in a content batch before applying any of them, so a
+later item's rejection can no longer leave an earlier item's paragraph
+behind either.
+
+### `SetIndent` no longer leaves a stale per-side flag behind
+
+v2.10.0 added `SetIndentLeft`/`SetIndentRight`/`SetIndentFirstLine`/
+`SetIndentHanging`, each marking a per-side "this was explicitly set" flag so
+the serializer can emit an explicit `0` on just that side. `SetIndent` — the
+whole-struct call — replaced the indentation values but never cleared those
+flags.
+
+The consequence: a paragraph hydrated by the reader (which calls
+`SetIndentLeft` for a source `<w:ind>`'s `left` attribute) and then given a
+plain `SetIndent` call for a different side kept the stale `indentLeftSet`
+flag from the read. The serializer, seeing that flag, emitted an explicit
+`w:left="0"` the `SetIndent` call never asked for — silently clobbering the
+paragraph's style indentation on the left side. This was a round-trip
+regression `SetIndent` introduced against v2.9.1's behavior, in the very
+release that added per-side indentation. `SetIndent` now clears all four
+flags along with the struct it replaces.
+
+### The serializer never emits both `firstLine` and `hanging` on `<w:ind>`
+
+`SetIndent` already rejects a caller trying to set both `FirstLine` and
+`Hanging` at once — Word treats them as mutually exclusive even though the
+OOXML schema technically allows both. The per-side setters
+`SetIndentFirstLine`/`SetIndentHanging` don't share that check, and the
+reader calls them independently per attribute present in a source `<w:ind>`,
+so a document whose original XML already carried both attributes could
+reach the serializer with both set. The serializer now emits only one —
+`hanging` wins, matching what Word itself does when it encounters both.
+
+### TOC field switches are written with a single backslash, not two
+
+`NewTOCField`'s default code and its `\o`/`\h`/`\n`/`\p`/`\z`/`\u` switches
+were built as Go raw string literals, each containing two literal
+backslashes rather than one escaped backslash. XML chardata escaping never
+touches a bare backslash, so the doubled backslash reached
+`word/document.xml` completely unchanged — and Word's field-code parser
+treats `\\o` as an unrecognized switch, not `\o` with an extra character. A
+table of contents field built by docxgo has never actually applied any of
+its switches (default heading levels, hyperlinks, page-number hiding, tab
+leaders) in any version before this one.
+
+This only affects documents containing a field constructed via `NewTOCField`
+(directly, or through `field: {"type": "toc"}` in the RPC layer) — rebuilding
+an existing, already-saved document doesn't change anything on its own.
+
+### `Field.SetCode` rejects control characters; the field-code sanitizer can no longer be bypassed
+
+v2.10.0's field-code sanitizer (#85) rejects a `"` that would break out of a
+quoted field-code argument, but only in the `New*Field` constructors.
+`Field.SetCode` — a lower-level, separately-reachable method on the same
+type — accepted any non-blank string verbatim, and the serializer emits
+`Code()` straight into `<w:instrText>`. `SetCode` is Go-API-only (no RPC
+parameter reaches it), but it was a way to reach the same class of
+byte-level corruption the #85 fix exists to prevent, entirely bypassing that
+fix.
+
+`SetCode` now rejects a control character or line break — unambiguously
+invalid inside a single-line field instruction — while still accepting
+balanced quotes, since a well-formed instruction legitimately contains them
+(e.g. `STYLEREF "Heading 1"`); a naive quote-count check can't tell that
+apart from an injection attempt. The reader, which hydrates a field's code
+from a real file's own `<w:instrText>`, uses a new unexported `SetCodeRaw`
+path that bypasses this guard — the source file is the ground truth for
+what a valid field instruction looks like, so `OpenDocument` won't fail on
+an ordinary `.docx` because of this new check.
+
+### Release workflow no longer hard-fails when `RELEASE_PAT` is unset
+
+`release.yml` already had a check that warned when `RELEASE_PAT` was empty
+and explained the release would fall back to being authored by
+`github-actions[bot]`. But the step that actually creates the GitHub Release
+passed `token: ${{ secrets.RELEASE_PAT }}` as a `with:` input — and an
+explicitly-passed *empty* `with:` input overrides
+`softprops/action-gh-release`'s own default fallback to `github.token`,
+unlike an unset environment variable. With the secret unset, the release
+step didn't degrade to a bot-authored release as the warning promised — it
+failed outright, taking the whole release with it. `token:` now reads
+`secrets.RELEASE_PAT || github.token` explicitly.
+
+## Changed
+
+### Docs corrected to match `paragraph.setText`/`table.setCell`'s actual behavior
+
+Both methods replace a paragraph's *content* (its text and runs) — any
+paragraph property (style, alignment, indentation, spacing) the request
+doesn't mention keeps whatever value the paragraph already had; neither
+method resets it. `CLI_GUIDE.md` and the npm `ParagraphSetTextParams` JSDoc
+previously described both as full replacements without drawing that
+distinction, which reads as "specify everything or it's gone" — the opposite
+of the actual behavior.
+
+### `TableSetCellResult`'s npm JSDoc corrected
+
+It said the cell "can grow but never shrink" — the behavior before #84,
+which shipped `TableCell.RemoveParagraph` in the very same v2.10.0 release
+that made this description false.
+
+## Compatibility
+
+- **No public Go interface changed. No new public Go, CLI protocol, or
+  Node.js API surface.**
+- **`document.replaceText`/`MergeTemplate` response semantics change for
+  documents with preserved headers/footers.** A call that used to report a
+  header/footer match as `replaced` now reports it as `skipped` (total match
+  count is unchanged); `MergeTemplate`'s `StrictMode` can now fail on a
+  document it previously reported as fully merged. Any document without
+  preserved headers/footers is unaffected.
+- **`document.replaceText`, `table.getCell`, and `table.setCell` now reject
+  an unrecognized top-level parameter**, where it used to be silently
+  ignored. A well-formed request is unaffected.
+- **TOC field code bytes change.** A document built with `NewTOCField` under
+  this release has single-backslash switches instead of the doubled-backslash
+  bytes every prior version produced. This isn't a behavior any caller could
+  have depended on — the doubled-backslash form was never a working TOC
+  field in Word.
+- **`Field.SetCode` (Go API only — no RPC parameter reaches it) now rejects
+  a control character or line break**, where it previously accepted
+  anything non-blank.
+- **Retroactive note on v2.10.0's `Config` pointerization.** v2.10.0's
+  `### Compatibility` section described `docx.Config`'s `DefaultFont`/
+  `DefaultFontSize`/`PageSize`/`Margins` fields becoming pointers, but not
+  its concrete consequence: this is source-breaking for code that writes to
+  a `*docx.Config` directly (for example, a hand-written `docx.Option`), not
+  for code that only calls `docx.With*` functions. `c.DefaultFont = "Arial"`
+  no longer compiles; see `MIGRATION.md` for the replacement.

--- a/builder_test.go
+++ b/builder_test.go
@@ -1220,6 +1220,45 @@ func TestFieldCreationFunctions(t *testing.T) {
 	})
 }
 
+// TestTOCFieldSwitches_SingleBackslashInSavedXML is an end-to-end regression
+// test: buildTOCCode and getDefaultCode's TOC branch built their switches as
+// Go raw string literals (`\\o`), which is two literal backslashes, not one
+// escaped backslash. XML chardata escaping never touches a bare backslash,
+// so that doubled backslash reached word/document.xml verbatim, and Word
+// treats "\\o" as an unrecognized switch — the TOC field code never actually
+// applied any of \o, \h, \n, \p, \z, or \u. The saved XML must carry exactly
+// one backslash per switch.
+func TestTOCFieldSwitches_SingleBackslashInSavedXML(t *testing.T) {
+	doc := NewDocument()
+	para, err := doc.AddParagraph()
+	if err != nil {
+		t.Fatalf("AddParagraph: %v", err)
+	}
+	run, err := para.AddRun()
+	if err != nil {
+		t.Fatalf("AddRun: %v", err)
+	}
+	if err := run.AddField(NewTOCField(map[string]string{"hidePageNumbers": "true", "hideTabLeader": "true"})); err != nil {
+		t.Fatalf("AddField: %v", err)
+	}
+
+	documentXML := readZipPart(t, doc, "word/document.xml")
+
+	if strings.Contains(documentXML, `\\`) {
+		t.Errorf("document.xml contains a doubled backslash — TOC switches would be inert in Word: %s", documentXML)
+	}
+	// XML chardata escaping turns the switch's literal '"' into &#34;, so the
+	// quoted levels argument is checked separately from the plain switches.
+	if !strings.Contains(documentXML, `\o &#34;1-3&#34;`) {
+		t.Errorf("document.xml missing \\o switch with levels: %s", documentXML)
+	}
+	for _, want := range []string{`\h`, `\n`, `\p`, `\z`, `\u`} {
+		if !strings.Contains(documentXML, want) {
+			t.Errorf("document.xml missing switch %q: %s", want, documentXML)
+		}
+	}
+}
+
 func TestTableBuilder_Style(t *testing.T) {
 	t.Run("sets table style", func(t *testing.T) {
 		builder := NewDocumentBuilder()

--- a/cmd/docxgo/handlers.go
+++ b/cmd/docxgo/handlers.go
@@ -876,13 +876,21 @@ func (s *server) handleParagraphAdd(req *Request) Response {
 			fmt.Sprintf("document %q not found", params.DocumentID), op)
 	}
 
+	// Validate before touching the document: applyParagraph can fail partway
+	// through (e.g. a field constructor rejecting a quote), which would
+	// otherwise leave a stray, half-populated paragraph appended to doc.
+	if err := validateParagraphItem(params.paragraphItem); err != nil {
+		return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
+	}
+
 	para, err := doc.AddParagraph()
 	if err != nil {
 		return errorResponse(req.ID, errors.ErrCodeInternal, "failed to add paragraph: "+err.Error(), op)
 	}
 
 	if err := applyParagraph(para, params.paragraphItem); err != nil {
-		return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
+		return errorResponse(req.ID, errors.ErrCodeInternal,
+			"applying validated paragraph: "+err.Error(), op)
 	}
 
 	index := len(doc.Paragraphs()) - 1
@@ -939,8 +947,17 @@ func (s *server) handleTableAdd(req *Request) Response {
 			fmt.Sprintf("document %q not found", params.DocumentID), op)
 	}
 
-	if err := applyTable(doc, params.tableItem); err != nil {
+	// Validate against a scratch document before touching doc: applyTable
+	// can fail partway through a multi-row, multi-cell table (e.g. a field
+	// constructor rejecting a quote in some cell), which would otherwise
+	// leave a stray, half-populated table appended to doc.
+	if err := applyTable(docx.NewDocument(), params.tableItem); err != nil {
 		return errorResponse(req.ID, errors.ErrCodeValidation, err.Error(), op)
+	}
+
+	if err := applyTable(doc, params.tableItem); err != nil {
+		return errorResponse(req.ID, errors.ErrCodeInternal,
+			"applying validated table: "+err.Error(), op)
 	}
 
 	index := len(doc.Tables()) - 1
@@ -1003,7 +1020,7 @@ func (s *server) handleReplaceText(req *Request) Response {
 	const op = "document.replaceText"
 
 	var params replaceTextParams
-	if err := json.Unmarshal(req.Params, &params); err != nil {
+	if err := decodeStrict(req.Params, &params); err != nil {
 		return errorResponse(req.ID, errors.ErrCodeValidation, "invalid params: "+err.Error(), op)
 	}
 
@@ -1135,7 +1152,7 @@ func (s *server) handleTableGetCell(req *Request) Response {
 	const op = "table.getCell"
 
 	var params tableCellRef
-	if err := json.Unmarshal(req.Params, &params); err != nil {
+	if err := decodeStrict(req.Params, &params); err != nil {
 		return errorResponse(req.ID, errors.ErrCodeValidation, "invalid params: "+err.Error(), op)
 	}
 
@@ -1167,7 +1184,7 @@ func (s *server) handleTableSetCell(req *Request) Response {
 	const op = "table.setCell"
 
 	var params tableSetCellParams
-	if err := json.Unmarshal(req.Params, &params); err != nil {
+	if err := decodeStrict(req.Params, &params); err != nil {
 		return errorResponse(req.ID, errors.ErrCodeValidation, "invalid params: "+err.Error(), op)
 	}
 
@@ -1749,49 +1766,70 @@ func lookupTheme(name string) themes.Theme {
 // ─── Content application ──────────────────────────────────────────────────────
 
 // applyContent processes a content array and adds items to the document.
+// applyContent applies every content item to doc. Each item is validated
+// against a scratch document first: content items are independent additive
+// mutations (each adds a new paragraph, table, or section), so a scratch
+// document gives the same verdict as the real one, and validating the whole
+// batch up front means a request that turns out to be invalid halfway
+// through never leaves the real document with a stray partial item — the
+// same failure this guards against as validateParagraphItem does for a
+// single paragraph.
 func applyContent(doc domain.Document, content []json.RawMessage) error {
 	for _, raw := range content {
-		var item contentItem
-		if err := json.Unmarshal(raw, &item); err != nil {
-			return fmt.Errorf("invalid content item: %w", err)
+		if err := applyContentItem(docx.NewDocument(), raw); err != nil {
+			return err
 		}
+	}
+	for _, raw := range content {
+		if err := applyContentItem(doc, raw); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
-		switch item.Type {
-		case "paragraph":
-			var pItem paragraphItem
-			if err := json.Unmarshal(raw, &pItem); err != nil {
-				return fmt.Errorf("invalid paragraph: %w", err)
-			}
-			para, err := doc.AddParagraph()
-			if err != nil {
-				return fmt.Errorf("failed to add paragraph: %w", err)
-			}
-			if err := applyParagraph(para, pItem); err != nil {
-				return err
-			}
-		case "table":
-			var tItem tableItem
-			if err := json.Unmarshal(raw, &tItem); err != nil {
-				return fmt.Errorf("invalid table: %w", err)
-			}
-			if err := applyTable(doc, tItem); err != nil {
-				return err
-			}
-		case "section":
-			var sItem sectionItem
-			if err := json.Unmarshal(raw, &sItem); err != nil {
-				return fmt.Errorf("invalid section: %w", err)
-			}
-			if err := applySection(doc, sItem); err != nil {
-				return err
-			}
-		case "pageBreak":
-			if err := doc.AddPageBreak(); err != nil {
-				return fmt.Errorf("failed to add page break: %w", err)
-			}
-		default:
-			return fmt.Errorf("unknown content type: %s", item.Type)
+// applyContentItem applies a single content item to doc.
+func applyContentItem(doc domain.Document, raw json.RawMessage) error {
+	var item contentItem
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return fmt.Errorf("invalid content item: %w", err)
+	}
+
+	switch item.Type {
+	case "paragraph":
+		var pItem paragraphItem
+		if err := json.Unmarshal(raw, &pItem); err != nil {
+			return fmt.Errorf("invalid paragraph: %w", err)
 		}
+		para, err := doc.AddParagraph()
+		if err != nil {
+			return fmt.Errorf("failed to add paragraph: %w", err)
+		}
+		if err := applyParagraph(para, pItem); err != nil {
+			return err
+		}
+	case "table":
+		var tItem tableItem
+		if err := json.Unmarshal(raw, &tItem); err != nil {
+			return fmt.Errorf("invalid table: %w", err)
+		}
+		if err := applyTable(doc, tItem); err != nil {
+			return err
+		}
+	case "section":
+		var sItem sectionItem
+		if err := json.Unmarshal(raw, &sItem); err != nil {
+			return fmt.Errorf("invalid section: %w", err)
+		}
+		if err := applySection(doc, sItem); err != nil {
+			return err
+		}
+	case "pageBreak":
+		if err := doc.AddPageBreak(); err != nil {
+			return fmt.Errorf("failed to add page break: %w", err)
+		}
+	default:
+		return fmt.Errorf("unknown content type: %s", item.Type)
 	}
 	return nil
 }

--- a/cmd/docxgo/handlers.go
+++ b/cmd/docxgo/handlers.go
@@ -1765,7 +1765,6 @@ func lookupTheme(name string) themes.Theme {
 
 // ─── Content application ──────────────────────────────────────────────────────
 
-// applyContent processes a content array and adds items to the document.
 // applyContent applies every content item to doc. Each item is validated
 // against a scratch document first: content items are independent additive
 // mutations (each adds a new paragraph, table, or section), so a scratch
@@ -1775,8 +1774,14 @@ func lookupTheme(name string) themes.Theme {
 // same failure this guards against as validateParagraphItem does for a
 // single paragraph.
 func applyContent(doc domain.Document, content []json.RawMessage) error {
+	// One shared scratch document for the whole validation pass, not one per
+	// item: items are independent additive mutations, so validating item N
+	// against a scratch document that already holds items 1..N-1 gives the
+	// same verdict as a fresh one would, at roughly half the construction
+	// cost for a large batch.
+	scratch := docx.NewDocument()
 	for _, raw := range content {
-		if err := applyContentItem(docx.NewDocument(), raw); err != nil {
+		if err := applyContentItem(scratch, raw); err != nil {
 			return err
 		}
 	}

--- a/cmd/docxgo/handlers_test.go
+++ b/cmd/docxgo/handlers_test.go
@@ -826,6 +826,67 @@ func TestHandleReplaceText_Validation(t *testing.T) {
 	}
 }
 
+// TestHandleReplaceText_RejectsUnknownField is a regression test: a request
+// with a misspelled "replacement" field instead of "replace" used to decode
+// via plain json.Unmarshal, silently treating params.Replace as "" and
+// deleting every occurrence of "find" while reporting success. It must now
+// be rejected before touching the document.
+func TestHandleReplaceText_RejectsUnknownField(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "document.replaceText", map[string]interface{}{
+		"documentId":  docID,
+		"find":        "ACME",
+		"replacement": "OTHER",
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Fatalf("expected VALIDATION_ERROR for unknown field, got %+v", resp.Error)
+	}
+
+	// The document must be untouched: "ACME" still present.
+	listResp := s.dispatch(makeRequest(3, "paragraph.list", map[string]interface{}{
+		"documentId": docID,
+	}))
+	paras := listResp.Result.(map[string]interface{})["paragraphs"].([]map[string]interface{})
+	if paras[0]["text"] != "Vendor: ACME Corp" {
+		t.Errorf("document was mutated despite rejected request: paragraph text = %q", paras[0]["text"])
+	}
+}
+
+// TestHandleTableSetCell_RejectsUnknownField uses "txet" (a typo of "text")
+// alongside a well-formed "text" field, so every currently-required field is
+// present and only DisallowUnknownFields can catch the mistake — a request
+// with the misspelled field alone would already be rejected by the "text or
+// paragraphs" presence check regardless of strict decoding.
+func TestHandleTableSetCell_RejectsUnknownField(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "table.setCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 0, "columnIndex": 0,
+		"text": "Correct",
+		"txet": "typo",
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Errorf("expected VALIDATION_ERROR for unknown field, got %+v", resp.Error)
+	}
+}
+
+// TestHandleTableGetCell_RejectsUnknownField includes a correctly-spelled
+// "columnIndex" alongside the typo'd "colummnIndex", so every required
+// pointer field is populated and only DisallowUnknownFields can catch the
+// mistake.
+func TestHandleTableGetCell_RejectsUnknownField(t *testing.T) {
+	s, docID := newEditTestDoc(t)
+
+	resp := s.dispatch(makeRequest(2, "table.getCell", map[string]interface{}{
+		"documentId": docID, "tableIndex": 0, "rowIndex": 0, "columnIndex": 0,
+		"colummnIndex": 0,
+	}))
+	if resp.Error == nil || resp.Error.Code != "VALIDATION_ERROR" {
+		t.Errorf("expected VALIDATION_ERROR for unknown field, got %+v", resp.Error)
+	}
+}
+
 func TestHandleParagraphSetText(t *testing.T) {
 	s, docID := newEditTestDoc(t)
 
@@ -1741,6 +1802,55 @@ func TestHandleAddContent_EmptyContent(t *testing.T) {
 	}
 }
 
+// TestHandleAddContent_RejectedItemLeavesNoPartialContent is a regression
+// test: applyContent used to apply items to the real document one at a time,
+// so a batch whose second item fails (e.g. a field constructor rejecting a
+// quote) would still leave the first item's paragraph appended even though
+// the call as a whole returned an error.
+func TestHandleAddContent_RejectedItemLeavesNoPartialContent(t *testing.T) {
+	s := newServer()
+
+	createResp := s.dispatch(makeRequest(1, "document.create", map[string]interface{}{
+		"output": "buffer",
+	}))
+	docID := createResp.Result.(map[string]interface{})["documentId"].(string)
+
+	resp := s.dispatch(makeRequest(2, "document.addContent", map[string]interface{}{
+		"documentId": docID,
+		"content": []interface{}{
+			map[string]interface{}{
+				"type": "paragraph",
+				"runs": []interface{}{map[string]interface{}{"text": "Valid first item"}},
+			},
+			map[string]interface{}{
+				"type": "paragraph",
+				"runs": []interface{}{
+					map[string]interface{}{
+						"field": map[string]interface{}{
+							"type":  "styleRef",
+							"style": `Heading 1" \* MERGEFORMAT "x`,
+						},
+					},
+				},
+			},
+		},
+	}))
+	if resp.Error == nil {
+		t.Fatal("expected error for a style name containing a double quote")
+	}
+	if resp.Error.Code != "VALIDATION_ERROR" {
+		t.Errorf("expected VALIDATION_ERROR, got %s", resp.Error.Code)
+	}
+
+	listResp := s.dispatch(makeRequest(3, "paragraph.list", map[string]interface{}{
+		"documentId": docID,
+	}))
+	paras := listResp.Result.(map[string]interface{})["paragraphs"].([]map[string]interface{})
+	if len(paras) != 0 {
+		t.Errorf("expected no paragraphs after rejected addContent batch, got %d", len(paras))
+	}
+}
+
 // ─── document.addPageBreak tests ─────────────────────────────────────────────
 
 func TestHandleAddPageBreak(t *testing.T) {
@@ -1817,6 +1927,46 @@ func TestHandleParagraphAdd_NotFound(t *testing.T) {
 	}
 	if resp.Error.Code != "NOT_FOUND" {
 		t.Errorf("expected NOT_FOUND, got %s", resp.Error.Code)
+	}
+}
+
+// TestHandleParagraphAdd_RejectedFieldLeavesNoOrphanParagraph is a
+// regression test: paragraph.add used to call doc.AddParagraph() before
+// applyParagraph could fail (e.g. a field constructor rejecting a quote in
+// its style name), leaving a stray empty paragraph appended to the document
+// even though the request as a whole was rejected.
+func TestHandleParagraphAdd_RejectedFieldLeavesNoOrphanParagraph(t *testing.T) {
+	s := newServer()
+
+	createResp := s.dispatch(makeRequest(1, "document.create", map[string]interface{}{
+		"output": "buffer",
+	}))
+	docID := createResp.Result.(map[string]interface{})["documentId"].(string)
+
+	resp := s.dispatch(makeRequest(2, "paragraph.add", map[string]interface{}{
+		"documentId": docID,
+		"runs": []interface{}{
+			map[string]interface{}{
+				"field": map[string]interface{}{
+					"type":  "styleRef",
+					"style": `Heading 1" \* MERGEFORMAT "x`,
+				},
+			},
+		},
+	}))
+	if resp.Error == nil {
+		t.Fatal("expected error for a style name containing a double quote")
+	}
+	if resp.Error.Code != "VALIDATION_ERROR" {
+		t.Errorf("expected VALIDATION_ERROR, got %s", resp.Error.Code)
+	}
+
+	listResp := s.dispatch(makeRequest(3, "paragraph.list", map[string]interface{}{
+		"documentId": docID,
+	}))
+	paras := listResp.Result.(map[string]interface{})["paragraphs"].([]map[string]interface{})
+	if len(paras) != 0 {
+		t.Errorf("expected no paragraphs after rejected paragraph.add, got %d", len(paras))
 	}
 }
 
@@ -2042,6 +2192,65 @@ func TestHandleTableAdd(t *testing.T) {
 	}
 	if _, ok := result["index"]; !ok {
 		t.Error("expected index in result")
+	}
+}
+
+// TestHandleTableAdd_RejectedFieldLeavesNoOrphanTable is a regression test:
+// table.add used to call doc.AddTable() and start populating cells before a
+// later cell's field could fail (e.g. a quote in a styleRef field's style
+// name), leaving a stray, half-populated table appended to the document even
+// though the request as a whole was rejected.
+func TestHandleTableAdd_RejectedFieldLeavesNoOrphanTable(t *testing.T) {
+	s := newServer()
+
+	createResp := s.dispatch(makeRequest(1, "document.create", map[string]interface{}{
+		"output": "buffer",
+	}))
+	docID := createResp.Result.(map[string]interface{})["documentId"].(string)
+
+	resp := s.dispatch(makeRequest(2, "table.add", map[string]interface{}{
+		"documentId": docID,
+		"rows": []interface{}{
+			map[string]interface{}{
+				"cells": []interface{}{
+					map[string]interface{}{
+						"paragraphs": []interface{}{
+							map[string]interface{}{
+								"runs": []interface{}{map[string]interface{}{"text": "A1"}},
+							},
+						},
+					},
+					map[string]interface{}{
+						"paragraphs": []interface{}{
+							map[string]interface{}{
+								"runs": []interface{}{
+									map[string]interface{}{
+										"field": map[string]interface{}{
+											"type":  "styleRef",
+											"style": `Heading 1" \* MERGEFORMAT "x`,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}))
+	if resp.Error == nil {
+		t.Fatal("expected error for a style name containing a double quote")
+	}
+	if resp.Error.Code != "VALIDATION_ERROR" {
+		t.Errorf("expected VALIDATION_ERROR, got %s", resp.Error.Code)
+	}
+
+	listResp := s.dispatch(makeRequest(3, "table.list", map[string]interface{}{
+		"documentId": docID,
+	}))
+	result := listResp.Result.(map[string]interface{})
+	if count := result["count"]; count != 0 {
+		t.Errorf("expected no tables after rejected table.add, got count=%v", count)
 	}
 }
 

--- a/doc.go
+++ b/doc.go
@@ -289,7 +289,7 @@ This library generates Office Open XML (OOXML) documents compatible with:
 
 # Version
 
-Current version: 2.10.0 (see the Version constant for the authoritative value).
+Current version: 2.11.0 (see the Version constant for the authoritative value).
 
 This is a major rewrite of the original go-docx library with breaking changes.
 See the migration guide in MIGRATION.md for details.

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -66,7 +66,7 @@ Verify the installation:
 
 ```bash
 docxgo version
-# 2.10.0
+# 2.11.0
 ```
 
 ---
@@ -198,7 +198,7 @@ Returns version, protocol version, and platform information.
 ```json
 {
   "name": "docxgo",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "protocolVersion": "1.0",
   "goVersion": "go1.23.0",
   "platform": "darwin",
@@ -253,7 +253,7 @@ Executes multiple RPC requests in a single roundtrip. Each sub-request is proces
 {
   "responses": [
     { "result": { "status": "ok" } },
-    { "result": { "name": "docxgo", "version": "2.10.0", ... } },
+    { "result": { "name": "docxgo", "version": "2.11.0", ... } },
     { "error": { "code": "NOT_FOUND", "message": "..." } }
   ]
 }

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -655,6 +655,7 @@ Some matches are reported in `skipped` instead of being replaced:
 
 - A match touching a run that carries a **field** (page number, TOC, MERGEFIELD, hyperlink) is always skipped. Word regenerates a field's displayed text when it opens the document, so replacing it would report a change that never appears. This includes a field on a run holding no text of its own — the shape Word uses for a MERGEFIELD, where the field sits in an empty run immediately before the run holding its display text.
 - A match spanning **several** runs is also skipped when any run between its ends carries a line/page break or an image, because collapsing those runs would leave that content stranded in the middle of the replacement. A match that fits inside a *single* run carrying a break or image is replaced normally, and the break or image is preserved.
+- On a document opened with `document.open`, every match inside a **header or footer** is skipped whenever the document has any preserved header or footer part. Header/footer XML from an opened document is written back byte-for-byte on save (see `document.save`), so an in-memory replacement there would never reach the saved file — reporting it as `replaced` would be a false success. This is a document-wide check, not a per-header/footer one: if any header or footer was preserved, all header/footer matches are skipped, even in a section whose own header/footer wasn't touched.
 
 This does not reach into tables nested inside other tables, or into tables placed inside a header or footer — the same traversal limits as `template.render`/`template.inspect`, which share the underlying paragraph walk.
 
@@ -665,6 +666,8 @@ This does not reach into tables nested inside other tables, or into tables place
 | `documentId` | String | Yes | Session document ID |
 | `find` | String | Yes | Literal text to search for; must not be empty |
 | `replace` | String | Yes | Replacement text; an empty string deletes each match |
+
+Params are decoded strictly: an unrecognized field is rejected rather than silently ignored.
 
 **Success result:**
 
@@ -761,7 +764,9 @@ Lists all paragraphs in a document with their text and style.
 
 ### paragraph.setText
 
-Replaces a body paragraph's content by index (the same index reported by `paragraph.list`). This clears all of the paragraph's existing runs before writing the new content, so it is a full replacement, not an append.
+Replaces a body paragraph's content by index (the same index reported by `paragraph.list`). This clears all of the paragraph's existing runs before writing the new content, so it is a full replacement of the paragraph's *content* (text and runs) — not an append.
+
+It is not a full replacement of the paragraph's *properties*. Style, alignment, indentation, and spacing are only touched by the fields you pass; anything omitted keeps whatever the paragraph already had. Fixing a typo with `paragraph.setText({"index": 0, "text": "..."})` on a Heading1, centered paragraph leaves it a Heading1, centered paragraph — it does not reset it to a plain, left-aligned one. To clear a property, set it explicitly to its default (e.g. `"alignment": "left"`).
 
 Accepts the same content fields as `paragraph.add`, but decoded strictly: an unrecognized field or a `null` value is rejected rather than silently treated as absent, since a typo in a request that replaces content must not read as "clear it". Passing only `style` (no `text` and no `runs`) clears the paragraph's runs and writes nothing back — the paragraph is emptied, not left unchanged. This method only addresses paragraphs in the document body; paragraphs inside table cells or headers/footers are not reachable by index here — use `table.setCell` for cell content.
 
@@ -907,6 +912,8 @@ Reads a single cell's content by table, row, and column index.
 | `rowIndex` | Number | Yes | Zero-based row index |
 | `columnIndex` | Number | Yes | Zero-based column index |
 
+Params are decoded strictly: an unrecognized field is rejected rather than silently ignored.
+
 **Success result:**
 
 ```json
@@ -923,7 +930,9 @@ Replaces a single cell's content by table, row, and column index.
 
 Provide exactly one of `text` (a shortcut that writes one plain paragraph) or `paragraphs` (rich paragraph items, same shape as `paragraph.add`). Supplying **both** is rejected, and so is supplying **neither** — this method replaces the cell's content, so a request that names no content at all (a misspelled field, say) is an error rather than a silent wipe. To empty a cell, pass `"paragraphs": []` or `"text": ""`.
 
-The whole request is validated before the cell is touched: if any paragraph item is malformed or rejected, the call fails and the cell keeps its original content. Unlike `paragraph.add`, each paragraph item here is decoded strictly — an unrecognized field or a `null` item is rejected rather than silently treated as an empty paragraph, since a typo in a request that replaces content must not read as "clear it".
+As with `paragraph.setText`, this replaces paragraph *content*, not paragraph *properties* — a reused paragraph slot keeps whatever style, alignment, indentation, and spacing it already had unless the corresponding paragraph item field says otherwise.
+
+The whole request is validated before the cell is touched: if any paragraph item is malformed or rejected, the call fails and the cell keeps its original content. Every field — the top-level params and each paragraph item — is decoded strictly: an unrecognized field or a `null` item is rejected rather than silently treated as an empty paragraph, since a typo in a request that replaces content must not read as "clear it".
 
 Writes to a cell covered by a horizontal merge are rejected. Such a cell is never written to the file, so accepting the write would report success and then silently drop the content on save — target the leading cell of the merged region instead.
 

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,7 +1,7 @@
 # docxgo v2 Implementation Status
 
 **Last Updated**: July 2026
-**Version**: 2.10.0 (Stable)
+**Version**: 2.11.0 (Stable)
 
 This document tracks the implementation status of all v2 features, helping developers understand what's available, what's in progress, and what's planned.
 
@@ -40,6 +40,7 @@ All development phases have been completed. The library has gone through multipl
 | v2.9.0      | Jul 2026 | Fixed npm-publish cascade, read-only `FindPlaceholders`, explicit zero spacing on styled paragraphs |
 | v2.9.1      | Jul 2026 | Code-review fixes: spacing emit gate no longer clobbers style line spacing, placeholder Location offsets corrected |
 | v2.10.0     | Jul 2026 | In-place editing RPC methods recovered from #64, field-code injection fix, mandatory CI checks (CodeQL), `table.setCell` shrink, per-side paragraph indentation, builder page size/margins/default font wiring |
+| v2.11.0     | Jul 2026 | Code-review fixes: header/footer edits no longer report as replaced when discarded on save, strict RPC param decoding, no orphaned content on rejected requests, indentation flag staleness, single-backslash TOC switches, `Field.SetCode` control-character rejection |
 
 ---
 
@@ -420,5 +421,5 @@ Want to help implement missing features? See [CONTRIBUTING.md](../CONTRIBUTING.m
 ---
 
 **Last Updated**: July 2026
-**Status**: Production Ready (v2.10.0 Stable)
+**Status**: Production Ready (v2.11.0 Stable)
 **Maintained by**: Misael Monterroca ([@mmonterroca](https://github.com/mmonterroca))

--- a/docs/README.md
+++ b/docs/README.md
@@ -224,4 +224,4 @@ See: IMPLEMENTATION_STATUS.md - Features list
 ---
 
 **Last Updated**: July 2026  
-**Documentation Version**: v2.10.0
+**Documentation Version**: v2.11.0

--- a/docs/V2_API_GUIDE.md
+++ b/docs/V2_API_GUIDE.md
@@ -1,6 +1,6 @@
 # docxgo v2 API Guide
 
-**Version**: 2.10.0
+**Version**: 2.11.0
 **Last Updated**: July 2026
 
 ---
@@ -1024,4 +1024,4 @@ See [`examples/14_mail_merge/`](../examples/14_mail_merge/) for a complete worki
 ---
 
 **Last Updated**: July 2026
-**Version**: 2.10.0
+**Version**: 2.11.0

--- a/docs/V2_DESIGN.md
+++ b/docs/V2_DESIGN.md
@@ -1,8 +1,8 @@
 # docxgo v2 - Clean Architecture Design
 
-**Status**: ✅ v2.10.0 Stable
+**Status**: ✅ v2.11.0 Stable
 **Progress**: Production Ready (all core features complete)
-**Latest Release**: v2.10.0 (July 2026)
+**Latest Release**: v2.11.0 (July 2026)
 **Breaking Changes**: Yes (major version bump from original fork)
 
 > **Project Note**: This project is a substantially rewritten successor to `fumiama/go-docx`, focused on clean architecture, type safety, and modern Go practices. The Git history includes AGPL-era upstream snapshots; the completed [provenance audit](./PROVENANCE_AUDIT.md) determines that the current MIT release contains no protectable AGPL implementation.
@@ -1344,7 +1344,7 @@ See [CREDITS.md](../CREDITS.md) for complete project history.
 ---
 
 **Last Updated**: July 2026
-**Status**: ✅ v2.10.0 Stable
+**Status**: ✅ v2.11.0 Stable
 **Progress**: Production Ready (all core features complete)
 
 **Current State:**

--- a/docx.go
+++ b/docx.go
@@ -88,7 +88,7 @@ func reconstructFromPackage(pkg *reader.Package, op string) (domain.Document, er
 }
 
 // Version is the library version.
-const Version = "2.10.0"
+const Version = "2.11.0"
 
 // Common color constants exported for convenience.
 var (

--- a/internal/core/document.go
+++ b/internal/core/document.go
@@ -803,6 +803,15 @@ func (d *document) HasPreservedParts() bool {
 	return d != nil && d.GetPreservedParts() != nil
 }
 
+// HasPreservedHeadersOrFooters returns true if this document has preserved
+// header or footer bytes from reading. WriteTo writes preserved headers and
+// footers verbatim (see writer.PreservedParts), so any in-memory mutation to
+// a header or footer paragraph on such a document never reaches the saved
+// file.
+func (d *document) HasPreservedHeadersOrFooters() bool {
+	return d != nil && (len(d.preservedHeaders) > 0 || len(d.preservedFooters) > 0)
+}
+
 func normalizeNumberingTarget(target string) string {
 	trimmed := strings.TrimSpace(target)
 	trimmed = strings.TrimPrefix(trimmed, "./")

--- a/internal/core/field.go
+++ b/internal/core/field.go
@@ -141,7 +141,18 @@ func (f *docxField) Code() string {
 	return f.code
 }
 
-// SetCode sets the field code.
+// SetCode sets the field code. code must be a complete, trusted field
+// instruction: SetCode performs no quote-sanitization the way the New*Field
+// constructors do (see docxField.err), because a well-formed instruction
+// legitimately contains balanced quotes (e.g. `STYLEREF "Heading 1"`) that a
+// naive quote check can't tell apart from an injection attempt. Untrusted,
+// caller-supplied fragments (a URL, a style name, ...) must go through one of
+// the New*Field constructors instead, which sanitize the fragment before
+// building the code around it.
+//
+// The one thing SetCode does reject is a control character or line break:
+// <w:instrText> holds a single-line instruction, and Word's field-code parser
+// has no defined behavior for one containing a raw control byte.
 func (f *docxField) SetCode(code string) error {
 	if strings.TrimSpace(code) == "" {
 		return errors.NewValidationError(
@@ -151,6 +162,16 @@ func (f *docxField) SetCode(code string) error {
 			"field code cannot be empty",
 		)
 	}
+	for _, r := range code {
+		if r < 0x20 {
+			return errors.NewValidationError(
+				"SetCode",
+				"code",
+				code,
+				"field code must not contain control characters or line breaks",
+			)
+		}
+	}
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -159,6 +180,22 @@ func (f *docxField) SetCode(code string) error {
 	f.isDirty = true
 
 	return nil
+}
+
+// SetCodeRaw hydrates the field's code directly, bypassing SetCode's
+// control-character guard. Used exclusively by the reader package during
+// OpenDocument to reflect a field instruction already present in the source
+// file's <w:instrText> — a real .docx from any producer is the ground truth
+// for what a "valid" instruction looks like, not this package's own
+// validation, so OpenDocument must not fail on one merely because it
+// contains a byte SetCode wouldn't have accepted from a caller. Not part of
+// domain.Field, reached only via the reader's own type-assertion (mirrors
+// SetLanguageRaw / SetPreservedStylesPart).
+func (f *docxField) SetCodeRaw(code string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.code = code
+	f.isDirty = true
 }
 
 // Result returns the field result (calculated value).
@@ -233,7 +270,7 @@ func (f *docxField) getDefaultCode() string {
 	case domain.FieldTypeNumPages:
 		return constants.FieldCodeNumPages
 	case domain.FieldTypeTOC:
-		return constants.FieldCodeTOC + ` \\o "1-3" \\h \\z \\u`
+		return constants.FieldCodeTOC + ` \o "1-3" \h \z \u`
 	case domain.FieldTypeDate:
 		return constants.FieldCodeDate
 	case domain.FieldTypeTime:
@@ -265,29 +302,29 @@ func (f *docxField) buildTOCCode() (string, error) {
 			return "", errors.NewValidationError("NewTOCField", "levels", levels,
 				`levels must not contain a double quote`)
 		}
-		code += fmt.Sprintf(` \\o "%s"`, safe)
+		code += fmt.Sprintf(` \o "%s"`, safe)
 	} else {
-		code += ` \\o "1-3"`
+		code += ` \o "1-3"`
 	}
 
 	// Hyperlinks (always included by default)
-	code += ` \\h`
+	code += ` \h`
 
 	// Hide page numbers (only if explicitly set to "true")
 	if hidePN, ok := f.properties["hidePageNumbers"]; ok && hidePN == "true" {
-		code += ` \\n`
+		code += ` \n`
 	}
 
 	// Hide tab leader (only if explicitly set to "true")
 	if hideTab, ok := f.properties["hideTabLeader"]; ok && hideTab == "true" {
-		code += ` \\p`
+		code += ` \p`
 	}
 
 	// Preserve tab entries
-	code += ` \\z`
+	code += ` \z`
 
 	// Use styles
-	code += ` \\u`
+	code += ` \u`
 
 	return code, nil
 }

--- a/internal/core/field_test.go
+++ b/internal/core/field_test.go
@@ -237,11 +237,9 @@ func TestNewStyleRefFieldRejectsQuote(t *testing.T) {
 func TestNewTOCFieldRejectsInvalidLevels(t *testing.T) {
 	field := NewTOCField(map[string]string{"levels": `1-3" \c "Figure`})
 
-	// field.go builds \\o (double backslash) as a raw string literal today —
-	// that's a separate, pre-existing quirk (tracked separately), not part
-	// of this fix. The default-else branch in buildTOCCode is the exact
-	// bytes this must match.
-	want := constants.FieldCodeTOC + ` \\o "1-3" \\h \\z \\u`
+	// The default-else branch in buildTOCCode is the exact bytes this must
+	// match.
+	want := constants.FieldCodeTOC + ` \o "1-3" \h \z \u`
 	if got := field.Code(); got != want {
 		t.Errorf("Code() = %q, want %q (safe default, not the injected value)", got, want)
 	}
@@ -257,7 +255,7 @@ func TestNewTOCFieldRejectsInvalidLevels(t *testing.T) {
 func TestNewTOCFieldAcceptsValidLevels(t *testing.T) {
 	field := NewTOCField(map[string]string{"levels": "1-5"})
 
-	want := constants.FieldCodeTOC + ` \\o "1-5" \\h \\z \\u`
+	want := constants.FieldCodeTOC + ` \o "1-5" \h \z \u`
 	if got := field.Code(); got != want {
 		t.Errorf("Code() = %q, want %q", got, want)
 	}
@@ -290,6 +288,39 @@ func TestFieldSetCodeEmpty(t *testing.T) {
 
 	if err := field.SetCode("   "); err == nil {
 		t.Error("SetCode() with whitespace should return error")
+	}
+}
+
+// TestFieldSetCodeRejectsControlCharacters is a regression test: SetCode used
+// to accept any non-blank string verbatim, including control characters and
+// line breaks, and serializer.go emits Code() straight into <w:instrText> —
+// a way to reach the exact byte-level corruption the #85 field-code
+// sanitizer existed to prevent, alongside the New*Field constructors' quote
+// rejection.
+func TestFieldSetCodeRejectsControlCharacters(t *testing.T) {
+	field := NewField(domain.FieldTypeCustom)
+
+	for _, tc := range []string{"CUSTOM\nINJECTED", "CUSTOM\rINJECTED", "CUSTOM\tINJECTED", "CUSTOM\x00INJECTED"} {
+		if err := field.SetCode(tc); err == nil {
+			t.Errorf("SetCode(%q) error = nil, want error for a control character", tc)
+		}
+	}
+}
+
+// TestFieldSetCode_BalancedQuotesAccepted guards against the quote-rejection
+// idea considered for SetCode: a legitimate instruction legitimately
+// contains balanced quotes (e.g. the examples in examples/04_fields), so
+// SetCode must not reject them the way the New*Field constructors reject a
+// caller-supplied fragment.
+func TestFieldSetCode_BalancedQuotesAccepted(t *testing.T) {
+	field := NewField(domain.FieldTypeCustom)
+
+	code := `STYLEREF "Heading 1" \* MERGEFORMAT`
+	if err := field.SetCode(code); err != nil {
+		t.Errorf("SetCode(%q) error = %v, want nil", code, err)
+	}
+	if field.Code() != code {
+		t.Errorf("Code() = %q, want %q", field.Code(), code)
 	}
 }
 

--- a/internal/core/paragraph.go
+++ b/internal/core/paragraph.go
@@ -434,14 +434,21 @@ func (p *paragraph) SetIndent(indent domain.Indentation) error {
 			"cannot have both first line indent and hanging indent")
 	}
 
-	// SetIndent replaces the whole struct in one call and deliberately does
-	// not touch the indent*Set flags: a zero-valued side in the struct is
-	// indistinguishable from a side the caller didn't intend to set, so
-	// marking all four here would claim explicit intent SetIndent's signature
-	// cannot actually express. Callers that need one side's zero value to
-	// override a style explicitly must use SetIndentLeft/Right/FirstLine/
+	// SetIndent replaces the whole struct in one call, so it clears all four
+	// set-flags along with it: a zero-valued side in the struct is the
+	// caller's explicit "no indent on this side" for the whole paragraph,
+	// not a per-side override, and any indent*Set left over from an earlier
+	// SetIndentLeft/Right/FirstLine/Hanging call would otherwise make the
+	// serializer emit that stale side's old value (e.g. a leftover
+	// w:left="0" from a prior SetIndentLeft) even though this call replaced
+	// it. Callers that need to override one side while leaving the other
+	// three genuinely untouched must use SetIndentLeft/Right/FirstLine/
 	// Hanging instead, each of which marks only its own side.
 	p.indent = indent
+	p.indentLeftSet = false
+	p.indentRightSet = false
+	p.indentFirstLineSet = false
+	p.indentHangingSet = false
 	return nil
 }
 

--- a/internal/reader/reconstruct.go
+++ b/internal/reader/reconstruct.go
@@ -1372,7 +1372,15 @@ func buildFieldFromInstruction(instr string) (domain.Field, error) {
 		return nil, nil
 	}
 
-	if err := field.SetCode(trimmed); err != nil {
+	// SetCodeRaw, not SetCode: trimmed comes from the source file's own
+	// <w:instrText>, which is the ground truth for what a field instruction
+	// looks like, not this package's own validation. Bypassing SetCode's
+	// control-character guard here means OpenDocument can't fail on a
+	// perfectly normal .docx merely because some producer emitted a byte
+	// SetCode wouldn't accept from a caller building a field from scratch.
+	if setter, ok := field.(interface{ SetCodeRaw(string) }); ok {
+		setter.SetCodeRaw(trimmed)
+	} else if err := field.SetCode(trimmed); err != nil {
 		return nil, errors.Wrap(err, opBuildField)
 	}
 

--- a/internal/reader/reconstruct.go
+++ b/internal/reader/reconstruct.go
@@ -698,7 +698,13 @@ func hydrateHyperlink(para domain.Paragraph, elem *Element, ctx *reconstructCont
 		var extraFields []domain.Field
 		if url != "" {
 			field := core.NewField(domain.FieldTypeHyperlink)
-			if err := field.SetCode(fmt.Sprintf(`HYPERLINK "%s"`, url)); err != nil {
+			// SetCodeRaw, not SetCode: url comes from the source file's own
+			// relationship target or w:anchor attribute, which is the
+			// ground truth here, not this package's own validation — same
+			// reasoning as buildFieldFromInstruction's SetCodeRaw call.
+			if setter, ok := field.(interface{ SetCodeRaw(string) }); ok {
+				setter.SetCodeRaw(fmt.Sprintf(`HYPERLINK "%s"`, url))
+			} else if err := field.SetCode(fmt.Sprintf(`HYPERLINK "%s"`, url)); err != nil {
 				return errors.Wrap(err, opHydrateHyperlink)
 			}
 			if accessor, ok := field.(interface{ SetProperty(string, string) }); ok {

--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -528,11 +528,23 @@ func (s *ParagraphSerializer) serializeProperties(para domain.Paragraph) *xml.Pa
 	leftSet, rightSet, firstLineSet, hangingSet := indentSetFlags(para)
 	if indent.Left != 0 || indent.Right != 0 || indent.FirstLine != 0 || indent.Hanging != 0 ||
 		leftSet || rightSet || firstLineSet || hangingSet {
+		firstLine := explicitOrNonZero(indent.FirstLine, firstLineSet)
+		hanging := explicitOrNonZero(indent.Hanging, hangingSet)
+		// CT_Ind allows both attributes, but Word treats them as mutually
+		// exclusive and only one can render correctly. SetIndent rejects
+		// setting both together, but the per-side setters (SetIndentFirstLine,
+		// SetIndentHanging) don't share that check — see their doc comments
+		// — so a paragraph can still reach here with both set, most often via
+		// the reader hydrating a source <w:ind> that already carries both.
+		// Emit only one, matching what Word itself does: hanging wins.
+		if firstLine != nil && hanging != nil {
+			firstLine = nil
+		}
 		props.Indentation = &xml.Indentation{
 			Left:      explicitOrNonZero(indent.Left, leftSet),
 			Right:     explicitOrNonZero(indent.Right, rightSet),
-			FirstLine: explicitOrNonZero(indent.FirstLine, firstLineSet),
-			Hanging:   explicitOrNonZero(indent.Hanging, hangingSet),
+			FirstLine: firstLine,
+			Hanging:   hanging,
 		}
 	}
 

--- a/internal/serializer/serializer_test.go
+++ b/internal/serializer/serializer_test.go
@@ -1069,6 +1069,80 @@ func TestParagraphSerializer_PartialIndentOmitsOtherSides(t *testing.T) {
 	}
 }
 
+// TestParagraphSerializer_SetIndentClearsStalePerSideFlags is a regression
+// test for a paragraph whose left indent was set via SetIndentLeft (the
+// reader's per-attribute path — see applyParagraphIndentation) and then
+// overwritten via a single SetIndent call. SetIndent used to leave
+// indentLeftSet at true from the earlier call, so the serializer emitted an
+// explicit w:left="0" and clobbered a style's own left indentation on a side
+// this SetIndent call never mentioned. SetIndent must clear all four
+// indent*Set flags along with the struct it replaces.
+func TestParagraphSerializer_SetIndentClearsStalePerSideFlags(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+
+	if err := para.SetIndentLeft(720); err != nil {
+		t.Fatalf("SetIndentLeft: %v", err)
+	}
+	if err := para.SetIndent(domain.Indentation{Right: 360}); err != nil {
+		t.Fatalf("SetIndent: %v", err)
+	}
+
+	ser := serializer.NewParagraphSerializer()
+	xmlPara := ser.Serialize(para)
+
+	if xmlPara.Properties == nil || xmlPara.Properties.Indentation == nil {
+		t.Fatal("expected w:ind to be set")
+	}
+	ind := xmlPara.Properties.Indentation
+	if ind.Left != nil {
+		t.Errorf("ind.Left = %v, want omitted (nil) — SetIndent must clear the stale indentLeftSet flag", ind.Left)
+	}
+	if ind.Right == nil || *ind.Right != 360 {
+		t.Errorf("ind.Right = %v, want 360", ind.Right)
+	}
+	if ind.FirstLine != nil {
+		t.Errorf("ind.FirstLine = %v, want omitted (nil)", ind.FirstLine)
+	}
+	if ind.Hanging != nil {
+		t.Errorf("ind.Hanging = %v, want omitted (nil)", ind.Hanging)
+	}
+}
+
+// TestParagraphSerializer_NeverEmitsBothFirstLineAndHanging is a regression
+// test: SetIndent rejects setting both FirstLine and Hanging together, but
+// the per-side setters SetIndentFirstLine/SetIndentHanging don't share that
+// check — reachable from the reader hydrating a source <w:ind> that already
+// carries both attributes (applyParagraphIndentation calls each setter
+// independently per attribute present). CT_Ind's schema allows both, but
+// Word treats them as mutually exclusive, so the serializer must emit only
+// one — hanging wins, matching what Word itself does.
+func TestParagraphSerializer_NeverEmitsBothFirstLineAndHanging(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+
+	if err := para.SetIndentFirstLine(200); err != nil {
+		t.Fatalf("SetIndentFirstLine: %v", err)
+	}
+	if err := para.SetIndentHanging(300); err != nil {
+		t.Fatalf("SetIndentHanging: %v", err)
+	}
+
+	ser := serializer.NewParagraphSerializer()
+	xmlPara := ser.Serialize(para)
+
+	if xmlPara.Properties == nil || xmlPara.Properties.Indentation == nil {
+		t.Fatal("expected w:ind to be set")
+	}
+	ind := xmlPara.Properties.Indentation
+	if ind.FirstLine != nil {
+		t.Errorf("ind.FirstLine = %v, want omitted (nil) — hanging must win when both are set", ind.FirstLine)
+	}
+	if ind.Hanging == nil || *ind.Hanging != 300 {
+		t.Errorf("ind.Hanging = %v, want 300", ind.Hanging)
+	}
+}
+
 // TestParagraphSerializer_ExplicitZeroAfterOnStyledParagraphIsEmitted guards
 // against the #69 bug: SpacingAfter() int can't distinguish "never called"
 // from "explicitly set to 0", so an explicit SetSpacingAfter(0) on a

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mmonterroca/docxgo",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mmonterroca/docxgo",
-      "version": "2.10.0",
+      "version": "2.11.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.3",
@@ -17,11 +17,11 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "@mmonterroca/docxgo-darwin-arm64": "2.10.0",
-        "@mmonterroca/docxgo-darwin-x64": "2.10.0",
-        "@mmonterroca/docxgo-linux-arm64": "2.10.0",
-        "@mmonterroca/docxgo-linux-x64": "2.10.0",
-        "@mmonterroca/docxgo-win32-x64": "2.10.0"
+        "@mmonterroca/docxgo-darwin-arm64": "2.11.0",
+        "@mmonterroca/docxgo-darwin-x64": "2.11.0",
+        "@mmonterroca/docxgo-linux-arm64": "2.11.0",
+        "@mmonterroca/docxgo-linux-x64": "2.11.0",
+        "@mmonterroca/docxgo-win32-x64": "2.11.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmonterroca/docxgo",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "Node.js wrapper for docxgo — create and manipulate Word documents via JSON-RPC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -50,10 +50,10 @@
     "typescript": "^5.4.0"
   },
   "optionalDependencies": {
-    "@mmonterroca/docxgo-darwin-arm64": "2.10.0",
-    "@mmonterroca/docxgo-darwin-x64": "2.10.0",
-    "@mmonterroca/docxgo-linux-arm64": "2.10.0",
-    "@mmonterroca/docxgo-linux-x64": "2.10.0",
-    "@mmonterroca/docxgo-win32-x64": "2.10.0"
+    "@mmonterroca/docxgo-darwin-arm64": "2.11.0",
+    "@mmonterroca/docxgo-darwin-x64": "2.11.0",
+    "@mmonterroca/docxgo-linux-arm64": "2.11.0",
+    "@mmonterroca/docxgo-linux-x64": "2.11.0",
+    "@mmonterroca/docxgo-win32-x64": "2.11.0"
   }
 }

--- a/npm/src/types.ts
+++ b/npm/src/types.ts
@@ -319,7 +319,10 @@ export interface ParagraphListParams {
   documentId: string;
 }
 
-/** Replaces a body paragraph's content by index (as reported by paragraph.list). */
+/** Replaces a body paragraph's content by index (as reported by paragraph.list).
+ * Replaces content (text and runs) only — any of the inherited fields you
+ * omit (style, alignment, indent, ...) leaves the paragraph's existing value
+ * untouched rather than resetting it. */
 export interface ParagraphSetTextParams extends ParagraphAddParams {
   index: number;
 }
@@ -470,8 +473,9 @@ export interface TableCellResult {
   paragraphCount: number;
 }
 
-/** Result of table.setCell. The cell can grow but never shrink; this is the
- * paragraph count after the write, which may exceed what was written. */
+/** Result of table.setCell. paragraphCount always equals the number of
+ * paragraph items written — fewer than the cell had removes the trailing
+ * ones, more appends new ones. */
 export interface TableSetCellResult {
   ok: boolean;
   paragraphCount: number;

--- a/pkg/template/consolidate_test.go
+++ b/pkg/template/consolidate_test.go
@@ -59,26 +59,34 @@ func countImageRuns(para domain.Paragraph) int {
 // (a zip archive) for tests that need to assert on the raw markup.
 func extractDocumentXML(t *testing.T, docxBytes []byte) []byte {
 	t.Helper()
+	return extractZipPart(t, docxBytes, "word/document.xml")
+}
+
+// extractZipPart reads a single named entry out of a serialized .docx (a zip
+// archive) for tests that need to assert on the raw markup of a part other
+// than word/document.xml (e.g. a header or footer).
+func extractZipPart(t *testing.T, docxBytes []byte, partName string) []byte {
+	t.Helper()
 	zr, err := zip.NewReader(bytes.NewReader(docxBytes), int64(len(docxBytes)))
 	if err != nil {
 		t.Fatalf("zip.NewReader: %v", err)
 	}
 	for _, f := range zr.File {
-		if f.Name != "word/document.xml" {
+		if f.Name != partName {
 			continue
 		}
 		rc, err := f.Open()
 		if err != nil {
-			t.Fatalf("open word/document.xml: %v", err)
+			t.Fatalf("open %s: %v", partName, err)
 		}
 		defer rc.Close()
 		var buf bytes.Buffer
 		if _, err := buf.ReadFrom(rc); err != nil {
-			t.Fatalf("read word/document.xml: %v", err)
+			t.Fatalf("read %s: %v", partName, err)
 		}
 		return buf.Bytes()
 	}
-	t.Fatal("word/document.xml not found in archive")
+	t.Fatalf("%s not found in archive", partName)
 	return nil
 }
 

--- a/pkg/template/merge.go
+++ b/pkg/template/merge.go
@@ -19,6 +19,14 @@ import (
 //
 // By default, placeholders use {{key}} syntax. Unmatched placeholders are left
 // as-is unless StrictMode is enabled in options.
+//
+// On a document opened via OpenDocument/OpenDocumentFromBytes/
+// OpenDocumentFromReader whose headers or footers were preserved for
+// round-trip fidelity, header and footer placeholders are never written:
+// WriteTo writes those parts verbatim, so an in-memory replacement there
+// would never reach the saved file. Their keys are reported through
+// missingKeys instead (and so trigger StrictMode's error), since silently
+// succeeding while discarding the write on save would be worse.
 func MergeTemplate(doc domain.Document, data MergeData, opts ...MergeOptions) error {
 	opt := DefaultMergeOptions()
 	if len(opts) > 0 {
@@ -26,9 +34,16 @@ func MergeTemplate(doc domain.Document, data MergeData, opts ...MergeOptions) er
 	}
 
 	pattern := BuildPattern(opt)
+	skipHeaderFooter := hasPreservedHeadersOrFooters(doc)
 	var missingKeys []string
 
 	err := walkParagraphs(doc, func(para domain.Paragraph, ctx paragraphContext) error {
+		if skipHeaderFooter && (ctx.locationType == LocationHeader || ctx.locationType == LocationFooter) {
+			for _, ph := range scanParagraph(para, pattern, ctx) {
+				missingKeys = append(missingKeys, ph.Name)
+			}
+			return nil
+		}
 		if err := ConsolidateRuns(para); err != nil {
 			return err
 		}

--- a/pkg/template/merge_test.go
+++ b/pkg/template/merge_test.go
@@ -7,9 +7,11 @@
 package template
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
+	docx "github.com/mmonterroca/docxgo/v2"
 	"github.com/mmonterroca/docxgo/v2/domain"
 	"github.com/mmonterroca/docxgo/v2/internal/core"
 )
@@ -156,6 +158,70 @@ func TestMergeTemplate_MissingKey_Strict(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "role") {
 		t.Errorf("expected error to mention 'role', got: %v", err)
+	}
+}
+
+// TestMergeTemplate_SkipsPreservedHeaderAndFooter is an end-to-end regression
+// test for the case where MergeTemplate silently replaced placeholder text
+// in a header/footer whose bytes WriteTo then writes verbatim, discarding
+// the edit on save. On a document whose headers/footers were preserved from
+// a round-trip open, a header/footer placeholder must be left untouched (so
+// re-running the merge later still finds it) and, in strict mode, reported
+// as missing rather than silently dropped.
+func TestMergeTemplate_SkipsPreservedHeaderAndFooter(t *testing.T) {
+	doc := core.NewDocument()
+	bodyPara, _ := doc.AddParagraph()
+	bodyRun, _ := bodyPara.AddRun()
+	bodyRun.SetText("Body: {{name}}")
+
+	section, err := doc.DefaultSection()
+	if err != nil {
+		t.Fatalf("DefaultSection: %v", err)
+	}
+	header, err := section.Header(domain.HeaderDefault)
+	if err != nil {
+		t.Fatalf("Header: %v", err)
+	}
+	headerPara, _ := header.AddParagraph()
+	headerRun, _ := headerPara.AddRun()
+	headerRun.SetText("Header: {{name}}")
+
+	templatePath := t.TempDir() + "/preserved_header.docx"
+	if err := doc.SaveAs(templatePath); err != nil {
+		t.Fatalf("SaveAs: %v", err)
+	}
+
+	opened, err := docx.OpenDocument(templatePath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	opts := MergeOptions{OpenDelimiter: "{{", CloseDelimiter: "}}", StrictMode: true}
+	err = MergeTemplate(opened, MergeData{"name": "Alice"}, opts)
+	if err == nil {
+		t.Fatal("expected strict-mode error for the header placeholder that cannot be persisted")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("expected error to mention 'name', got: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := opened.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	savedBytes := buf.Bytes()
+
+	docXML := string(extractDocumentXML(t, savedBytes))
+	if !strings.Contains(docXML, "Body: Alice") {
+		t.Errorf("document.xml: expected merged body text, got %s", docXML)
+	}
+
+	headerXML := string(extractZipPart(t, savedBytes, "word/header1.xml"))
+	if !strings.Contains(headerXML, "Header: {{name}}") {
+		t.Errorf("header1.xml: expected untouched placeholder, got %s", headerXML)
+	}
+	if strings.Contains(headerXML, "Alice") {
+		t.Errorf("header1.xml: unexpected merged value — header should be preserved verbatim, got %s", headerXML)
 	}
 }
 

--- a/pkg/template/replace.go
+++ b/pkg/template/replace.go
@@ -58,8 +58,7 @@ func ReplaceText(doc domain.Document, find, replace string) (ReplaceResult, erro
 	var result ReplaceResult
 	err := walkParagraphs(doc, func(para domain.Paragraph, ctx paragraphContext) error {
 		if skipHeaderFooter && (ctx.locationType == LocationHeader || ctx.locationType == LocationFooter) {
-			_, full := paragraphSpans(para)
-			result.Skipped += strings.Count(full, find)
+			result.Skipped += strings.Count(para.Text(), find)
 			return nil
 		}
 		replaced, skipped, err := replaceInParagraph(para, find, replace)

--- a/pkg/template/replace.go
+++ b/pkg/template/replace.go
@@ -40,19 +40,46 @@ type ReplaceResult struct {
 // or an image, since blanking a spanned run would strand that content in the
 // middle of the replacement. A match confined to a single run carrying a
 // break or an image is replaced, and the break or image is preserved.
+//
+// On a document opened via OpenDocument/OpenDocumentFromBytes/
+// OpenDocumentFromReader whose headers or footers were preserved for
+// round-trip fidelity, every header and footer match is skipped too: WriteTo
+// writes those parts verbatim, so an in-memory edit there would never reach
+// the saved file. This check is document-wide, not per-header/footer — if
+// any header or footer part was preserved, all header/footer paragraphs are
+// skipped, even ones belonging to a different section.
 func ReplaceText(doc domain.Document, find, replace string) (ReplaceResult, error) {
 	if find == "" {
 		return ReplaceResult{}, fmt.Errorf("template: find text must not be empty")
 	}
 
+	skipHeaderFooter := hasPreservedHeadersOrFooters(doc)
+
 	var result ReplaceResult
-	err := walkParagraphs(doc, func(para domain.Paragraph, _ paragraphContext) error {
+	err := walkParagraphs(doc, func(para domain.Paragraph, ctx paragraphContext) error {
+		if skipHeaderFooter && (ctx.locationType == LocationHeader || ctx.locationType == LocationFooter) {
+			_, full := paragraphSpans(para)
+			result.Skipped += strings.Count(full, find)
+			return nil
+		}
 		replaced, skipped, err := replaceInParagraph(para, find, replace)
 		result.Replaced += replaced
 		result.Skipped += skipped
 		return err
 	})
 	return result, err
+}
+
+// hasPreservedHeadersOrFooters reports whether doc carries preserved
+// header/footer bytes from a round-trip read. domain.Document does not
+// expose this on its own — the check goes through the same type-assertion
+// idiom walkParagraphs already uses for HeadersAll/FootersAll.
+func hasPreservedHeadersOrFooters(doc domain.Document) bool {
+	type preservedHeaderFooterChecker interface {
+		HasPreservedHeadersOrFooters() bool
+	}
+	checker, ok := doc.(preservedHeaderFooterChecker)
+	return ok && checker.HasPreservedHeadersOrFooters()
 }
 
 // runSpan maps a run to its byte-offset range [start, end) within the

--- a/pkg/template/replace_test.go
+++ b/pkg/template/replace_test.go
@@ -7,9 +7,11 @@
 package template
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
+	docx "github.com/mmonterroca/docxgo/v2"
 	"github.com/mmonterroca/docxgo/v2/domain"
 	"github.com/mmonterroca/docxgo/v2/internal/core"
 )
@@ -418,5 +420,91 @@ func TestReplaceText_DeletionMatchesStdlibSemantics(t *testing.T) {
 	}
 	if result.Replaced != 1 {
 		t.Errorf("replaced = %d, want 1", result.Replaced)
+	}
+}
+
+// TestReplaceText_SkipsPreservedHeaderAndFooter is an end-to-end regression
+// test for the case where ReplaceText reported a header/footer match as
+// Replaced even though WriteTo writes preserved headers/footers verbatim,
+// silently discarding the edit. It builds a document with "FOO" in the body,
+// a header, and a footer, saves it, reopens it (which preserves the header
+// and footer bytes for round-trip), replaces "FOO" with "BAR", saves again,
+// and inspects the raw zip entries: the body must change and the header/
+// footer must not.
+func TestReplaceText_SkipsPreservedHeaderAndFooter(t *testing.T) {
+	doc := core.NewDocument()
+	bodyPara, _ := doc.AddParagraph()
+	bodyRun, _ := bodyPara.AddRun()
+	bodyRun.SetText("FOO in body")
+
+	section, err := doc.DefaultSection()
+	if err != nil {
+		t.Fatalf("DefaultSection: %v", err)
+	}
+	header, err := section.Header(domain.HeaderDefault)
+	if err != nil {
+		t.Fatalf("Header: %v", err)
+	}
+	headerPara, _ := header.AddParagraph()
+	headerRun, _ := headerPara.AddRun()
+	headerRun.SetText("FOO in header")
+
+	footer, err := section.Footer(domain.FooterDefault)
+	if err != nil {
+		t.Fatalf("Footer: %v", err)
+	}
+	footerPara, _ := footer.AddParagraph()
+	footerRun, _ := footerPara.AddRun()
+	footerRun.SetText("FOO in footer")
+
+	templatePath := t.TempDir() + "/preserved_header_footer.docx"
+	if err := doc.SaveAs(templatePath); err != nil {
+		t.Fatalf("SaveAs: %v", err)
+	}
+
+	opened, err := docx.OpenDocument(templatePath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	result, err := ReplaceText(opened, "FOO", "BAR")
+	if err != nil {
+		t.Fatalf("ReplaceText: %v", err)
+	}
+	if result.Replaced != 1 {
+		t.Errorf("replaced = %d, want 1 (body only)", result.Replaced)
+	}
+	if result.Skipped != 2 {
+		t.Errorf("skipped = %d, want 2 (header + footer)", result.Skipped)
+	}
+
+	var buf bytes.Buffer
+	if _, err := opened.WriteTo(&buf); err != nil {
+		t.Fatalf("WriteTo: %v", err)
+	}
+	savedBytes := buf.Bytes()
+
+	docXML := string(extractDocumentXML(t, savedBytes))
+	if !strings.Contains(docXML, "BAR in body") {
+		t.Errorf("document.xml: expected replaced body text, got %s", docXML)
+	}
+	if strings.Contains(docXML, "FOO") {
+		t.Errorf("document.xml: unexpected leftover FOO, got %s", docXML)
+	}
+
+	headerXML := string(extractZipPart(t, savedBytes, "word/header1.xml"))
+	if !strings.Contains(headerXML, "FOO in header") {
+		t.Errorf("header1.xml: expected untouched FOO, got %s", headerXML)
+	}
+	if strings.Contains(headerXML, "BAR") {
+		t.Errorf("header1.xml: unexpected BAR — header should be preserved verbatim, got %s", headerXML)
+	}
+
+	footerXML := string(extractZipPart(t, savedBytes, "word/footer1.xml"))
+	if !strings.Contains(footerXML, "FOO in footer") {
+		t.Errorf("footer1.xml: expected untouched FOO, got %s", footerXML)
+	}
+	if strings.Contains(footerXML, "BAR") {
+		t.Errorf("footer1.xml: unexpected BAR — footer should be preserved verbatim, got %s", footerXML)
 	}
 }


### PR DESCRIPTION
## Summary

v2.10.0 was merged and published to npm without a code review — CI alone. A post-hoc `/code-review` of that release's full diff (37 candidates verified, 2 refuted, 10 confirmed) found ten real defects that gofmt, `go vet`, `go test -race`, and golangci-lint cannot see by construction. This PR fixes all ten and prepares v2.11.0.

Two are silent data loss and are the most important to land:
- `document.replaceText` could report a header/footer edit as `replaced` when it was actually discarded on save (preserved-parts round-trip).
- A misspelled param (`"replacement"` instead of `"replace"`) silently decoded to an empty string and deleted a document's content while reporting success.

See `CHANGELOG.md` (`## v2.11.0`) and `RELEASE_NOTES_v2.11.0.md` for the full writeup of all ten, and each commit message for the specific fix.

## Commits

1. `fix(template)` — skip header/footer matches on documents with preserved parts (`ReplaceText`, `MergeTemplate`)
2. `fix(cli)` — decode `document.replaceText`/`table.getCell`/`table.setCell` params strictly; validate `paragraph.add`/`table.add`/`document.addContent` before mutating the document
3. `fix(core,serializer)` — `SetIndent` clears stale per-side flags; serializer never emits both `firstLine` and `hanging`
4. `fix(core)` — TOC field switches use a single backslash (were inert in Word); `Field.SetCode` rejects control characters
5. `ci` — `release.yml` falls back to `github.token` when `RELEASE_PAT` is unset, instead of hard-failing
6. `docs` — correct `setText`/`setCell` property semantics and `TableSetCellResult` docs
7. `release: prepare v2.11.0`

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- [x] `go test ./...` and `go test -race ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `actionlint .github/workflows/*.yml` — clean
- [x] `examples/test_all.sh` (10/10) plus manual run of `examples/03_toc` — verified single-backslash TOC switches in the saved XML
- [x] `npm run lint` and `npm test` (35/35) in `npm/`
- [x] Every new regression test verified to fail with its fix `git stash`ed, confirming it actually exercises the bug
- [x] Header/footer skip and TOC backslash fixes verified against real saved `.docx` bytes (unzipped XML), not just in-memory assertions