### PR TITLE
feat: per-run language override (domain.Run.SetLanguage/Language)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## v2.12.0 — 2026-08-02
+
+### Added
+
+- **`domain.Run.SetLanguage` / `Language`** — set a per-run proofing language override, used by Word for spell-checking, grammar-checking, and hyphenation of just that run (e.g. a foreign-language phrase inside an otherwise single-language paragraph). Complements `Document.SetLanguage`/`WithLanguage`, which only set the document-wide default; a run without an override inherits that default.
+  - `SetLanguage(lang *domain.Language) error` — same `Language{Val, EastAsia, Bidi}` shape as `Document.SetLanguage`; at least one field must be non-empty. Pass `nil` to clear the override and fall back to the document default.
+  - `Language() *domain.Language` — returns a defensive copy, or `nil` if unset. Mutating it has no effect on the run.
+  - Written as `w:lang` in the run's own `w:rPr`, into the field `internal/xml.RunProperties.Lang` that already existed but nothing wrote to.
+  - Opening an existing `.docx` via `OpenDocument`/`OpenDocumentFromBytes`/`OpenDocumentFromReader` now hydrates each run's `Language()` from its `w:rPr/w:lang`, if present — same round-trip fidelity as every other run property (`Bold`, `Highlight`, etc).
+
+### Changed
+
+- **`domain.Run` interface gained two methods** (`SetLanguage`, `Language`, above). If you implement `domain.Run` directly with your own type — most commonly a hand-written test double — you'll need to add both methods; embedding `domain.Run` in your type is unaffected, since the new methods are promoted automatically. No exported docxgo API accepts a `domain.Run` from a caller (only returns one), same reasoning as `Document.SetLanguage`/`Language` in v2.6.0.
+
+---
+
 ## v2.11.0 — 2026-07-29
 
 v2.10.0 was merged and published without a code review — CI alone. A

--- a/doc.go
+++ b/doc.go
@@ -289,7 +289,7 @@ This library generates Office Open XML (OOXML) documents compatible with:
 
 # Version
 
-Current version: 2.11.0 (see the Version constant for the authoritative value).
+Current version: 2.12.0 (see the Version constant for the authoritative value).
 
 This is a major rewrite of the original go-docx library with breaking changes.
 See the migration guide in MIGRATION.md for details.

--- a/docx.go
+++ b/docx.go
@@ -88,7 +88,7 @@ func reconstructFromPackage(pkg *reader.Package, op string) (domain.Document, er
 }
 
 // Version is the library version.
-const Version = "2.11.0"
+const Version = "2.12.0"
 
 // Common color constants exported for convenience.
 var (

--- a/domain/run.go
+++ b/domain/run.go
@@ -63,6 +63,20 @@ type Run interface {
 	// SetHighlight sets the highlight color.
 	SetHighlight(color HighlightColor) error
 
+	// Language returns the run's language override, or nil if unset — in
+	// which case the run inherits the document's default proofing language
+	// (see Document.SetLanguage). Mutating the returned value has no effect
+	// on the run.
+	Language() *Language
+
+	// SetLanguage sets a per-run language override, used by Word for
+	// spell-checking, grammar-checking, and hyphenation of just this run —
+	// e.g. a foreign-language phrase inside an otherwise single-language
+	// paragraph. Pass nil to clear it and fall back to the document default.
+	// Returns an error if lang is non-nil but has no tag set (Val, EastAsia,
+	// and Bidi all empty).
+	SetLanguage(lang *Language) error
+
 	// AddText is a convenience method that appends text to the run.
 	AddText(text string) error
 

--- a/internal/core/core_test.go
+++ b/internal/core/core_test.go
@@ -210,6 +210,54 @@ func TestRun_TextFormatting(t *testing.T) {
 	}
 }
 
+func TestRun_Language(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	run, _ := para.AddRun()
+
+	if run.Language() != nil {
+		t.Fatal("expected no language override by default")
+	}
+
+	lang := &domain.Language{Val: "fr", EastAsia: "fr", Bidi: "fr"}
+	if err := run.SetLanguage(lang); err != nil {
+		t.Fatalf("SetLanguage failed: %v", err)
+	}
+	got := run.Language()
+	if got == nil || *got != *lang {
+		t.Errorf("expected language %+v, got %+v", lang, got)
+	}
+
+	// Mutating the caller's copy after SetLanguage must not affect the run,
+	// and mutating the returned copy must not affect the run either — same
+	// copy-semantics contract as Document.SetLanguage/Language.
+	lang.Val = "mutated"
+	if run.Language().Val != "fr" {
+		t.Error("SetLanguage must copy its argument")
+	}
+	got.Val = "mutated"
+	if run.Language().Val != "fr" {
+		t.Error("Language must return a copy")
+	}
+
+	if err := run.SetLanguage(nil); err != nil {
+		t.Fatalf("SetLanguage(nil) failed: %v", err)
+	}
+	if run.Language() != nil {
+		t.Error("expected SetLanguage(nil) to clear the override")
+	}
+}
+
+func TestRun_SetLanguage_RejectsEmptyTag(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	run, _ := para.AddRun()
+
+	if err := run.SetLanguage(&domain.Language{}); err == nil {
+		t.Error("expected an error for a Language with no Val/EastAsia/Bidi set")
+	}
+}
+
 func TestRun_SetSize_Validation(t *testing.T) {
 	doc := core.NewDocument()
 	para, _ := doc.AddParagraph()

--- a/internal/core/run.go
+++ b/internal/core/run.go
@@ -27,6 +27,7 @@ type run struct {
 	underline  domain.UnderlineStyle
 	strike     bool
 	highlight  domain.HighlightColor
+	language   *domain.Language
 	fields     []domain.Field     // Fields embedded in this run
 	breaks     []domain.BreakType // Breaks in this run
 	relManager *manager.RelationshipManager
@@ -169,6 +170,30 @@ func (r *run) SetHighlight(color domain.HighlightColor) error {
 			"invalid highlight color")
 	}
 	r.highlight = color
+	return nil
+}
+
+// Language returns a copy of the run's language override, or nil if unset.
+// Mutating the returned value has no effect on the run.
+func (r *run) Language() *domain.Language {
+	if r.language == nil {
+		return nil
+	}
+	langCopy := *r.language
+	return &langCopy
+}
+
+// SetLanguage sets a per-run language override.
+func (r *run) SetLanguage(lang *domain.Language) error {
+	if lang != nil && lang.Val == "" && lang.EastAsia == "" && lang.Bidi == "" {
+		return errors.InvalidArgument("Run.SetLanguage", "lang", lang, "at least one of Val, EastAsia, or Bidi must be set")
+	}
+	if lang == nil {
+		r.language = nil
+		return nil
+	}
+	langCopy := *lang
+	r.language = &langCopy
 	return nil
 }
 

--- a/internal/reader/reader_test.go
+++ b/internal/reader/reader_test.go
@@ -212,6 +212,9 @@ func TestReconstructDocumentFormatting(t *testing.T) {
 	if err := run.SetFont(domain.Font{Name: "Times New Roman", EastAsia: "SimSun", CS: "Arial"}); err != nil {
 		t.Fatalf("SetFont: %v", err)
 	}
+	if err := run.SetLanguage(&domain.Language{Val: "fr", EastAsia: "ja", Bidi: "ar"}); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
 
 	var buf bytes.Buffer
 	if _, err := doc.WriteTo(&buf); err != nil {
@@ -297,6 +300,10 @@ func TestReconstructDocumentFormatting(t *testing.T) {
 	}
 	if font.CS != "Arial" {
 		t.Fatalf("unexpected complex script font: %s", font.CS)
+	}
+	recoveredLang := recoveredRun.Language()
+	if recoveredLang == nil || recoveredLang.Val != "fr" || recoveredLang.EastAsia != "ja" || recoveredLang.Bidi != "ar" {
+		t.Fatalf("unexpected run language: %+v", recoveredLang)
 	}
 }
 

--- a/internal/reader/reconstruct.go
+++ b/internal/reader/reconstruct.go
@@ -659,6 +659,17 @@ func applyRunProperties(run domain.Run, props *Element) error {
 		}
 	}
 
+	if langElem := findChild(props, "lang"); langElem != nil {
+		val, _ := getAttr(langElem, "val")
+		eastAsia, _ := getAttr(langElem, "eastAsia")
+		bidi, _ := getAttr(langElem, "bidi")
+		if val != "" || eastAsia != "" || bidi != "" {
+			if err := run.SetLanguage(&domain.Language{Val: val, EastAsia: eastAsia, Bidi: bidi}); err != nil {
+				return errors.Wrap(err, opApplyRunProperties)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/internal/serializer/serializer.go
+++ b/internal/serializer/serializer.go
@@ -134,6 +134,12 @@ func (s *RunSerializer) serializeProperties(run domain.Run) *xml.RunProperties {
 		}
 	}
 
+	// Language override — falls back to the document default (SerializeStyles)
+	// when unset, same Val/EastAsia/Bidi shape.
+	if lang := run.Language(); lang != nil {
+		props.Lang = &xml.Language{Val: lang.Val, EastAsia: lang.EastAsia, Bidi: lang.Bidi}
+	}
+
 	return props
 }
 

--- a/internal/serializer/serializer_test.go
+++ b/internal/serializer/serializer_test.go
@@ -476,6 +476,40 @@ func TestRunSerializer_Highlight(t *testing.T) {
 	}
 }
 
+func TestRunSerializer_Language(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	run, _ := para.AddRun()
+	run.SetText("bonjour")
+	if err := run.SetLanguage(&domain.Language{Val: "fr", EastAsia: "fr", Bidi: "fr"}); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+
+	ser := serializer.NewRunSerializer()
+	xmlRun := ser.Serialize(run)
+
+	if xmlRun.Properties == nil || xmlRun.Properties.Lang == nil {
+		t.Fatal("expected run language to be set")
+	}
+	if xmlRun.Properties.Lang.Val != "fr" || xmlRun.Properties.Lang.EastAsia != "fr" || xmlRun.Properties.Lang.Bidi != "fr" {
+		t.Errorf("unexpected Lang: %+v", xmlRun.Properties.Lang)
+	}
+}
+
+func TestRunSerializer_Language_UnsetOmitsLangElement(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+	run, _ := para.AddRun()
+	run.SetText("plain")
+
+	ser := serializer.NewRunSerializer()
+	xmlRun := ser.Serialize(run)
+
+	if xmlRun.Properties != nil && xmlRun.Properties.Lang != nil {
+		t.Error("expected no run-level language when unset — should inherit the document default")
+	}
+}
+
 func TestParagraphSerializer_LineSpacing(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

- Adds `domain.Run.SetLanguage`/`Language` — a per-run `w:lang` override, complementing
  `Document.SetLanguage`/`WithLanguage` (document-wide default). Motivated by
  `ziradocs/toolchain#63`: marking that a specific phrase in a document is in a different
  language than the document's declared default (WCAG 2.2 "Language of Parts").
- The XML field this writes to (`internal/xml.RunProperties.Lang`) already existed —
  nothing wrote to it before this change.
- `OpenDocument`/`OpenDocumentFromBytes`/`OpenDocumentFromReader` now hydrate a run's
  `Language()` from its `w:rPr/w:lang` on read, same round-trip fidelity as every other run
  property (`Bold`, `Highlight`, etc).
- `domain.Run` gains two interface methods — see CHANGELOG's Changed section for the
  compatibility note (same shape as `Document.SetLanguage`/`Language` in v2.6.0).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` clean
- [x] `go test ./...` — full suite green, including new tests:
  `TestRun_Language`, `TestRun_SetLanguage_RejectsEmptyTag` (internal/core),
  `TestRunSerializer_Language`, `TestRunSerializer_Language_UnsetOmitsLangElement`
  (internal/serializer), and `TestReconstructDocumentFormatting` extended with a
  write→parse→reconstruct round-trip through `Val`/`EastAsia`/`Bidi`.
