### PR TITLE
fix(template): language-aware run consolidation; release: prepare v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   - Written as `w:lang` in the run's own `w:rPr`, into the field `internal/xml.RunProperties.Lang` that already existed but nothing wrote to.
   - Opening an existing `.docx` via `OpenDocument`/`OpenDocumentFromBytes`/`OpenDocumentFromReader` now hydrates each run's `Language()` from its `w:rPr/w:lang`, if present — same round-trip fidelity as every other run property (`Bold`, `Highlight`, etc).
 
+### Fixed
+
+- **`ConsolidateRuns` (and therefore `MergeTemplate`/`ReplaceText`) could merge across a language boundary.** `formatsEqual`, which decides whether two adjacent runs are mergeable, compared 8 visual formatting attributes but not the new `Language`. Two visually-identical runs — one carrying a `SetLanguage` override (e.g. a `bonjour` run tagged `fr` inside otherwise-untagged prose), one not — were merged into a single run, silently discarding whichever run's language the merge didn't keep. Found in review of this same release before it was tagged. `formatsEqual` now compares `Language()` too (nil-safe: both unset, or both set to the same `Val`/`EastAsia`/`Bidi`), so a language boundary blocks the merge like any other formatting difference.
+
 ### Changed
 
 - **`domain.Run` interface gained two methods** (`SetLanguage`, `Language`, above). If you implement `domain.Run` directly with your own type — most commonly a hand-written test double — you'll need to add both methods; embedding `domain.Run` in your type is unaffected, since the new methods are promoted automatically. No exported docxgo API accepts a `domain.Run` from a caller (only returns one), same reasoning as `Document.SetLanguage`/`Language` in v2.6.0.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,6 @@
 # Migration Guide: v1 → docxgo v2
 
-**Current target:** v2.11.0
+**Current target:** v2.12.0
 **Minimum Go version:** 1.23
 
 This guide covers migration from the historical `fumiama/go-docx` API to the
@@ -27,7 +27,7 @@ For the complete current API, see the [API guide](docs/V2_API_GUIDE.md) and
 ## 1. Update the module
 
 ```bash
-go get github.com/mmonterroca/docxgo/v2@v2.11.0
+go get github.com/mmonterroca/docxgo/v2@v2.12.0
 go mod tidy
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Since v2.7.0 it also ships a JSON-RPC command-line interface and a Node.js wrapp
 - **Proofing language** — `WithLanguage` / `WithLanguageEx` for spell-check, grammar, hyphenation
 - **Production quality** — clean architecture, explicit errors, thread-safe internals
 
-**Status:** v2.11.0 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
+**Status:** v2.12.0 · Production-ready · Requires Go 1.23+ (no external C dependencies; runs on Linux, macOS, Windows). See the [CHANGELOG](CHANGELOG.md) for version history.
 
 ---
 

--- a/docs/CLI_GUIDE.md
+++ b/docs/CLI_GUIDE.md
@@ -66,7 +66,7 @@ Verify the installation:
 
 ```bash
 docxgo version
-# 2.11.0
+# 2.12.0
 ```
 
 ---
@@ -198,7 +198,7 @@ Returns version, protocol version, and platform information.
 ```json
 {
   "name": "docxgo",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "protocolVersion": "1.0",
   "goVersion": "go1.23.0",
   "platform": "darwin",
@@ -253,7 +253,7 @@ Executes multiple RPC requests in a single roundtrip. Each sub-request is proces
 {
   "responses": [
     { "result": { "status": "ok" } },
-    { "result": { "name": "docxgo", "version": "2.11.0", ... } },
+    { "result": { "name": "docxgo", "version": "2.12.0", ... } },
     { "error": { "code": "NOT_FOUND", "message": "..." } }
   ]
 }

--- a/docs/IMPLEMENTATION_STATUS.md
+++ b/docs/IMPLEMENTATION_STATUS.md
@@ -1,7 +1,7 @@
 # docxgo v2 Implementation Status
 
-**Last Updated**: July 2026
-**Version**: 2.11.0 (Stable)
+**Last Updated**: August 2026
+**Version**: 2.12.0 (Stable)
 
 This document tracks the implementation status of all v2 features, helping developers understand what's available, what's in progress, and what's planned.
 
@@ -41,6 +41,7 @@ All development phases have been completed. The library has gone through multipl
 | v2.9.1      | Jul 2026 | Code-review fixes: spacing emit gate no longer clobbers style line spacing, placeholder Location offsets corrected |
 | v2.10.0     | Jul 2026 | In-place editing RPC methods recovered from #64, field-code injection fix, mandatory CI checks (CodeQL), `table.setCell` shrink, per-side paragraph indentation, builder page size/margins/default font wiring |
 | v2.11.0     | Jul 2026 | Code-review fixes: header/footer edits no longer report as replaced when discarded on save, strict RPC param decoding, no orphaned content on rejected requests, indentation flag staleness, single-backslash TOC switches, `Field.SetCode` control-character rejection |
+| v2.12.0     | Aug 2026 | `domain.Run.SetLanguage`/`Language` — per-run proofing language override, with `ConsolidateRuns` guarding against merging across a language boundary |
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -223,5 +223,5 @@ See: IMPLEMENTATION_STATUS.md - Features list
 
 ---
 
-**Last Updated**: July 2026  
-**Documentation Version**: v2.11.0
+**Last Updated**: August 2026  
+**Documentation Version**: v2.12.0

--- a/docs/V2_API_GUIDE.md
+++ b/docs/V2_API_GUIDE.md
@@ -1,7 +1,7 @@
 # docxgo v2 API Guide
 
-**Version**: 2.11.0
-**Last Updated**: July 2026
+**Version**: 2.12.0
+**Last Updated**: August 2026
 
 ---
 
@@ -1023,5 +1023,5 @@ See [`examples/14_mail_merge/`](../examples/14_mail_merge/) for a complete worki
 
 ---
 
-**Last Updated**: July 2026
-**Version**: 2.11.0
+**Last Updated**: August 2026
+**Version**: 2.12.0

--- a/docs/V2_DESIGN.md
+++ b/docs/V2_DESIGN.md
@@ -1,8 +1,8 @@
 # docxgo v2 - Clean Architecture Design
 
-**Status**: ✅ v2.11.0 Stable
+**Status**: ✅ v2.12.0 Stable
 **Progress**: Production Ready (all core features complete)
-**Latest Release**: v2.11.0 (July 2026)
+**Latest Release**: v2.12.0 (August 2026)
 **Breaking Changes**: Yes (major version bump from original fork)
 
 > **Project Note**: This project is a substantially rewritten successor to `fumiama/go-docx`, focused on clean architecture, type safety, and modern Go practices. The Git history includes AGPL-era upstream snapshots; the completed [provenance audit](./PROVENANCE_AUDIT.md) determines that the current MIT release contains no protectable AGPL implementation.
@@ -1343,8 +1343,8 @@ See [CREDITS.md](../CREDITS.md) for complete project history.
 
 ---
 
-**Last Updated**: July 2026
-**Status**: ✅ v2.11.0 Stable
+**Last Updated**: August 2026
+**Status**: ✅ v2.12.0 Stable
 **Progress**: Production Ready (all core features complete)
 
 **Current State:**

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mmonterroca/docxgo",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mmonterroca/docxgo",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.3",
@@ -17,11 +17,11 @@
         "node": ">=16.0.0"
       },
       "optionalDependencies": {
-        "@mmonterroca/docxgo-darwin-arm64": "2.11.0",
-        "@mmonterroca/docxgo-darwin-x64": "2.11.0",
-        "@mmonterroca/docxgo-linux-arm64": "2.11.0",
-        "@mmonterroca/docxgo-linux-x64": "2.11.0",
-        "@mmonterroca/docxgo-win32-x64": "2.11.0"
+        "@mmonterroca/docxgo-darwin-arm64": "2.12.0",
+        "@mmonterroca/docxgo-darwin-x64": "2.12.0",
+        "@mmonterroca/docxgo-linux-arm64": "2.12.0",
+        "@mmonterroca/docxgo-linux-x64": "2.12.0",
+        "@mmonterroca/docxgo-win32-x64": "2.12.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmonterroca/docxgo",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "description": "Node.js wrapper for docxgo — create and manipulate Word documents via JSON-RPC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -50,10 +50,10 @@
     "typescript": "^5.4.0"
   },
   "optionalDependencies": {
-    "@mmonterroca/docxgo-darwin-arm64": "2.11.0",
-    "@mmonterroca/docxgo-darwin-x64": "2.11.0",
-    "@mmonterroca/docxgo-linux-arm64": "2.11.0",
-    "@mmonterroca/docxgo-linux-x64": "2.11.0",
-    "@mmonterroca/docxgo-win32-x64": "2.11.0"
+    "@mmonterroca/docxgo-darwin-arm64": "2.12.0",
+    "@mmonterroca/docxgo-darwin-x64": "2.12.0",
+    "@mmonterroca/docxgo-linux-arm64": "2.12.0",
+    "@mmonterroca/docxgo-linux-x64": "2.12.0",
+    "@mmonterroca/docxgo-win32-x64": "2.12.0"
   }
 }

--- a/pkg/template/consolidate_test.go
+++ b/pkg/template/consolidate_test.go
@@ -185,6 +185,46 @@ func TestConsolidateRuns_DifferentFormatting(t *testing.T) {
 	}
 }
 
+func TestConsolidateRuns_DifferentLanguage(t *testing.T) {
+	doc := core.NewDocument()
+	para, _ := doc.AddParagraph()
+
+	r1, _ := para.AddRun()
+	r1.SetText("hello ")
+
+	r2, _ := para.AddRun()
+	r2.SetText("bonjour")
+	if err := r2.SetLanguage(&domain.Language{Val: "fr"}); err != nil {
+		t.Fatalf("SetLanguage: %v", err)
+	}
+
+	r3, _ := para.AddRun()
+	r3.SetText(" world")
+
+	if err := ConsolidateRuns(para); err != nil {
+		t.Fatalf("ConsolidateRuns: %v", err)
+	}
+
+	// Visually identical formatting (no bold/italic/color/etc on any of the
+	// three), but r2's language override must keep it from merging with its
+	// neighbors — a merge would either lose the "fr" tag on r2's text or
+	// wrongly stamp it onto "hello "/" world" too.
+	runs := para.Runs()
+	if len(runs) != 3 {
+		t.Fatalf("expected 3 runs (no merge across a language boundary), got %d", len(runs))
+	}
+	if runs[0].Text() != "hello " || runs[0].Language() != nil {
+		t.Errorf("run[0]: expected unset language 'hello ', got %q lang=%+v", runs[0].Text(), runs[0].Language())
+	}
+	lang := runs[1].Language()
+	if runs[1].Text() != "bonjour" || lang == nil || lang.Val != "fr" {
+		t.Errorf("run[1]: expected fr 'bonjour', got %q lang=%+v", runs[1].Text(), lang)
+	}
+	if runs[2].Text() != " world" || runs[2].Language() != nil {
+		t.Errorf("run[2]: expected unset language ' world', got %q lang=%+v", runs[2].Text(), runs[2].Language())
+	}
+}
+
 func TestConsolidateRuns_SplitPlaceholder(t *testing.T) {
 	doc := core.NewDocument()
 	para, _ := doc.AddParagraph()

--- a/pkg/template/format.go
+++ b/pkg/template/format.go
@@ -9,8 +9,14 @@ package template
 import "github.com/mmonterroca/docxgo/v2/domain"
 
 // formatsEqual returns true if two runs have identical visible formatting.
-// It compares all 8 formatting attributes that affect text appearance.
-// This is used by ConsolidateRuns to decide if adjacent runs can be merged.
+// It compares the 8 visual formatting attributes plus Language — not
+// visible, but ConsolidateRuns must not merge two runs with different
+// language overrides, since the merge keeps only the leader's formatting
+// (see ConsolidateRuns) and silently discarding one run's Language would
+// wrongly re-tag a foreign-language phrase (domain.Run.SetLanguage; e.g. a
+// [bonjour]{lang=fr} span in otherwise French-unmarked prose) as the
+// surrounding document's default language the moment MergeTemplate or
+// ReplaceText happened to run over it.
 func formatsEqual(a, b domain.Run) bool {
 	return a.Font() == b.Font() &&
 		a.Color() == b.Color() &&
@@ -19,7 +25,17 @@ func formatsEqual(a, b domain.Run) bool {
 		a.Italic() == b.Italic() &&
 		a.Underline() == b.Underline() &&
 		a.Strike() == b.Strike() &&
-		a.Highlight() == b.Highlight()
+		a.Highlight() == b.Highlight() &&
+		languagesEqual(a.Language(), b.Language())
+}
+
+// languagesEqual is a nil-safe comparison of two *domain.Language: both
+// unset, or both set to the same Val/EastAsia/Bidi.
+func languagesEqual(a, b *domain.Language) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 // isTextOnly returns true if the run contains only text (no fields, breaks, or images).


### PR DESCRIPTION
## Summary

Two things, landed together since the fix touches the same feature this release ships and
hadn't been tagged yet:

- **Fix found in review of #99, before tagging:** `ConsolidateRuns` (and therefore
  `MergeTemplate`/`ReplaceText`) could silently merge two runs across a language boundary.
  `formatsEqual` compared 8 visual attributes but not the new `Run.Language()` — two
  visually-identical runs, one tagged (e.g. `fr`) and one not, merged into one run and lost
  whichever language the merge didn't keep. Now compared nil-safely alongside the other 8.
- **Release prep for v2.12.0:** version constant, npm package metadata/lock, and docs that
  carry a version string.

## Test plan

- [x] `go build ./... && go vet ./... && gofmt -l .` clean
- [x] `go test ./...` full suite green
- [x] New `TestConsolidateRuns_DifferentLanguage` confirmed to **fail** without the fix
      (merges to 1 run, drops the `fr` tag) and **pass** with it
